### PR TITLE
seslib: correct downstream container for "sesdev create {ses7,octopus}"

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -650,7 +650,7 @@ class Deployment():
                     'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph'
             else:
                 self.settings.ceph_container_image = \
-                    'docker.io/ceph/daemon-base:latest-master-devel'
+                    'registry.opensuse.org/filesystems/ceph/master/upstream/images/ceph/ceph'
 
         if not self.settings.libvirt_networks:
             self._generate_static_networks()

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -647,7 +647,7 @@ class Deployment():
         if self.settings.ceph_container_image is None:
             if self.settings.version == 'ses7':
                 self.settings.ceph_container_image = \
-                    'registry.suse.de/devel/storage/7.0/cr/images/ses/7/ceph/ceph'
+                    'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph'
             else:
                 self.settings.ceph_container_image = \
                     'docker.io/ceph/daemon-base:latest-master-devel'

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -33,7 +33,7 @@ zypper mr -p 98 {{ version }}-repo{{ loop.index }}
 zypper ar -f http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo
 {% endif %}
 
-{% if version == 'ses7' or version == 'ses6' or version == 'caasp4' %}
+{% if version == 'ses6' or version == 'caasp4' %}
 zypper ar -f http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo
 {% endif %}
 


### PR DESCRIPTION
We have a rule of thumb that, in the deployment, the following commands
should show the same version of ceph:

    ceph --version    # host ceph version
    ceph versions     # container ceph version

But currently that is not the case for "sesdev create {ses7,octopus}", unless
the default container path is overrided. This patch should fix it.
