### PR TITLE
spec: disable RH/Fedora Python dependendency generator

### DIFF
--- a/sesdev.spec
+++ b/sesdev.spec
@@ -16,10 +16,6 @@
 #
 
 
-%if 0%{?el8} || (0%{?fedora} && 0%{?fedora} < 30)
-%{python_enable_dependency_generator}
-%endif
-
 Name:           sesdev
 Version:        1.1.6
 Release:        1%{?dist}
@@ -42,7 +38,7 @@ Requires:       python3-Jinja2 >= 2.10.1
 Requires:       python3-libvirt-python >= 5.1.0
 Requires:       python3-PyYAML >= 3.13
 %endif
-%if 0%{?fedora}
+%if 0%{?el8} || 0%{?fedora}
 Requires:       python3-jinja2 >= 2.10.1
 Requires:       python3-libvirt >= 5.1.0
 Requires:       python3-pyyaml >= 3.13
@@ -52,6 +48,10 @@ Requires:       python3-pycryptodomex >= 3.4.6
 Requires:       python3-setuptools
 Requires:       vagrant
 Requires:       vagrant-libvirt
+
+%if 0%{?el8} || 0%{?fedora}
+%{?python_disable_dependency_generator}
+%endif
 
 %description
 sesdev is a CLI tool for developers to help with deploying SES clusters.


### PR DESCRIPTION
According to
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_automatically_generated_dependencies

"Packages MAY use the automatic Python dependency generator."

"This generator is enabled by default in Fedora. If a packager wishes to
explicitly opt out of the generator . . ., a packager SHOULD opt out
explicitly by adding:

%{?python_disable_dependency_generator}

Although this statement can be used anywhere in the spec, we recommend
putting it just before the main package’s %description declaration."

As maintainer of the upstream spec file, I want to opt out, because
I prefer to explicitly declare (and track) the dependencies in the spec
file.

The dependencies defined in `setup.cfg` are used when sesdev is installed using `pip`.

The dependencies defined in `sesdev.spec` are used when sesdev is installed using `rpm`.

Fedora offers an automated dependency generator. openSUSE does not. It's confusing to list Python dependencies only for one, but not the other.

Obviously, the dependencies in the spec file must be kept in sync with those in `setup.cfg`, otherwise it will break. Activating an automated dependency generator which is available only on Fedora does not relieve me of this responsibility, since I still have to do it for openSUSE.

Being explicit about the dependencies adds information value to the spec file, too, because at once glance I can tell you which RPM package meets the dependency on Fedora, whereas `setup.cfg` does not tell me this information.

Signed-off-by: Nathan Cutler <ncutler@suse.com>