### PR TITLE
qa: fix path to qa scripts for RPM case

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -33,7 +33,7 @@ class GlobalSettings():
     @classmethod
     def init_path_to_qa(cls, full_path_to_sesdev_executable):
         if full_path_to_sesdev_executable.startswith('/usr'):
-            cls.PATH_TO_QA = '/usr/share/sesdev-qa'
+            cls.PATH_TO_QA = '/usr/share/sesdev/qa'
         else:
             cls.PATH_TO_QA = os.path.join(
                 os.path.dirname(full_path_to_sesdev_executable),


### PR DESCRIPTION
When running sesdev (and sesdev-qa) installed from RPM, I hit a bug
- sesdev is trying to find the qa scripts at the wrong path!

Signed-off-by: Nathan Cutler <ncutler@suse.com>