### PR TITLE
vagrant: generate random serial number for each attached disk

### DIFF
--- a/seslib/templates/engine/libvirt/vagrant.node.j2
+++ b/seslib/templates/engine/libvirt/vagrant.node.j2
@@ -6,6 +6,6 @@
       lv.memory = {{ node.ram }}
       lv.cpus = {{ node.cpus }}
 {% for disk in node.storage_disks %}
-      lv.storage :file, size: "{{ disk.size }}G", type: 'qcow2'
+      lv.storage :file, size: "{{ disk.size }}G", type: 'qcow2', serial: "{{ range(1, 1000000) | random }}"
 {% endfor %}
     end


### PR DESCRIPTION
Fixes: https://github.com/SUSE/sesdev/issues/48
Signed-off-by: Nathan Cutler <ncutler@suse.com>