### PR TITLE
CaaSP setup

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -654,6 +654,8 @@ def caasp4(deployment_id, deploy, deploy_ses, **kwargs):
     settings_dict = _gen_settings_dict('caasp4', **kwargs)
     if 'roles' not in settings_dict:
         settings_dict['roles'] = _parse_roles("[master],[worker],[loadbalancer],[storage]")
+    if deploy_ses:
+        settings_dict['caasp_deploy_ses'] = True
     _create_command(deployment_id, deploy, settings_dict)
 
 
@@ -686,7 +688,7 @@ def ssh(deployment_id, node=None):
     _node = node
     if node is None:
         if dep.settings.version == 'caasp4':
-            _node = 'master'
+            _node = 'master1'
         else:
             _node = 'admin'
     dep.ssh(_node)

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -376,6 +376,11 @@ SETTINGS = {
         'help': 'Use `ceph-bootstrap deploy` command to run ceph-salt formula',
         'default': True
     },
+    'caasp_deploy_ses': {
+        'type': bool,
+        'help': 'Deploy SES using rook in CaasP',
+        'default': False
+    },
 }
 
 
@@ -722,18 +727,22 @@ class Deployment():
                 fqdn = 'admin.{}'.format(self.settings.domain.format(self.dep_id))
             elif 'master' in node_roles:
                 master_id += 1
+                node_id += 1
                 name = 'master{}'.format(master_id)
                 fqdn = 'master{}.{}'.format(master_id, self.settings.domain.format(self.dep_id))
             elif 'worker' in node_roles:
                 worker_id += 1
+                node_id += 1
                 name = 'worker{}'.format(worker_id)
                 fqdn = 'worker{}.{}'.format(worker_id, self.settings.domain.format(self.dep_id))
             elif 'loadbalancer' in node_roles:
                 loadbl_id += 1
+                node_id += 1
                 name = 'loadbl{}'.format(loadbl_id)
                 fqdn = 'loadbl{}.{}'.format(loadbl_id, self.settings.domain.format(self.dep_id))
             elif 'storage' in node_roles and self.settings.version == 'caasp4':
                 storage_id += 1
+                node_id += 1
                 name = 'storage{}'.format(storage_id)
                 fqdn = 'storage{}.{}'.format(storage_id, self.settings.domain.format(self.dep_id))
             else:
@@ -894,7 +903,8 @@ class Deployment():
             'ceph_bootstrap_deploy_mgrs': self.settings.ceph_bootstrap_deploy_mgrs,
             'ceph_bootstrap_deploy_osds': self.settings.ceph_bootstrap_deploy_osds,
             'ceph_bootstrap_deploy': self.settings.ceph_bootstrap_deploy,
-            'node_manager': NodeManager(list(self.nodes.values()))
+            'node_manager': NodeManager(list(self.nodes.values())),
+            'caasp_deploy_ses': self.settings.caasp_deploy_ses,
         }
 
         scripts = {}

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -101,6 +101,7 @@ VERSION_PREFERRED_OS = {
     'ses7': 'sles-15-sp2',
     'nautilus': 'leap-15.1',
     'octopus': 'leap-15.2',
+    'caasp4': 'sles-15-sp1',
 }
 
 VERSION_PREFERRED_DEPLOYMENT_TOOL = {
@@ -155,6 +156,14 @@ VERSION_OS_REPO_MAPPING = {
             'http://download.suse.de/ibs/Devel:/Storage:/7.0/images/repo/'
             'SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/'
         ],
+    },
+    'caasp4': {
+        'sles-15-sp1': [
+            'http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/'
+            'standard/',
+            'http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/',
+            'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/'
+        ]
     }
 }
 
@@ -573,6 +582,29 @@ class Node():
         self.repos.append(repo)
 
 
+class NodeManager:
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+    def get_by_role(self, role):
+        return [n for n in self.nodes if n.has_role(role)]
+
+    def get_one_by_role(self, role):
+        node_list = self.get_by_role(role)
+        if node_list:
+            return node_list[0]
+        return None
+
+    def get_by_name(self, name):
+        for node in self.nodes:
+            if node.name == name:
+                return node
+        return None
+
+    def count_by_role(self, role):
+        return len(self.get_by_role(role))
+
+
 class Deployment():
     def __init__(self, dep_id, settings):
         self.dep_id = dep_id
