### PR TITLE
fix example in help of CLI

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -164,13 +164,13 @@ def cli(work_path=None, config_file=None, debug=False, log_file=None):
     """
     Welcome to the sesdev tool.
 
-    Usage example:
+    Usage examples:
 
     # Deployment of single node SES6 cluster:
 
         $ sesdev create ses6 --single-node my_ses6_cluster
 
-    # Deployment of Octopus cluster with deepsea where each storage node contains 4 10G disks for
+    # Deployment of Octopus cluster where each storage node contains 4 10G disks for
 OSDs:
 
         \b


### PR DESCRIPTION
I've previously forgotten to adapt the text in the example when I removed the non-working `--deepsea` argument in favor of an example not deployed by deepsea.

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>