### PR TITLE
Let --debug run "vagrant up/destroy" in debug mode

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -191,10 +191,14 @@ $ sesdev create octopus --roles="[admin, mon, mgr], \\
        --num-disks=4 --disk-size=10 my_octopus_cluster
 
     """
+    if debug:
+        logger.info("Debug mode: ON")
+        seslib.GlobalSettings.DEBUG = debug
+
     if log_file:
         logging.basicConfig(format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s',
                             filename=log_file, filemode='w',
-                            level=logging.INFO if not debug else logging.DEBUG)
+                            level=logging.DEBUG if debug else logging.INFO)
     else:
         logging.basicConfig(format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s',
                             level=logging.CRITICAL)

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 class GlobalSettings():
     WORKING_DIR = os.path.join(Path.home(), '.sesdev')
     CONFIG_FILE = os.path.join(WORKING_DIR, 'config.yaml')
+    DEBUG = False
 
     @classmethod
     def init_path_to_qa(cls, full_path_to_sesdev_executable):
@@ -1008,13 +1009,18 @@ class Deployment():
         cmd = ["vagrant", "up"]
         if node is not None:
             cmd.append(node)
+        if GlobalSettings.DEBUG:
+            cmd.append('--debug')
         tools.run_async(cmd, log_handler, self.dep_dir)
 
     def destroy(self, log_handler):
         for node in self.nodes.values():
             if node.status == 'not deployed':
                 continue
-            tools.run_async(["vagrant", "destroy", node.name, "--force"], log_handler, self.dep_dir)
+            cmd = ["vagrant", "destroy", node.name, "--force"]
+            if GlobalSettings.DEBUG:
+                cmd.append('--debug')
+            tools.run_async(cmd, log_handler, self.dep_dir)
         shutil.rmtree(self.dep_dir)
         # clean up any orphaned volumes
         images_to_remove = self.box.get_images_by_deployment(self.dep_id)


### PR DESCRIPTION
With this patch, we get debug-level output from "vagrant up" and
"vagrant destroy", but only when the command fails.
    
When the command succeeds, vagrant sends the debug messages to stderr
and these are ignored by run_async.

Still, this is better than no debug messages at all when vagrant fails.
