### PR TITLE
Pillar is now automatically configured by ceph-bootstrap

### DIFF
--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -20,15 +20,6 @@ zypper -n in ceph-bootstrap-qa
 {% endif %}
 {% endif %}
 
-cat <<EOF > /srv/pillar/top.sls
-base:
-  '*':
-    - ceph-salt
-EOF
-chown -R salt:salt /srv/pillar
-
-systemctl restart salt-master
-
 # make sure all minions are responding
 set +ex
 LOOP_COUNT="0"


### PR DESCRIPTION
Since https://github.com/SUSE/ceph-bootstrap/pull/61, the pillar is automatically configured.

Signed-off-by: Ricardo Marques <rimarques@suse.com>