### PR TITLE
ceph_salt_deployment: disable system update and reboot

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -59,6 +59,8 @@ ceph-salt config /Cluster/Roles/Mgr add {{ node.fqdn }}
 {% endif %}
 {% endfor %}
 
+ceph-salt config /System_Update/Packages disable
+ceph-salt config /System_Update/Reboot disable
 ceph-salt config /SSH/ generate
 {% if ceph_container_image %}
 ceph-salt config /Containers/Images/ceph set {{ ceph_container_image }}


### PR DESCRIPTION
Since https://github.com/ceph/ceph-salt/pull/76 was merged, sesdev
can no longer deploy ceph on an even slightly out-of-date Vagrant
box. Instead, it displays a message:

```
Salt master must be rebooted manually
```
and refuses to continue.

Since sesdev already has the `sesdev box remove` feature for updating
out-of-date Vagrant Boxes, and because the ceph-salt update
functionality effectively prevents automated deployment of Ceph by
sesdev, disable ceph-salt's automated system update/reboot feature.

Signed-off-by: Nathan Cutler <ncutler@suse.com>