### PR TITLE
Revert: "seslib: add SES7 Internal Media when --qa-test given"

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -173,9 +173,6 @@ VERSION_OS_REPO_MAPPING = {
 }
 
 VERSION_QA_REPO_MAPPING = {
-    'octopus': {
-        'leap-15.2': [],
-    },
     'ses7': {
         'sles-15-sp2': [
             'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/SES7/images/repo/'

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -12,12 +12,11 @@ from jinja2 import Environment, PackageLoader
 import libvirt
 
 from . import tools
-from .exceptions import DeploymentDoesNotExists, VersionOSNotSupported, VersionQANotSupported, \
-                        SettingTypeError, VagrantBoxDoesNotExist, NodeDoesNotExist, \
-                        NoSourcePortForPortForwarding, ServicePortForwardingNotSupported, \
-                        DeploymentAlreadyExists, ServiceNotFound, ExclusiveRoles, \
-                        RoleNotSupported, CmdException, VagrantSshConfigNoHostName, \
-                        ScpInvalidSourceOrDestination
+from .exceptions import DeploymentDoesNotExists, VersionOSNotSupported, SettingTypeError, \
+                        VagrantBoxDoesNotExist, NodeDoesNotExist, NoSourcePortForPortForwarding, \
+                        ServicePortForwardingNotSupported, DeploymentAlreadyExists, \
+                        ServiceNotFound, ExclusiveRoles, RoleNotSupported, CmdException, \
+                        VagrantSshConfigNoHostName, ScpInvalidSourceOrDestination
 
 
 JINJA_ENV = Environment(loader=PackageLoader('seslib', 'templates'), trim_blocks=True)
@@ -172,16 +171,6 @@ VERSION_OS_REPO_MAPPING = {
     }
 }
 
-VERSION_QA_REPO_MAPPING = {
-    'ses7': {
-        'sles-15-sp2': [
-            'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/SES7/images/repo/'
-            'SUSE-Enterprise-Storage-7-POOL-Internal-x86_64-Media/',
-            'http://download.suse.de/ibs/Devel:/Storage:/7.0/images/repo/'
-            'SUSE-Enterprise-Storage-7-POOL-Internal-x86_64-Media/'
-        ],
-    }
-}
 
 SETTINGS = {
     'version': {
@@ -853,12 +842,6 @@ class Deployment():
             version_repos = VERSION_OS_REPO_MAPPING[self.settings.version][self.settings.os]
         except KeyError:
             raise VersionOSNotSupported(self.settings.version, self.settings.os)
-
-        try:
-            if self.settings.qa_test_opt:
-                version_repos += VERSION_QA_REPO_MAPPING[self.settings.version][self.settings.os]
-        except KeyError:
-            raise VersionQANotSupported(self.settings.version, self.settings.os)
 
         if self.settings.os in OS_REPOS:
             os_base_repos = list(OS_REPOS[self.settings.os].items())

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -28,15 +28,7 @@ class DeploymentDoesNotExists(SesDevException):
 class VersionOSNotSupported(SesDevException):
     def __init__(self, version, os):
         super(VersionOSNotSupported, self).__init__(
-            "Combination of version '{}' and OS '{}' not supported"
-            .format(version, os))
-
-
-class VersionQANotSupported(SesDevException):
-    def __init__(self, version, os):
-        super(VersionQANotSupported, self).__init__(
-            "Combination of version '{}' and OS '{}' not supported with --qa-test"
-            .format(version, os))
+            "Combination of version '{}' and OS '{}' not supported".format(version, os))
 
 
 class SettingIncompatibleError(SesDevException):


### PR DESCRIPTION
We no longer try to install the sesdev-qa package on the VMs. Instead, it gets installed on the host where sesdev is run, and the QA script files get copied to the VMs during the provisioning phase.