@@ -594,7 +626,7 @@ class Deployment():
         if self.settings.os is None:
             self.settings.os = VERSION_PREFERRED_OS[self.settings.version]
 
-        if self.settings.deployment_tool is None:
+        if self.settings.deployment_tool is None and self.settings.version != 'caasp4':
             self.settings.deployment_tool = VERSION_PREFERRED_DEPLOYMENT_TOOL[self.settings.version]
 
         if self.settings.ceph_container_image is None:
@@ -663,6 +695,11 @@ class Deployment():
 
     def _generate_nodes(self):
         node_id = 0
+        master_id = 0
+        worker_id = 0
+        storage_id = 0
+        loadbl_id = 0
+        storage_id = 0
         for node_roles in self.settings.roles:
             for role_type in ["ganesha", "igw", "mds", "mgr", "mon", "rgw", "storage"]:
                 if role_type in node_roles:
@@ -671,9 +708,34 @@ class Deployment():
             if 'suma' in node_roles and self.settings.version not in ['octopus']:
                 raise RoleNotSupported('suma', self.settings.version)
 
+            if 'master' in node_roles and self.settings.version != 'caasp4':
+                raise RoleNotSupported('master', self.settings.version)
+
+            if 'worker' in node_roles and self.settings.version != 'caasp4':
+                raise RoleNotSupported('master', self.settings.version)
+
+            if 'loadbalancer' in node_roles and self.settings.version != 'caasp4':
+                raise RoleNotSupported('master', self.settings.version)
+
             if 'admin' in node_roles or 'suma' in node_roles:
                 name = 'admin'
                 fqdn = 'admin.{}'.format(self.settings.domain.format(self.dep_id))
+            elif 'master' in node_roles:
+                master_id += 1
+                name = 'master{}'.format(master_id)
+                fqdn = 'master{}.{}'.format(master_id, self.settings.domain.format(self.dep_id))
+            elif 'worker' in node_roles:
+                worker_id += 1
+                name = 'worker{}'.format(worker_id)
+                fqdn = 'worker{}.{}'.format(worker_id, self.settings.domain.format(self.dep_id))
+            elif 'loadbalancer' in node_roles:
+                loadbl_id += 1
+                name = 'loadbl{}'.format(loadbl_id)
+                fqdn = 'loadbl{}.{}'.format(loadbl_id, self.settings.domain.format(self.dep_id))
+            elif 'storage' in node_roles and self.settings.version == 'caasp4':
+                storage_id += 1
+                name = 'storage{}'.format(storage_id)
+                fqdn = 'storage{}.{}'.format(storage_id, self.settings.domain.format(self.dep_id))
             else:
                 node_id += 1
                 name = 'node{}'.format(node_id)
@@ -717,7 +779,7 @@ class Deployment():
             if 'suma' in node_roles:
                 self.suma = node
 
-            if 'storage' in node_roles:
+            if 'storage' in node_roles and self.settings.version != 'caasp4':
                 if self.settings.cluster_network:
                     node.cluster_address = '{}{}'.format(self.settings.cluster_network,
                                                          200 + node_id)
@@ -749,6 +811,16 @@ class Deployment():
             r_name = 'custom-repo-{}'
             for idx, repo_url in enumerate(self.settings.repos):
                 node.add_repo(ZypperRepo(r_name.format(idx+1), repo_url))
+
+            if 'master' in node_roles or 'worker' in node_roles:
+                if node.cpus < 2:
+                    node.cpus = 2
+                if self.settings.ram < 2:
+                    node.ram = 2 * 2**10
+
+            if 'worker' in node_roles:
+                for _ in range(self.settings.num_disks):
+                    node.storage_disks.append(Disk(self.settings.disk_size))
 
             self.nodes[node.name] = node
 
@@ -790,6 +862,7 @@ class Deployment():
             'nodes': list(self.nodes.values()),
             'admin': self.admin,
             'suma': self.suma,
+            'domain': self.settings.domain.format(self.dep_id),
             'deepsea_git_repo': self.settings.deepsea_git_repo,
             'deepsea_git_branch': self.settings.deepsea_git_branch,
             'version': self.settings.version,
