### PR TITLE
added another salt-minion restart after salt-master installation

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -73,6 +73,7 @@ sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
 systemctl enable salt-master
 systemctl start salt-master
 sleep 5
+systemctl restart salt-minion
 {% endif %}
 
 while : ; do


### PR DESCRIPTION
This fixes the issues that after the salt-master is setup and installed the minion on the master doesn't work and test.ping fails. If we do another salt-minion restart after the master is configured it works now.

Signed-off-by: Kai Wagner <kwagner@suse.com>