### PR TITLE
[AFTER: M4 RELEASE] Pillar is now automatically configured by ceph-bootstrap

### DIFF
--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -20,27 +20,6 @@ zypper -n in ceph-bootstrap-qa
 {% endif %}
 {% endif %}
 
-# make sure all minions are responding
-set +ex
-LOOP_COUNT="0"
-while true ; do
-  set -x
-  sleep 5
-  set +x
-  if [ "$LOOP_COUNT" -ge "20" ] ; then
-    echo "ERROR: minion(s) not responding to ping?"
-    exit 1
-  fi
-  LOOP_COUNT="$((LOOP_COUNT + 1))"
-  set -x
-  MINIONS_RESPONDING="$(salt '*' test.ping | grep True | wc --lines)"
-  if [ "$MINIONS_RESPONDING" = "{{ nodes|length }}" ]; then
-    break
-  fi
-  set +x
-done
-set -ex
-
 salt '*' saltutil.pillar_refresh
 salt '*' saltutil.sync_all
 

--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -20,15 +20,6 @@ zypper -n in ceph-bootstrap-qa
 {% endif %}
 {% endif %}
 
-cat <<EOF > /srv/pillar/top.sls
-base:
-  '*':
-    - ceph-salt
-EOF
-chown -R salt:salt /srv/pillar
-
-systemctl restart salt-master
-
 # make sure all minions are responding
 set +ex
 LOOP_COUNT="0"

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -94,6 +94,27 @@ while true; do
 done
 salt-key -Ay
 
+# make sure all minions are responding
+set +ex
+LOOP_COUNT="0"
+while true ; do
+  set -x
+  sleep 5
+  set +x
+  if [ "$LOOP_COUNT" -ge "20" ] ; then
+    echo "ERROR: minion(s) not responding to ping?"
+    exit 1
+  fi
+  LOOP_COUNT="$((LOOP_COUNT + 1))"
+  set -x
+  MINIONS_RESPONDING="$(salt '*' test.ping | grep True | wc --lines)"
+  if [ "$MINIONS_RESPONDING" = "{{ nodes|length }}" ]; then
+    break
+  fi
+  set +x
+done
+set -ex
+
 {% if deployment_tool == "deepsea" %}
 {% include "deepsea/deepsea_deployment.sh.j2" %}
 {% endif %}


### PR DESCRIPTION
Since https://github.com/SUSE/ceph-bootstrap/pull/61, the pillar is automatically configured.

Signed-off-by: Ricardo Marques <rimarques@suse.com>

---

The test.ping loop is applicable to all environments, not just
ceph-bootstrap ones.

Signed-off-by: Nathan Cutler <ncutler@suse.com>