### PR TITLE
provision: remove which RPM from test environment

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -4,6 +4,10 @@
 head -1 /etc/hosts | grep -q '127.*' && sed -i '1d' /etc/hosts
 
 {% for _node in nodes %}
+
+# remove "which" RPM because testing environments typically don't have it installed
+zypper -n rm which || true
+
 {% if _node.public_address %}
 echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/hosts
 {% endif %}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -1,5 +1,8 @@
 {% include "engine/" + vm_engine + "/vagrant.provision.sh.j2" ignore missing %}
 
+# show the user what we are doing
+set -x
+
 # remove the first line introduced by vagrant
 head -1 /etc/hosts | grep -q '127.*' && sed -i '1d' /etc/hosts
 


### PR DESCRIPTION
If we include "which", it's easy for developers to assume that it's
always available everywhere, which is not true.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

Tested does not break:

- [x] `sesdev create ses7 --single-node`
- [x] `sesdev create ses6 --single-node`
- [x] `sesdev create ses5 --single-node`