### PR TITLE
Implement "sesdev qa-test" command

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -754,6 +754,16 @@ def scp(recursive, deployment_id, source, destination):
 
 @cli.command()
 @click.argument('deployment_id')
+def qa_test(deployment_id):
+    """
+    Runs QA test on an already-deployed cluster.
+    """
+    dep = seslib.Deployment.load(deployment_id)
+    dep.qa_test(_print_log)
+
+
+@cli.command()
+@click.argument('deployment_id')
 @click.argument('node', required=False)
 def stop(deployment_id, node=None):
     """

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -107,7 +107,7 @@ def common_create_options(func):
                      help='Custom zypper repo URL. The repo will be added to each node.'),
         click.option('--repo-priority/--no-repo-priority', default=True,
                      help="Automatically set priority on custom zypper repos"),
-        click.option('--qa-test/--no-qa-test', default=False,
+        click.option('--qa-test/--no-qa-test', 'qa_test_opt', default=False,
                      help="Automatically run integration tests on the deployed cluster"),
         click.option('--scc-user', type=str, default=None,
                      help='SCC organization username'),
@@ -380,7 +380,7 @@ def _gen_settings_dict(version,
                        ram,
                        disk_size,
                        repo_priority,
-                       qa_test,
+                       qa_test_opt,
                        vagrant_box,
                        scc_user,
                        scc_pass,
@@ -478,8 +478,8 @@ def _gen_settings_dict(version,
     if repo_priority is not None:
         settings_dict['repo_priority'] = repo_priority
 
-    if qa_test is not None:
-        settings_dict['qa_test'] = qa_test
+    if qa_test_opt is not None:
+        settings_dict['qa_test_opt'] = qa_test_opt
 
     if vagrant_box:
         settings_dict['vagrant_box'] = vagrant_box

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1204,6 +1204,9 @@ class Deployment():
     def scp(self, recursive, source, destination):
         tools.run_interactive(self._scp_cmd(recursive, source, destination))
 
+    def qa_test(self, log_handler):
+        tools.run_async(["vagrant", "provision", "--provision-with", "qa-test"], log_handler, self.dep_dir)
+
     def _find_service_node(self, service):
         if service == 'grafana' and self.settings.version == 'ses5':
             return 'admin'

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -321,7 +321,7 @@ SETTINGS = {
         'help': 'Automatically set priority on custom zypper repos',
         'default': True
     },
-    'qa_test': {
+    'qa_test_opt': {
         'type': bool,
         'help': 'Automatically run integration tests on the deployed cluster',
         'default': False
@@ -858,7 +858,7 @@ class Deployment():
             raise VersionOSNotSupported(self.settings.version, self.settings.os)
 
         try:
-            if self.settings.qa_test:
+            if self.settings.qa_test_opt:
                 version_repos += VERSION_QA_REPO_MAPPING[self.settings.version][self.settings.os]
         except KeyError:
             raise VersionQANotSupported(self.settings.version, self.settings.os)
@@ -893,7 +893,7 @@ class Deployment():
             'version_repos': version_repos,
             'os_base_repos': os_base_repos,
             'repo_priority': self.settings.repo_priority,
-            'qa_test': self.settings.qa_test,
+            'qa_test': self.settings.qa_test_opt,
             'ganesha_nodes': self.node_counts["ganesha"],
             'igw_nodes': self.node_counts["igw"],
             'mds_nodes': self.node_counts["mds"],
@@ -1105,7 +1105,7 @@ class Deployment():
                                                                        disk.size)
                     dev_letter += 1
             result += "     - repo_priority:    {}\n".format(self.settings.repo_priority)
-            result += "     - qa_test:          {}\n".format(self.settings.qa_test)
+            result += "     - qa_test:          {}\n".format(self.settings.qa_test_opt)
             if self.settings.version in ['octopus', 'ses7'] \
                     and self.settings.deployment_tool == 'orchestrator':
                 result += "     - container_images:\n"
@@ -1205,7 +1205,11 @@ class Deployment():
         tools.run_interactive(self._scp_cmd(recursive, source, destination))
 
     def qa_test(self, log_handler):
-        tools.run_async(["vagrant", "provision", "--provision-with", "qa-test"], log_handler, self.dep_dir)
+        tools.run_async(
+            ["vagrant", "provision", "--provision-with", "qa-test"],
+            log_handler,
+            self.dep_dir
+            )
 
     def _find_service_node(self, service):
         if service == 'grafana' and self.settings.version == 'ses5':

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -20,9 +20,7 @@ Vagrant.configure("2") do |config|
 
 {% if node == admin %}
     node.vm.provision "file", source: "bin/", destination: "/home/vagrant/"
-{% if qa_test is defined and qa_test is sameas true %}
     node.vm.provision "file", source: "{{ sesdev_path_to_qa }}", destination: "/home/vagrant/sesdev-qa"
-{% endif %}
 {% endif %}
 
     node.vm.synced_folder ".", "/vagrant", disabled: true
@@ -31,4 +29,8 @@ Vagrant.configure("2") do |config|
   end
 
 {% endfor %}
+
+  config.vm.provision "qa-test", type: "shell", run: "never" do |s|
+    s.inline = "/home/vagrant/qa-test.sh"
+  end
 end

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -107,7 +107,29 @@ stdbuf -o0 ceph-salt -ldebug deploy --non-interactive
 salt -G 'ceph-salt:member' state.apply ceph-salt
 {% endif %}
 
-{% if qa_test is defined and qa_test is sameas true %}
-/home/vagrant/sesdev-qa/health-ok.sh --total-nodes={{ nodes|length }} --nfs-ganesha-nodes={{ ganesha_nodes }} --igw-nodes={{ igw_nodes }} --mds-nodes={{ mds_nodes }} --mgr-nodes={{ mgr_nodes }} --mon-nodes={{ mon_nodes }} --osd-nodes={{ storage_nodes }} --osds={{ total_osds }} --rgw-nodes={{ rgw_nodes }}
+{% set qa_test_script = "/home/vagrant/qa-test.sh" %}
+{%- set qa_test_cmd = "/home/vagrant/sesdev-qa/health-ok.sh"
+    ~ " --total-nodes=" ~ nodes|length
+    ~ " --nfs-ganesha-nodes=" ~ ganesha_nodes
+    ~ " --igw-nodes=" ~ igw_nodes
+    ~ " --mds-nodes=" ~ mds_nodes
+    ~ " --mgr-nodes=" ~ mgr_nodes
+    ~ " --mon-nodes=" ~ mon_nodes
+    ~ " --osd-nodes=" ~ storage_nodes
+    ~ " --osds=" ~ total_osds
+    ~ " --rgw-nodes=" ~ rgw_nodes
+-%}
+
+cat > {{ qa_test_script }} << EOF
+#!/bin/bash
+set -x
+if [[ $(hostname) == admin* ]] ; then
+    {{ qa_test_cmd }}
+fi
+EOF
+chmod 755 {{ qa_test_script }}
+
+{% if qa_test is sameas true %}
+{{ qa_test_cmd }}
 {% endif %}
 


### PR DESCRIPTION
Even if the user does not give --qa-test on the "sesdev create" command
line, set up a script on each VM which can be triggered after initial
deployment.

And go even a step further and provide a "sesdev qa-test" command
for triggering the script.

Fixes: https://github.com/SUSE/sesdev/issues/128
Signed-off-by: Nathan Cutler <ncutler@suse.com>