### PR TITLE
deepsea_deployment.sh: try test.ping in a loop

### DIFF
--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -23,8 +23,27 @@ EOF
 
 chown -R salt:salt /srv
 
-sleep 10
-salt '*' test.ping > /dev/null 2>&1
+# make sure all minions are responding
+set +ex
+LOOP_COUNT="0"
+while true ; do
+  set -x
+  sleep 5
+  set +x
+  if [ "$LOOP_COUNT" -ge "20" ] ; then
+    echo "ERROR: minion(s) not responding to ping?"
+    exit 1
+  fi
+  LOOP_COUNT="$((LOOP_COUNT + 1))"
+  set -x
+  MINIONS_RESPONDING="$(salt '*' test.ping | grep True | wc --lines)"
+  if [ "$MINIONS_RESPONDING" = "{{ nodes|length }}" ]; then
+    break
+  fi
+  set +x
+done
+set -ex
+
 sleep 2
 salt '*' grains.set deepsea True
 sleep 5


### PR DESCRIPTION
I tried to deploy nautilus and ran into the same bug we've seen
elsewhere: sometimes, test.ping does not succeed on the first try
and it has to be repeated.

Signed-off-by: Nathan Cutler <ncutler@suse.com>