@@ -821,6 +894,7 @@ class Deployment():
             'ceph_bootstrap_deploy_mgrs': self.settings.ceph_bootstrap_deploy_mgrs,
             'ceph_bootstrap_deploy_osds': self.settings.ceph_bootstrap_deploy_osds,
             'ceph_bootstrap_deploy': self.settings.ceph_bootstrap_deploy,
+            'node_manager': NodeManager(list(self.nodes.values()))
         }
 
         scripts = {}

--- a/seslib/templates/caasp/loadbalancer.sh.j2
+++ b/seslib/templates/caasp/loadbalancer.sh.j2
@@ -1,0 +1,59 @@
+zypper -n install nginx
+
+cat > /etc/nginx/nginx.conf << EOF
+user  nginx;
+worker_processes  auto;
+load_module /usr/lib64/nginx/modules/ngx_stream_module.so;
+error_log  /var/log/nginx/error.log;
+error_log  /var/log/nginx/error.log  notice;
+error_log  /var/log/nginx/error.log  info;
+events {
+    worker_connections  1024;
+    use epoll;
+}
+stream {
+    log_format proxy '$remote_addr [$time_local] '
+                     '$protocol $status $bytes_sent $bytes_received '
+                     '$session_time "$upstream_addr"';
+    error_log  /var/log/nginx/k8s-masters-lb-error.log;
+    access_log /var/log/nginx/k8s-masters-lb-access.log proxy;
+    upstream k8s-masters {
+EOF
+
+{% for _node in node_manager.get_by_role('master') %}
+printf "        server {{ _node.name }}:6443 weight=1 max_fails=1;\n" >> /etc/nginx/nginx.conf
+{% endfor %}
+printf "    }\n" >> /etc/nginx/nginx.conf
+printf "    upstream k8s-workers_http {\n" >> /etc/nginx/nginx.conf
+{% for _node in node_manager.get_by_role('worker') %}
+printf "        server {{ _node.name }}:80 weight=1 max_fails=1;\n" >> /etc/nginx/nginx.conf
+{% endfor %}
+printf "    }\n" >> /etc/nginx/nginx.conf
+
+printf "    upstream k8s-workers_https {\n" >> /etc/nginx/nginx.conf
+{% for _node in node_manager.get_by_role('worker') %}
+printf "        server {{ _node.name }}:443 weight=1 max_fails=1;\n" >> /etc/nginx/nginx.conf
+{% endfor %}
+
+cat >> /etc/nginx/nginx.conf << EOF
+    }
+    server {
+        listen 6443;
+        #proxy_connect_timeout 1s;
+        #proxy_timeout 3s;
+        proxy_pass k8s-masters;
+    }
+   server {
+        listen 80;
+        proxy_pass k8s-workers_http;
+    }
+    server {
+        listen 443;
+        proxy_pass k8s-workers_https;
+    }
+}
+EOF
+
+systemctl enable --now nginx
+
+touch /tmp/ready

