### PR TITLE
pylintrc: ignore libvirt module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -233,6 +233,7 @@ int-import-graph=
 known-standard-library=
 known-third-party=enchant
 preferred-modules=
+ignored-modules=libvirt
 
 
 [CLASSES]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ $ pip install --editable .
 
 Remember to re-run `pip install --editable .` after each git pull.
 
+#### Linting
+
+If you are preparing a code change for submission and would like to run it
+through the linter, install the "tox" and "pylint" packages in your system,
+first:
+
+```
+zypper -n install python3-tox python3-pylint
+```
+
+Then, execute the following command in the top-level of your local git clone:
+
+```
+tox -elint
+```
+
 ## Usage
 
 Run `sesdev --help` or `sesdev <command> --help` to get check the available


### PR DESCRIPTION
After the introduction of the libvirt dependency, there were reports
that local "tox -elint" started failing with:

    seslib/__init__.py:12:0: E0401: Unable to import 'libvirt' (import-error)

even though libvirt module is installed in the virtualenv.

Signed-off-by: Nathan Cutler <ncutler@suse.com>