### PR TITLE
Remove any orphaned images after destroy

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -304,7 +304,7 @@ def remove_box(box_name, **kwargs):
         click.echo("There is no Vagrant Box called ->{}<-".format(box_name))
         sys.exit(-1)
 
-    image_to_remove = box_obj.get_image_to_remove(box_name)
+    image_to_remove = box_obj.get_image_by_box(box_name)
     if image_to_remove:
         click.echo("Found related image ->{}<- in libvirt storage pool"
                    .format(image_to_remove))


### PR DESCRIPTION
Handle the following edge case:

An existing deployment has one or more node snapshot images and/or disk
volume images, but no base box image. As a result, the deployment is
registered as "not deployed".

Without this patch, running "sesdev destroy" on that deployment will not
trigger "vagrant destroy" and all the images still existing and associated 
with that deployment will be left behind. Then, when the user tries to create 
another deployment with the same deployment ID, vagrant will complain 
like so:

"Volume for domain is already created. Please run 'vagrant destroy' first."

However, the user is not expected to be able to run "vagrant destroy"
("sesdev destroy" is supposed to do that for him).

Signed-off-by: Nathan Cutler <ncutler@suse.com>