--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -1,0 +1,87 @@
+
+zypper -n in -t pattern SUSE-CaaSP-Management
+
+{% if node.name == 'master1' %}
+
+function wait_for_masters_ready {
+    printf "Waiting for masters to be ready"
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-master-[0-9]\s+Ready") -eq $NMASTERS ]]; do
+         sleep 5
+		 printf "."
+    done
+	printf "\n"
+}
+
+function wait_for_workers_ready {
+    printf "Waiting for workers to be ready"
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-worker-[0-9]\s+Ready") -eq $NWORKERS ]]; do
+         sleep 5
+         printf "."
+    done
+    printf "\n"
+}
+
+function wait_for_workers_notready {
+    printf "Waiting for workers to be flagged 'NotReady'"
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-worker-[0-9]\s+NotReady") -eq $NWORKERS ]]; do
+         sleep 5
+         printf "."
+    done
+    printf "\n"
+}
+
+touch /tmp/ready
+
+while : ; do
+  PROVISIONED_NODES=`ls -l /tmp/ready-* 2>/dev/null | wc -l`
+  echo "waiting for nodes (${PROVISIONED_NODES}/{{ nodes|length }})";
+  [[ "${PROVISIONED_NODES}" != "{{ nodes|length }}" ]] || break
+  sleep 2;
+{% for node in nodes %}
+  scp -o StrictHostKeyChecking=no {{ node.name }}:/tmp/ready /tmp/ready-{{ node.name }};
+{% endfor %}
+done
+
+SKUBA_VERBOSITY=${SKUBA_VERBOSITY:-1}
+
+eval $(ssh-agent -s)
+ssh-add ~/.ssh/id_rsa
+
+mkdir -p ~/cluster
+cd ~/cluster
+
+skuba -v ${SKUBA_VERBOSITY} cluster init --control-plane {{ node_manager.get_one_by_role('loadbalancer').name }} caasp4-cluster
+chmod g+rx caasp4-cluster
+cd caasp4-cluster
+skuba -v ${SKUBA_VERBOSITY} node bootstrap --user sles --sudo --target {{ node.name }} {{ node.name }}
+skuba -v ${SKUBA_VERBOSITY} cluster status
+mkdir -p ~/.kube
+ln -sf /root/cluster/caasp4-cluster/admin.conf ~/.kube/config
+chmod g+r /root/cluster/caasp4-cluster/admin.conf
+kubectl get nodes -o wide
+
+# adding masters
+{% for _node in node_manager.get_by_role('master') %}
+{% if _node != node %}
+skuba -v ${SKUBA_VERBOSITY} node join --role master --user sles --sudo --target {{ _node.name }} {{ _node.name }}
+{% endif %}
+{% endfor %}
+skuba -v ${SKUBA_VERBOSITY} cluster status
+kubectl get nodes -o wide
+
+# adding workers
+{% for _node in node_manager.get_by_role('worker') %}
+skuba -v ${SKUBA_VERBOSITY} node join --role worker --user sles --sudo --target {{ _node.name }} {{ _node.name }}
+{% endfor %}
+
+wait_for_masters_ready
+wait_for_workers_ready
+
+skuba -v ${SKUBA_VERBOSITY} cluster status
+kubectl get nodes -o wide
+
+{% else %}
+
+touch /tmp/ready
+
+{% endif %}

--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -30,6 +30,8 @@ function wait_for_workers_notready {
     printf "\n"
 }
 
+zypper -n in skuba skuba-update
+
 touch /tmp/ready
 
 while : ; do

--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -5,7 +5,7 @@ zypper -n in -t pattern SUSE-CaaSP-Management
 
 function wait_for_masters_ready {
     printf "Waiting for masters to be ready"
-    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-master-[0-9]\s+Ready") -eq $NMASTERS ]]; do
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "master[0-9]\s+Ready") -eq {{node_manager.get_by_role('master') | length}} ]]; do
          sleep 5
 		 printf "."
     done
@@ -14,16 +14,7 @@ function wait_for_masters_ready {
 
 function wait_for_workers_ready {
     printf "Waiting for workers to be ready"
-    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-worker-[0-9]\s+Ready") -eq $NWORKERS ]]; do
-         sleep 5
-         printf "."
-    done
-    printf "\n"
-}
-
-function wait_for_workers_notready {
-    printf "Waiting for workers to be flagged 'NotReady'"
-    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-worker-[0-9]\s+NotReady") -eq $NWORKERS ]]; do
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "worker[0-9]\s+Ready") -eq {{node_manager.get_by_role('worker') | length}} ]]; do
          sleep 5
          printf "."
     done
@@ -81,6 +72,95 @@ wait_for_workers_ready
 
 skuba -v ${SKUBA_VERBOSITY} cluster status
 kubectl get nodes -o wide
