### PR TITLE
tools/run_async: decode stderr bytes

### DIFF
--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -4,8 +4,10 @@ class SesDevException(Exception):
 
 class CmdException(SesDevException):
     def __init__(self, command, retcode, stderr):
-        super(CmdException, self).__init__("Command '{}' failed: ret={} stderr:\n{}"
-                                           .format(command, retcode, stderr))
+        super(CmdException, self).__init__(
+            "Command '{}' failed: ret={} stderr:\n{}"
+            .format(command, retcode, stderr)
+            )
         self.command = command
         self.retcode = retcode
         self.stderr = stderr

--- a/seslib/tools.py
+++ b/seslib/tools.py
@@ -47,7 +47,7 @@ def run_async(command, callback, cwd=None):
             retcode = proc.poll()
             if retcode is not None:
                 if retcode != 0:
-                    raise CmdException(command, retcode, proc.stderr.read())
+                    raise CmdException(command, retcode, proc.stderr.read().decode('utf-8'))
                 break
 
 


### PR DESCRIPTION
When the command it is running fails, "run_async" captures whatever
got written to stderr as a sequence of bytes.

Make sure we decode these bytes before sending them to CmdException.
