### PR TITLE
ceph_bootstrap_deployment: log cephadm and ceph-bootstrap version

### DIFF
--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -71,6 +71,10 @@ ceph-bootstrap config /Deployment/Dashboard/password set admin
 
 ceph-bootstrap config ls
 
+zypper lr -upEP
+zypper info cephadm | grep -E '(^Repo|^Version)'
+ceph-bootstrap --version
+
 {% if stop_before_ceph_bootstrap_deploy %}
 exit 0
 {% endif %}


### PR DESCRIPTION
This information is logged to facilitate faster debugging of problems
arising out of incompatibility between cephadm and ceph-bootstrap.

Fixes: https://github.com/SUSE/sesdev/issues/85
Signed-off-by: Nathan Cutler <ncutler@suse.com>