+
+# setting up helm
+kubectl create serviceaccount --namespace kube-system tiller
+kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+helm init --service-account=tiller --wait
+
+# adding nfs storage class
+helm install --name=nfs-client --set nfs.server=storage1 --set nfs.path=/nfs --set storageClass.defaultClass=true stable/nfs-client-provisioner
+
+# Installing Kubernetes Dashboard
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-rc2/aio/deploy/recommended.yaml
+kubectl patch svc kubernetes-dashboard --type='json' -p '[{"op":"replace","path":"/spec/type","value":"NodePort"}]' -n kubernetes-dashboard
+
+cat >/tmp/dashboard-admin.yaml <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kube-system
+EOF
+
+kubectl apply -f /tmp/dashboard-admin.yaml
+
+cat >/tmp/admin-user-crb.yaml <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: admin-user
+    namespace: kube-system
+EOF
+
+kubectl apply -f /tmp/admin-user-crb.yaml
+
+rm -f /tmp/dashboard-admin.yaml /tmp/admin-user-crb.yaml 2>/dev/null
+
+ST=$(kubectl -n kube-system get serviceaccounts admin-user -o jsonpath="{.secrets[0].name}")
+SECRET=$(kubectl -n kube-system get secret ${ST} -o jsonpath="{.data.token}"|base64 -d)
+export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services kubernetes-dashboard -n kubernetes-dashboard)
+export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}" -n kubernetes-dashboard)
+
+echo "    token: $SECRET" >> ~/.kube/config
+echo "Access your dashboard at: https://$NODE_IP:$NODE_PORT/"
+echo "Your login token is: ${SECRET}"
+echo "Or use ~/.kube/config to authenticate with kubeconfig"
+
+# setting up MetalLB
+MLBCONFIG=/tmp/metallb.yaml
+
+kubectl create namespace metallb-system
+
+cat > ${MLBCONFIG} <<EOF
+configInline:
+  address-pools:
+  - name: default
+    protocol: layer2
+    addresses:
+    - 192.168.121.240-192.168.121.250
+EOF
+
+helm install --namespace metallb-system --name metallb stable/metallb -f ${MLBCONFIG}
+rm ${MLBCONFIG}
+
+
+{% if caasp_deploy_ses %}
+
+# deploy and configure rook + Ceph
+
+zypper -n in rook-k8s-yaml
+cd /usr/share/k8s-yaml/rook/ceph/
+
+{% if node_manager.get_by_role('worker') | length <3 %}
+
+sed -i 's/allowMultiplePerNode: false/allowMultiplePerNode: true/' /usr/share/k8s-yaml/rook/ceph/cluster.yaml
+
+{% endif %}
+
+kubectl apply -f common.yaml -f operator.yaml
+sleep 15
+kubectl apply -f cluster.yaml -f toolbox.yaml
+echo "Verify the installation by running 'kubectl get pods -n rook-ceph'"
+
+{% endif %}
 
 {% else %}
 

--- a/seslib/templates/caasp/provision.sh.j2
+++ b/seslib/templates/caasp/provision.sh.j2
@@ -6,8 +6,8 @@ echo "sles ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/sles
 cp -r ~root/.ssh ~sles/
 chown -R sles:users ~sles/.ssh
 
-zypper -n install skuba cri-o-kubeadm-criconfig kubernetes-kubeadm kubernetes-kubelet \
-          kubernetes-client podman skuba-update SUSEConnect
+zypper -n install cri-o-kubeadm-criconfig kubernetes-kubeadm kubernetes-kubelet \
+          kubernetes-client podman SUSEConnect nfs-client
 
 zypper -n install -t pattern SUSE-CaaSP-Node
 

--- a/seslib/templates/caasp/provision.sh.j2
+++ b/seslib/templates/caasp/provision.sh.j2
@@ -1,0 +1,28 @@
+useradd -m sles
+usermod -v 10000000-20000000 -w 10000000-20000000 sles
+
+echo "sles ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/sles
+
+cp -r ~root/.ssh ~sles/
+chown -R sles:users ~sles/.ssh
+
+zypper -n install skuba cri-o-kubeadm-criconfig kubernetes-kubeadm kubernetes-kubelet \
+          kubernetes-client podman skuba-update SUSEConnect
+
+zypper -n install -t pattern SUSE-CaaSP-Node
+
+{% if node.has_role('master') %}
+{% include "caasp/master.sh.j2" %}
+{% endif %}
+
+{% if node.has_role('loadbalancer') %}
+{% include "caasp/loadbalancer.sh.j2" %}
+{% endif %}
+
+{% if node.has_role('storage') %}
+{% include "caasp/storage.sh.j2" %}
+{% endif %}
+
+{% if node.has_role('worker') %}
+touch /tmp/ready
+{% endif %}

