### PR TITLE
libvirt/network: autostart networks per default

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -668,11 +668,11 @@ class Deployment():
             else:
                 if 'admin' in node_roles or 'suma' in node_roles:
                     public_address = '{}{}'.format(self.settings.public_network, 200)
-                    networks = ('node.vm.network :private_network, ip:'
+                    networks = ('node.vm.network :private_network, autostart: true, ip:'
                                 '"{}"').format(public_address)
                 else:
                     public_address = '{}{}'.format(self.settings.public_network, 200 + node_id)
-                    networks = ('node.vm.network :private_network, ip:'
+                    networks = ('node.vm.network :private_network, autostart: true, ip:'
                                 '"{}"').format(public_address)
 
             if self.settings.version != 'ses5':


### PR DESCRIPTION
enabled here: https://github.com/vagrant-libvirt/vagrant-libvirt/pull/708/commits/04b34f8c13f824129b1addb1d21c685f0203da75

Will enable 'autostart' in the libvirt network configuration.

Signed-off-by: Joshua Schmid <jschmid@suse.de>