### PR TITLE
several fixes for octopus/ses7 deployment

### DIFF
--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -91,8 +91,7 @@ ceph-bootstrap config /Deployment/OSD enable
 # OSDs drive groups spec for each node
 {% for node in nodes %}
 {% if node.has_role('storage') %}
-DEV_LIST=`seq 1 {{ node.storage_disks | length }} | awk 'BEGIN{i=0; printf("[");}{if (i>0){printf(", ")}; i++; printf("\"/dev/vd%c\"", $1 + 97)}END{printf("]")}'`
-ceph-bootstrap config /Storage/Drive_Groups add value="{\"host_pattern\": \"{{ node.name }}*\", \"data_devices\": { \"paths\": $DEV_LIST }}"
+ceph-bootstrap config /Storage/Drive_Groups add value="{\"testing_dg_{{ node.name }}\": {\"host_pattern\": \"{{ node.name }}*\", \"data_devices\": {\"all\": true}}}"
 {% endif %}
 {% endfor %}
 {% endif %} {# if ceph_bootstrap_deploy_osds #}

--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -36,7 +36,7 @@ while true ; do
   set -x
   sleep 5
   set +x
-  if [ "$LOOP_COUNT" -ge "10" ] ; then
+  if [ "$LOOP_COUNT" -ge "20" ] ; then
     echo "ERROR: minion(s) not responding to ping?"
     exit 1
   fi

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -48,7 +48,7 @@ cat /home/vagrant/.ssh/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
 chmod 600 /home/vagrant/.ssh/id_rsa
 cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
-hostnamectl set-hostname {{ node.fqdn }}
+hostnamectl set-hostname {{ node.name }}
 
 {% if not suma %}
 zypper -n install salt-minion

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -1,5 +1,8 @@
 {% include "engine/" + vm_engine + "/vagrant.provision.sh.j2" ignore missing %}
 
+# remove the first line introduced by vagrant
+head -1 /etc/hosts | grep -q '127.*' && sed -i '1d' /etc/hosts
+
 {% for _node in nodes %}
 {% if _node.public_address %}
 echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/hosts


### PR DESCRIPTION
One of the fixes guarantees that when ceph daemons generate their metadata, the `hostname` info will have the short hostname of the machine, which will match the ceph orchestrator inventory.

It also fixes the drive-groups spec generation to match the requirements of ceph 15.1.0 version.

Signed-off-by: Ricardo Dias <rdias@suse.com>