### PR TITLE
Add support for IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The Jenkins CI tests that `sesdev` can be used to deploy a single-node Ceph
    * ["Failed to connect socket" error when attempting to use remote libvirt server](#failed-to-connect-socket-error-when-attempting-to-use-remote-libvirt-server)
    * [mount.nfs: Unknown error 521](#mountnfs-unknown-error-521)
    * [Problems accessing dashboard on remote sesdev](#problems-accessing-dashboard-on-remote-sesdev)
+   * [Error creating IPv6 cluster](#error-creating-ipv6-cluster)
 * [Contributing](#contributing)
 
 
@@ -1282,6 +1283,29 @@ PROTOCOL://CORRECT_IP_ADDRESS:ANY_ARBITRARY_HIGH_NUMBERED_PORT
 One final note: it's a good practice to use a different
 `ANY_ARBITRARY_HIGH_NUMBERED_PORT` every time you run `sesdev tunnel`. This is
 because of ``https://github.com/SUSE/sesdev/issues/276``.
+
+### Error creating IPv6 cluster
+
+#### Symptom
+
+I'm running `sesdev create` with `--ipv6` option, and I'm getting the following error:
+
+```
+Error while activating network: Call to virNetworkCreate failed: internal error:
+Check the host setup: enabling IPv6 forwarding with RA routes without accept_ra
+set to 2 is likely to cause routes loss. Interfaces to look at: enp0s25.
+```
+
+#### Resolution
+
+Set "Accept Router Advertisements" to 2 ("Overrule forwarding behaviour"), by running:
+
+```
+sysctl -w net.ipv6.conf.<if>.accept_ra=2
+```
+
+Where `<if>` is the network interface from the error, or `all` if you want to apply
+the config to all network interfaces.
 
 ## Contributing
 

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -332,6 +332,9 @@ if [ "$PACIFIC" ] ; then
     run_cmd sesdev --verbose create pacific --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node pacific-1node
     run_cmd sesdev --verbose qa-test pacific-1node
     run_cmd sesdev --verbose destroy --non-interactive pacific-1node
+    run_cmd sesdev --verbose create pacific --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --ipv6 pacific-1node-ipv6
+    run_cmd sesdev --verbose qa-test pacific-1node-ipv6
+    run_cmd sesdev --verbose destroy --non-interactive pacific-1node-ipv6
     run_cmd sesdev --verbose create pacific --non-interactive "${CEPH_SALT_OPTIONS[@]}" pacific-4node
     run_cmd sesdev --verbose qa-test pacific-4node
     run_cmd sesdev --verbose destroy --non-interactive pacific-4node

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -154,6 +154,18 @@ def common_create_options(func):
     return _decorator_composer(click_options, func)
 
 
+def ipv6_options(func):
+    click_options = [
+        click.option('--ipv6', is_flag=True, default=False,
+                     help='Configure IPv6 addresses. This option requires "Accept Router '
+                          'Advertisements" to be set to 2. You can change it by running '
+                          '"sysctl -w net.ipv6.conf.<if>.accept_ra=2" where '
+                          '<if> is the network interface used by libvirt for network '
+                          'forwarding, or "all" to apply to all interfaces.',),
+    ]
+    return _decorator_composer(click_options, func)
+
+
 def _parse_roles(roles):
     roles = "".join(roles.split())
     if roles.startswith('[[') and roles.endswith(']]'):
@@ -494,6 +506,7 @@ def _gen_settings_dict(
         encrypted_osds=None,
         force=None,
         image_path=None,
+        ipv6=None,
         libvirt_host=None,
         libvirt_networks=None,
         libvirt_private_key_file=None,
@@ -551,6 +564,9 @@ def _gen_settings_dict(
 
     if os is not None:
         settings_dict['os'] = os
+
+    if ipv6 is not None:
+        settings_dict['ipv6'] = ipv6
 
     if cpus is not None:
         settings_dict['cpus'] = cpus
@@ -873,6 +889,7 @@ def ses6(deployment_id, deploy, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
+@ipv6_options
 def ses7(deployment_id, deploy, **kwargs):
     """
     Creates a SES7 cluster using SLES-15-SP2 and packages (and container image)
@@ -909,6 +926,7 @@ def nautilus(deployment_id, deploy, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
+@ipv6_options
 def octopus(deployment_id, deploy, **kwargs):
     """
     Creates a Ceph Octopus cluster using openSUSE Leap 15.2 and packages
@@ -926,6 +944,7 @@ def octopus(deployment_id, deploy, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
+@ipv6_options
 def pacific(deployment_id, deploy, **kwargs):
     """
     Creates a Ceph Pacific cluster using openSUSE Leap 15.2 and packages

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -303,6 +303,12 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                     public_address = '{}{}'.format(self.settings.public_network, 200 + node_id)
                     networks = ('node.vm.network :private_network, autostart: true, ip:'
                                 '"{}"').format(public_address)
+                networks = ('node.vm.network :private_network, autostart: true, ip:'
+                            '"{}"').format(public_address)
+                if self.settings.ipv6:
+                    networks += ', libvirt__guest_ipv6: "yes"' \
+                                ', libvirt__ipv6_address: "fde4:8dba:82e1::c4"' \
+                                ', libvirt__ipv6_prefix: "64"'
 
             if 'bootstrap' in node_roles:
                 self.bootstrap_mon_ip = public_address
@@ -442,6 +448,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'libvirt_use_ssh': 'true' if self.settings.libvirt_use_ssh else 'false',
             'libvirt_private_key_file': self.settings.libvirt_private_key_file,
             'libvirt_storage_pool': self.settings.libvirt_storage_pool,
+            'ipv6': self.settings.ipv6,
             'vagrant_box': self.vagrant_box,
             'nodes': list(self.nodes.values()),
             'cluster_json': json.dumps({

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -200,6 +200,15 @@ SETTINGS = {
         'help': 'Automatically run integration tests on the deployed cluster',
         'default': False,
     },
+    'ipv6': {
+        'type': bool,
+        'help': 'Configure IPv6 addresses. This option requires "Accept Router '
+                'Advertisements" to be set to 2. You can change it by running '
+                '"sysctl -w net.ipv6.conf.<if>.accept_ra=2" where '
+                '<if> is the network interface used by libvirt for network '
+                'forwarding, or "all" to apply to all interfaces.',
+        'default': False
+    },
     'ram': {
         'type': int,
         'help': 'RAM size in gigabytes for each node',

--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -58,6 +58,13 @@ ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
 {% endif %}
 {% endfor %}
 ceph-salt config /ceph_cluster/roles/bootstrap set {{ cephadm_bootstrap_node.fqdn }}
+{% if ipv6 %}
+IPV6_CMD="ip -6 addr | grep 'scope global dynamic mngtmpaddr' | sed -e 's/.*inet6 \(.*\)\/.*/\1/'"
+IPV6_ADDR="$(ssh {{ cephadm_bootstrap_node.name }} $IPV6_CMD)"
+ceph-salt config /cephadm_bootstrap/mon_ip set "$IPV6_ADDR"
+{% else %}
+ceph-salt config /cephadm_bootstrap/mon_ip set {{ bootstrap_mon_ip }}
+{% endif %}
 
 ceph-salt config /ssh/ generate
 ceph-salt config /time_server/server_hostname set {{ master.fqdn }}
@@ -77,7 +84,6 @@ ceph-salt config /cephadm_bootstrap/ceph_conf/global set "osd crush chooseleaf t
 ceph-salt config /cephadm_bootstrap/dashboard/username set admin
 ceph-salt config /cephadm_bootstrap/dashboard/password set admin
 ceph-salt config /cephadm_bootstrap/dashboard/force_password_update disable
-ceph-salt config /cephadm_bootstrap/mon_ip set {{ bootstrap_mon_ip }}
 
 ceph-salt config ls
 ceph-salt export --pretty

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -52,6 +52,24 @@ while true ; do
 done
 set -x
 
+{% if ipv6 %}
+IPV6_CMD="ip -6 addr | grep 'scope global dynamic mngtmpaddr' | sed -e 's/.*inet6 \(.*\)\/.*/\1/'"
+{% for _node in nodes %}
+{% if _node == node %}
+IPV6_HOST="$(bash -c "$IPV6_CMD") {{ _node.fqdn }} {{ _node.name }}"
+{% else %}
+IPV6_HOST="$(ssh {{ _node.name }} $IPV6_CMD) {{ _node.fqdn }} {{ _node.name }}"
+{% endif %} {# _node == node #}
+{% for __node in nodes %}
+{% if __node == node %}
+echo $IPV6_HOST >> /etc/hosts
+{% else %}
+ssh {{ __node.name }} "echo \"$IPV6_HOST\" >> /etc/hosts"
+{% endif %} {# _node == node #}
+{% endfor %}
+{% endfor %}
+{% endif %} {# ipv6 #}
+
 {% if node == master %}
 set +x
 echo "Waiting for {{ nodes | length }} minions to submit their keys..."


### PR DESCRIPTION
- [x] https://github.com/SUSE/ceph-bootstrap/pull/46 merged
- [x] this PR rebased to eliminate conflicts with master
- [x] https://github.com/ceph/ceph/pull/36360 merged into master
- [x] https://github.com/ceph/ceph/pull/36360 included in Octopus backport PR (add PR URL here)
- [x] backport of https://github.com/ceph/ceph/pull/36360 reaches downstream product
- [x] remove DNM
- [x] manual test green
- [x] contrib/standalone.sh run passes

---

If `--ipv6` option is used when creating `pacific`, `octopus` or `ses7` environment, IPv6 addresses will be configured:

![Screenshot from 2020-01-23 11-18-44](https://user-images.githubusercontent.com/14297426/72980336-4e0b2080-3dd2-11ea-851c-3899f7804943.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>