### PR TITLE
Implement "vagrant box list" and "vagrant box remove"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     env: TOX_ENV=py37
   - python: 3.7
     env: TOX_ENV=lint
+before_install:
+- sudo apt-get -y install libvirt-dev
 install:
 - pip install tox
 script:

--- a/README.md
+++ b/README.md
@@ -76,10 +76,22 @@ Where `<distro>` can be either `Fedora_29` or `Fedora_30`.
 
 ### Install sesdev from source
 
+sesdev uses the libvirt API Python bindings, and these cannot be installed via
+pip unless the RPM package "libvirt-devel" is installed. So, before proceeding,
+make sure that package is installed:
+
+```
+$ sudo zypper -n install libvirt-devel
+```
+
+Once libvirt-devel is installed in the system, you can proceed to clone the
+sesdev source code repo, create and activate a virtualenv, and install sesdev's
+Python dependencies:
+
 ```
 $ git clone https://github.com/SUSE/sesdev.git
 $ cd sesdev
-$ virtualenv --python=<path_to_python3> venv
+$ virtualenv venv
 $ source venv/bin/activate
 $ pip install --editable .
 ```

--- a/sesdev.spec
+++ b/sesdev.spec
@@ -43,6 +43,7 @@ BuildRequires:  python3-setuptools
 %if 0%{?suse_version}
 Requires:       python3-click >= 6.7
 Requires:       python3-Jinja2 >= 2.10.1
+Requires:       python3-libvirt-python >= 5.1.0
 Requires:       python3-pycryptodomex >= 3.4.6
 Requires:       python3-PyYAML >= 3.13
 Requires:       python3-setuptools

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -9,11 +9,13 @@ import yaml
 from Cryptodome.PublicKey import RSA
 from jinja2 import Environment, PackageLoader
 
+import libvirt
+
 from . import tools
 from .exceptions import DeploymentDoesNotExists, VersionOSNotSupported, SettingTypeError, \
                         VagrantBoxDoesNotExist, NodeDoesNotExist, NoSourcePortForPortForwarding, \
                         ServicePortForwardingNotSupported, DeploymentAlreadyExists, \
-                        ServiceNotFound, ExclusiveRoles, RoleNotSupported
+                        ServiceNotFound, ExclusiveRoles, RoleNotSupported, CmdException
 
 
 JINJA_ENV = Environment(loader=PackageLoader('seslib', 'templates'), trim_blocks=True)
@@ -349,6 +351,109 @@ SETTINGS = {
 }
 
 
