### PR TITLE
Increase chances of getting the latest ses7 packages

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -148,6 +148,8 @@ VERSION_OS_REPO_MAPPING = {
     },
     'ses7': {
         'sles-15-sp2': [
+            'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/SES7/images/repo/'
+            'SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/',
             'http://download.suse.de/ibs/Devel:/Storage:/7.0/images/repo/'
             'SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/'
         ],


### PR DESCRIPTION
When a package (such as "ceph") is promoted from Devel:Storage:7.0 to
SUSE:SLE-15-SP2:Update:Products:SES7, it gets automatically deleted from
Devel:Storage:7.0 when the associated SR is accepted.

This creates a race condition: due to the way the Build Service works,
the next Devel:Storage:7.0 image build after the package "disappears"
typically does not get the latest package from
SUSE:SLE-15-SP2:Update:Products:SES7 (to where it was promoted), because
the package in that project is still building. This is an especially big
problem with the package "ceph", because it takes a long time to build.

By including both image repos - Devel:Storage:7.0 and
SUSE:SLE-15-SP2:Update:Products:SES7 - we mitigate the damage caused by
this race condition. Chances are that _one_ of these two will have the
latest version of ceph.

---

TO DO

- [x] #83 merged
- [x] rebase