### PR TITLE
ceph_salt_deployment: honor --no-deploy-osds option

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -77,7 +77,7 @@ ceph-salt config /Deployment/Mon enable
 ceph-salt config /Deployment/Mgr enable
 {% endif %}
 
-{% if ceph_salt_deploy_mons %}
+{% if ceph_salt_deploy_osds %}
 ceph-salt config /Deployment/OSD enable
 
 # OSDs drive groups spec for each node


### PR DESCRIPTION
This fixes a bug that has been present since the very beginning.

Fixes: c6cdd7339952671c6c2fbf7184711da8a488a01c
Fixes: https://github.com/SUSE/sesdev/issues/142
Signed-off-by: Nathan Cutler <ncutler@suse.com>