### PR TITLE
ceph-bootstrap: 'ceph-salt-formula' moved to 'ceph-bootstrap'

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -59,10 +59,6 @@ def ceph_bootstrap_options(func):
                      help='ceph-bootstrap Git repo URL'),
         click.option('--ceph-bootstrap-branch', type=str, default=None,
                      help='ceph-bootstrap Git branch'),
-        click.option('--ceph-salt-formula-repo', type=str, default=None,
-                     help='ceph-salt-formula Git repo URL'),
-        click.option('--ceph-salt-formula-branch', type=str, default=None,
-                     help='ceph-salt-formula Git branch'),
         click.option('--ceph-container-image', type=str, default=None,
                      help='container image path for Ceph daemons'),
         click.option('--deploy-bootstrap', is_flag=True, default=True,
@@ -254,7 +250,6 @@ def _gen_settings_dict(version, roles, os, num_disks, single_node, libvirt_host,
                        libvirt_storage_pool, deepsea_cli, stop_before_deepsea_stage, deepsea_repo,
                        deepsea_branch, repo, cpus, ram, disk_size, repo_priority, vagrant_box,
                        scc_user, scc_pass, ceph_bootstrap_repo=None, ceph_bootstrap_branch=None,
-                       ceph_salt_formula_repo=None, ceph_salt_formula_branch=None,
                        stop_before_ceph_bootstrap_config=False,
                        stop_before_ceph_bootstrap_deploy=False,
                        ceph_container_image=None, deploy_bootstrap=True, deploy_mons=True,
@@ -338,12 +333,6 @@ def _gen_settings_dict(version, roles, os, num_disks, single_node, libvirt_host,
 
     if ceph_bootstrap_branch:
         settings_dict['ceph_bootstrap_git_branch'] = ceph_bootstrap_branch
-
-    if ceph_salt_formula_repo:
-        settings_dict['ceph_salt_formula_git_repo'] = ceph_salt_formula_repo
-
-    if ceph_salt_formula_branch:
-        settings_dict['ceph_salt_formula_git_branch'] = ceph_salt_formula_branch
 
     if stop_before_ceph_bootstrap_config:
         settings_dict['stop_before_ceph_bootstrap_config'] = stop_before_ceph_bootstrap_config

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -274,16 +274,6 @@ SETTINGS = {
         'help': 'ceph-bootstrap git branch to use',
         'default': 'master'
     },
-    'ceph_salt_formula_git_repo': {
-        'type': str,
-        'help': 'If set, it will install ceph-salt-formula from this git repo',
-        'default': None
-    },
-    'ceph_salt_formula_git_branch': {
-        'type': str,
-        'help': 'ceph-salt-formula git branch to use',
-        'default': 'master'
-    },
     'stop_before_ceph_bootstrap_config': {
         'type': bool,
         'help': 'Stops deployment before ceph-bootstrap config',
@@ -594,8 +584,6 @@ class Deployment():
             'scc_password': self.settings.scc_password,
             'ceph_bootstrap_git_repo': self.settings.ceph_bootstrap_git_repo,
             'ceph_bootstrap_git_branch': self.settings.ceph_bootstrap_git_branch,
-            'ceph_salt_formula_git_repo': self.settings.ceph_salt_formula_git_repo,
-            'ceph_salt_formula_git_branch': self.settings.ceph_salt_formula_git_branch,
             'stop_before_ceph_bootstrap_config': self.settings.stop_before_ceph_bootstrap_config,
             'stop_before_ceph_bootstrap_deploy': self.settings.stop_before_ceph_bootstrap_deploy,
             'ceph_container_image': self.settings.ceph_container_image,

--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -2,25 +2,20 @@
 set -ex
 
 {% if ceph_bootstrap_git_repo %}
+# install ceph-bootstrap
 cd /root
 git clone {{ ceph_bootstrap_git_repo }}
 cd ceph-bootstrap
 zypper -n in autoconf gcc python3-devel python3-pip
 git checkout {{ ceph_bootstrap_git_branch }}
 pip install .
+# install ceph-salt-formula
+mkdir -p /srv/salt/ceph-salt
+cp -r ceph-salt-formula/states/* /srv/salt/ceph-salt/
+chown -R salt:salt /srv
 {% else %}
 # ceph-salt-formula is installed automatically as a dependency of ceph-bootstrap
 zypper -n in ceph-bootstrap
-{% endif %}
-
-{% if ceph_salt_formula_git_repo %}
-cd /root
-git clone {{ ceph_salt_formula_git_repo }}
-cd ceph-salt-formula
-git checkout {{ ceph_salt_formula_git_branch }}
-mkdir -p /srv/salt/ceph-salt
-cp -r states/* /srv/salt/ceph-salt/
-chown -R salt:salt /srv
 {% endif %}
 
 cat <<EOF > /srv/pillar/top.sls


### PR DESCRIPTION
Since https://github.com/SUSE/ceph-bootstrap/pull/26, https://github.com/suse/ceph-salt-formula was moved to https://github.com/suse/ceph-bootstrap.

Signed-off-by: Ricardo Marques <rimarques@suse.com>