### PR TITLE
ceph_bootstrap: restart salt-master after ceph-bootstrap installation

### DIFF
--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -20,6 +20,29 @@ zypper -n in ceph-bootstrap-qa
 {% endif %}
 {% endif %}
 
+systemctl restart salt-master
+
+# make sure all minions are responding
+set +ex
+LOOP_COUNT="0"
+while true ; do
+  set -x
+  sleep 5
+  set +x
+  if [ "$LOOP_COUNT" -ge "20" ] ; then
+    echo "ERROR: minion(s) not responding to ping?"
+    exit 1
+  fi
+  LOOP_COUNT="$((LOOP_COUNT + 1))"
+  set -x
+  MINIONS_RESPONDING="$(salt '*' test.ping | grep True | wc --lines)"
+  if [ "$MINIONS_RESPONDING" = "{{ nodes|length }}" ]; then
+    break
+  fi
+  set +x
+done
+set -ex
+
 salt '*' saltutil.pillar_refresh
 salt '*' saltutil.sync_all
 


### PR DESCRIPTION
The ceph-salt-formula state files are installed in a custom directory
that is configured in an additional configuration file stored in
/etc/salt/master.d and the salt-master needs to be restarted to load
the state files in that custom directory.

Signed-off-by: Ricardo Dias <rdias@suse.com>