--- a/seslib/templates/caasp/provision.sh.j2
+++ b/seslib/templates/caasp/provision.sh.j2
@@ -3,8 +3,8 @@ usermod -v 10000000-20000000 -w 10000000-20000000 sles
 
 echo "sles ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/sles
 
-cp -r ~root/.ssh ~sles/
-chown -R sles:users ~sles/.ssh
+cp -r /root/.ssh/ /home/sles/
+chown -R sles:users /home/sles/.ssh/
 
 zypper -n install cri-o-kubeadm-criconfig kubernetes-kubeadm kubernetes-kubelet \
           kubernetes-client podman SUSEConnect nfs-client

--- a/seslib/templates/caasp/storage.sh.j2
+++ b/seslib/templates/caasp/storage.sh.j2
@@ -1,4 +1,8 @@
+zypper -n in nfs-kernel-server
+
 mkdir /nfs
 echo '/nfs     *.{{ domain }}(rw,no_root_squash)' >/etc/exports
 systemctl enable --now nfs-server
 exportfs -a
+
+touch /tmp/ready

--- a/seslib/templates/caasp/storage.sh.j2
+++ b/seslib/templates/caasp/storage.sh.j2
@@ -1,0 +1,4 @@
+mkdir /nfs
+echo '/nfs     *.{{ domain }}(rw,no_root_squash)' >/etc/exports
+systemctl enable --now nfs-server
+exportfs -a

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -20,7 +20,7 @@ zypper ar {{ _repo }} {{ version }}-repo{{ loop.index }}
 zypper mr -p 98 {{ version }}-repo{{ loop.index }}
 {% endfor %}
 
-{% if version == 'ses7' %}
+{% if version == 'ses7' or version == 'caasp4' %}
 zypper ar -f http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo
 {% endif %}
 
@@ -32,7 +32,7 @@ zypper -n install vim git-core iputils jq make iptables patch man
 zypper -n install vim git iputils hostname jq make iptables patch man
 {% endif %}
 
-{% if version == 'ses7' %}
+{% if version == 'ses7' or version == 'caasp4' %}
 zypper -n install ca-certificates-suse
 {% endif %}
 
@@ -52,6 +52,10 @@ chmod 600 /home/vagrant/.ssh/id_rsa
 cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
 hostnamectl set-hostname {{ node.name }}
+
+{% if version == 'caasp4' %}
+{% include "caasp/provision.sh.j2" %}
+{% else %}
 
 {% if not suma %}
 zypper -n install salt-minion
@@ -130,3 +134,4 @@ set -ex
 
 {% endif %} {# node == admin or node == suma #}
 
+{% endif %} {# version != caasp4 #}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -20,8 +20,12 @@ zypper ar {{ _repo }} {{ version }}-repo{{ loop.index }}
 zypper mr -p 98 {{ version }}-repo{{ loop.index }}
 {% endfor %}
 
-{% if version == 'ses7' or version == 'caasp4' %}
+{% if version == 'ses7' %}
 zypper ar -f http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo
+{% endif %}
+
+{% if version == 'ses7' or version == 'ses6' or version == 'caasp4' %}
+zypper ar -f http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo
 {% endif %}
 
 zypper --gpg-auto-import-keys ref

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ packages =
 seslib =
     templates/*.j2
     templates/deepsea/*.j2
+    templates/caasp/*.j2
     templates/ceph-bootstrap/*.j2
     templates/suma/*.j2
     templates/engine/libvirt/*.j2


### PR DESCRIPTION
Ricardo and I added the possibility to do a CaaSP deployment with sesdev. 
You can now either just spawn a completely configured CaaSP environment for development purposes or you could also directly add rook+ceph on top of it.

Example:

`sesdev create caasp4 caasp4` (gives you just a CaaSP cluster)

`sesdev create caasp4 caasp4 --deploy-ses` (gives you a CaaSP cluster with already rook+Ceph on top)`

If you want to have multiple workers or master you could work with the `--roles` option as follows:

`--roles="[master],[worker],[worker],[loadbalancer],[storage]"`

Signed-off-by: Kai Wagner <kwagner@suse.com>