+class Box():
+    # pylint: disable=no-member
+    def __init__(self, settings):
+        self.libvirt_use_ssh = settings.libvirt_use_ssh
+        self.libvirt_private_key_file = settings.libvirt_private_key_file
+        self.libvirt_user = settings.libvirt_user
+        self.libvirt_host = settings.libvirt_host
+        self.libvirt_storage_pool = (
+            settings.libvirt_storage_pool if settings.libvirt_storage_pool else 'default'
+        )
+        self.libvirt_conn = None
+        self.libvirt_uri = None
+        self.pool = None
+        self.removal_candidate = None
+        self._populate_box_list()
+
+    def _build_libvirt_uri(self):
+        uri = None
+        if self.libvirt_use_ssh:
+            uri = 'qemu+ssh://'
+            if self.libvirt_user:
+                uri += "{}@".format(self.libvirt_user)
+            assert self.libvirt_host, "Cannot use qemu+ssh without a host"
+            uri += "{}/system".format(self.libvirt_host)
+            if self.libvirt_private_key_file:
+                if '/' not in self.libvirt_private_key_file:
+                    self.libvirt_private_key_file = os.path.join(
+                        os.path.expanduser('~'),
+                        '.ssh',
+                        self.libvirt_private_key_file
+                        )
+                uri += '?keyfile={}'.format(self.libvirt_private_key_file)
+        else:
+            uri = 'qemu:///system'
+        self.libvirt_uri = uri
+
+    def _populate_box_list(self):
+        self.all_possible_boxes = OS_BOX_MAPPING.keys()
+        self.boxes = []
+        output = tools.run_sync(["vagrant", "box", "list"])
+        lines = output.split('\n')
+        for line in lines:
+            if 'libvirt' in line:
+                box_name = line.split()[0]
+                if box_name in self.all_possible_boxes:
+                    self.boxes.append(box_name)
+
+    def exists(self, box_name):
+        return box_name in self.boxes
+
+    def get_image_to_remove(self, box_name):
+        #
+        # open connection to libvirt server
+        self.open_libvirt_connection()
+        #
+        # verify that the corresponding image exists in libvirt storage pool
+        self.pool = self.libvirt_conn.storagePoolLookupByName(self.libvirt_storage_pool)
+        removal_candidates = []
+        for removal_candidate in self.pool.listVolumes():
+            if str(removal_candidate).startswith('{}_vagrant_box_image'.format(box_name)):
+                removal_candidates.append(removal_candidate)
+        if len(removal_candidates) == 0:
+            return None
+        if len(removal_candidates) == 1:
+            self.removal_candidate = removal_candidates[0]
+            return self.removal_candidate
+        #
+        # bad news - multiple images match the box name
+        print("Removal candidates")
+        print("==================")
+        for candidate in removal_candidates:
+            print(candidate)
+        print()
+        assert False, \
+            (
+                "Too many removal candidates. Don't know which one to remove. "
+                "This should not happen - please raise a bug!"
+            )
+        return None
+
+    def list(self):
+        for box in self.boxes:
+            print(box)
+
+    def open_libvirt_connection(self):
+        if self.libvirt_conn:
+            return None
+        self._build_libvirt_uri()
+        # print("Opening libvirt connection to ->{}<-".format(self.libvirt_uri))
+        self.libvirt_conn = libvirt.open(self.libvirt_uri)
+        return None
+
+    def remove_image(self, image_name):
+        assert image_name == self.removal_candidate, \
+                "Wrong image_name passed to Box.remove_image!"
+        image = self.pool.storageVolLookupByName(image_name)
+        image.delete()
+
+    @staticmethod
+    def remove_box(box_name):
+        tools.run_sync(["vagrant", "box", "remove", box_name])
+
+
 class Settings():
     # pylint: disable=no-member
     def __init__(self, **kwargs):
@@ -460,6 +565,7 @@ class Deployment():
         }
         self.admin = None
         self.suma = None
+        self.box = Box(settings)
 
         if self.settings.os is None:
             self.settings.os = VERSION_PREFERRED_OS[self.settings.version]
@@ -764,6 +870,12 @@ class Deployment():
 
             log_handler("Downloading vagrant box: {}\n".format(self.settings.os))
 
+            image_to_remove = self.box.get_image_to_remove(self.settings.os)
+            if image_to_remove:
+                # remove image in libvirt to guarantee that, when "vagrant up"
+                # runs, the new box will be uploaded to libvirt
+                self.box.remove_image(image_to_remove)
+
             tools.run_async(["vagrant", "box", "add", "--provider", "libvirt", "--name",
                              self.settings.os, OS_BOX_MAPPING[self.settings.os]], log_handler)
 
@@ -954,7 +1066,7 @@ class Deployment():
                 try:
                     node = tools.run_sync(ssh_cmd)
                     node = node.strip()
-                except tools.CmdException:
+                except CmdException:
                     node = 'null'
                 if node == 'null':
                     raise ServiceNotFound(service)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifier =
 install_requires =
     Click >= 6.7
     Jinja2 >= 2.10.1
+    libvirt-python >= 5.1.0
     pycryptodomex >= 3.4.6
     PyYAML >= 3.13
 


### PR DESCRIPTION
Fixes: https://github.com/SUSE/sesdev/issues/58
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

TO DO:

- [x] if sesdev executes `vagrant box add` then it should remove the current image in libvirt to guarantee that when `vagrant up` runs, the new box is uploaded to libvirt 