### PR TITLE
Change "admin" role semantics and make roles configurable

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -615,8 +615,8 @@ def ses6(deployment_id, deploy, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
-@click.option("--use-deepsea/--use-orchestrator", default=False,
-              help="Use deepsea to deploy SES7 instead of SSH orchestrator")
+@click.option("--use-deepsea/--use-cephadm", default=False,
+              help="Use deepsea to deploy SES7 instead of cephadm")
 def ses7(deployment_id, deploy, use_deepsea, **kwargs):
     """
     Creates a SES7 cluster using SLES-15-SP2
@@ -647,8 +647,8 @@ def nautilus(deployment_id, deploy, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
-@click.option("--use-deepsea/--use-orchestrator", default=False,
-              help="Use deepsea to deploy Ceph Octopus instead of SSH orchestrator")
+@click.option("--use-deepsea/--use-cephadm", default=False,
+              help="Use deepsea to deploy Ceph Octopus instead of cephadm")
 def octopus(deployment_id, deploy, use_deepsea, **kwargs):
     """
     Creates a Ceph Octopus cluster using openSUSE Leap 15.2 and packages

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -487,7 +487,7 @@ def _gen_settings_dict(version,
         settings_dict['repo_priority'] = repo_priority
 
     if qa_test_opt is not None:
-        settings_dict['qa_test_opt'] = qa_test_opt
+        settings_dict['qa_test'] = qa_test_opt
 
     if vagrant_box:
         settings_dict['vagrant_box'] = vagrant_box

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -169,10 +169,13 @@ def _abort_if_false(ctx, _, value):
 @click.option('-c', '--config-file', required=False,
               type=click.Path(exists=True, dir_okay=False, file_okay=True),
               help='Configuration file location')
-@click.option('--debug/--no-debug', default=False)
+@click.option('--debug/--no-debug', default=False,
+              help='Whether to emit DEBUG-level log messages')
 @click.option('--log-file', type=str, default=None)
+@click.option('--vagrant-debug/--no-vagrant-debug', default=False,
+              help='Whether to run vagrant with --debug option')
 @click.version_option(pkg_resources.get_distribution('sesdev'), message="%(version)s")
-def cli(work_path=None, config_file=None, debug=False, log_file=None):
+def cli(work_path=None, config_file=None, debug=False, log_file=None, vagrant_debug=False):
     """
     Welcome to the sesdev tool.
 
@@ -194,6 +197,10 @@ $ sesdev create octopus --roles="[admin, mon, mgr], \\
     if debug:
         logger.info("Debug mode: ON")
         seslib.GlobalSettings.DEBUG = debug
+
+    if vagrant_debug:
+        logger.info("vagrant will be run with --debug option")
+        seslib.GlobalSettings.VAGRANT_DEBUG = vagrant_debug
 
     if log_file:
         logging.basicConfig(format='%(asctime)s [%(levelname)s] [%(name)s] %(message)s',

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -30,6 +30,7 @@ class GlobalSettings():
     WORKING_DIR = os.path.join(Path.home(), '.sesdev')
     CONFIG_FILE = os.path.join(WORKING_DIR, 'config.yaml')
     DEBUG = False
+    VAGRANT_DEBUG = False
 
     @classmethod
     def init_path_to_qa(cls, full_path_to_sesdev_executable):
@@ -1070,7 +1071,7 @@ class Deployment():
         cmd = ["vagrant", "up"]
         if node is not None:
             cmd.append(node)
-        if GlobalSettings.DEBUG:
+        if GlobalSettings.VAGRANT_DEBUG:
             cmd.append('--debug')
         tools.run_async(cmd, log_handler, self.dep_dir)
 
@@ -1089,7 +1090,7 @@ class Deployment():
             if node.status == 'not deployed':
                 continue
             cmd = ["vagrant", "destroy", node.name, "--force"]
-            if GlobalSettings.DEBUG:
+            if GlobalSettings.VAGRANT_DEBUG:
                 cmd.append('--debug')
             tools.run_async(cmd, log_handler, self.dep_dir)
 

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -118,9 +118,9 @@ VERSION_PREFERRED_OS = {
 VERSION_PREFERRED_DEPLOYMENT_TOOL = {
     'ses5': 'deepsea',
     'ses6': 'deepsea',
-    'ses7': 'orchestrator',
+    'ses7': 'cephadm',
     'nautilus': 'deepsea',
-    'octopus': 'orchestrator'
+    'octopus': 'cephadm'
 }
 
 VERSION_OS_REPO_MAPPING = {
@@ -715,7 +715,7 @@ class Deployment():
             self.settings.deployment_tool = VERSION_PREFERRED_DEPLOYMENT_TOOL[self.settings.version]
 
         if self.settings.image_path is None:
-            if self.settings.deployment_tool == 'orchestrator':
+            if self.settings.deployment_tool == 'cephadm':
                 self.settings.image_path = self.settings.image_paths[self.settings.version]
 
         if not self.settings.libvirt_networks:
@@ -1192,7 +1192,7 @@ class Deployment():
             result += "     - repo_priority:    {}\n".format(self.settings.repo_priority)
             result += "     - qa_test:          {}\n".format(self.settings.qa_test_opt)
             if self.settings.version in ['octopus', 'ses7'] \
-                    and self.settings.deployment_tool == 'orchestrator':
+                    and self.settings.deployment_tool == 'cephadm':
                 result += "     - image_path:       {}\n".format(self.settings.image_path)
             if v.repos:
                 result += "     - custom_repos:\n"

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -650,6 +650,10 @@ class Settings():
                 config_tree = yaml.load(file, Loader=yaml.FullLoader)
             except AttributeError:  # older versions of pyyaml does not have FullLoader
                 config_tree = yaml.load(file)
+        if not config_tree:
+            config_tree = {}
+        log_msg = "_load_config_file: config_tree: {}".format(config_tree)
+        logger.debug(log_msg)
         assert isinstance(config_tree, dict), "yaml.load() of config file misbehaved!"
         __fill_in_config_tree('os_repos', OS_REPOS)
         __fill_in_config_tree('version_os_repo_mapping', VERSION_OS_REPO_MAPPING)

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -90,6 +90,12 @@ class RoleNotSupported(SesDevException):
             "Role '{}' is not supported in version '{}'".format(role, version))
 
 
+class TooManyMasters(SesDevException):
+    def __init__(self, number):
+        super(TooManyMasters, self).__init__(
+            "There can only be one 'master' role (you gave {})'".format(number))
+
+
 class VagrantSshConfigNoHostName(SesDevException):
     def __init__(self, name):
         super(VagrantSshConfigNoHostName, self).__init__(
@@ -101,3 +107,9 @@ class ScpInvalidSourceOrDestination(SesDevException):
     def __init__(self):
         super(ScpInvalidSourceOrDestination, self).__init__(
             "Either source or destination must contain a ':' - not both or neither")
+
+
+class SettingNotKnown(SesDevException):
+    def __init__(self, setting):
+        super(SettingNotKnown, self).__init__(
+            "Setting '{}' is not known - please open a bug report!".format(setting))

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
     node.vm.provision "file", source: "keys/id_rsa.pub",
                               destination:".ssh/id_rsa.pub"
 
-{% if node == admin %}
+{% if node == master %}
     node.vm.provision "file", source: "bin/", destination: "/home/vagrant/"
     node.vm.provision "file", source: "{{ sesdev_path_to_qa }}", destination: "/home/vagrant/sesdev-qa"
 {% endif %}

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -51,9 +51,7 @@ exit 0
 
 {% for node in nodes %}
 ceph-salt config /Cluster/Minions add {{ node.fqdn }}
-{% if node.has_role('admin') %}
 ceph-salt config /Cluster/Roles/Admin add {{ node.fqdn }}
-{% endif %}
 {% if node.has_role('mon') %}
 ceph-salt config /Cluster/Roles/Mon add {{ node.fqdn }}
 {% endif %}
@@ -68,7 +66,7 @@ ceph-salt config /SSH/ generate
 {% if image_path %}
 ceph-salt config /Containers/Images/ceph set {{ image_path }}
 {% endif %}
-ceph-salt config /Time_Server/Server_Hostname set {{ admin.fqdn }}
+ceph-salt config /Time_Server/Server_Hostname set {{ master.fqdn }}
 ceph-salt config /Time_Server/External_Servers add 0.pt.pool.ntp.org
 {% if not ceph_salt_cephadm_bootstrap %}
 ceph-salt config /Deployment/Bootstrap disable
@@ -128,7 +126,7 @@ salt -G 'ceph-salt:member' state.apply ceph-salt
 cat > {{ qa_test_script }} << EOF
 #!/bin/bash
 set -x
-if [[ $(hostname) == admin* ]] ; then
+if [[ $(hostname) == master* ]] ; then
     {{ qa_test_cmd }}
 fi
 EOF

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -117,7 +117,7 @@ ceph osd crush rule rm replicated_rule
 ceph osd crush rule create-replicated replicated_rule default osd
 {% endif %}
 
-{% if num_osds < 6 %}
+{% if total_osds < 6 %}
 {% if version != 'ses5' %}
 # we need to increase the number of max pg per osd for deepsea to work
 # correctly with this number of OSDs

--- a/seslib/templates/deepsea/nautilus_policy.cfg.j2
+++ b/seslib/templates/deepsea/nautilus_policy.cfg.j2
@@ -1,6 +1,7 @@
 cluster-ceph/cluster/*.sls
 config/stack/default/global.yml
 config/stack/default/ceph/cluster.yml
+role-admin/cluster/*.sls
 
 {% for node in nodes: %}
 {% if node.has_role('storage') %}
@@ -11,8 +12,7 @@ role-storage/cluster/{{ node.name }}*.sls
 role-mon/cluster/{{ node.name }}*.sls
 {% endif %}
 
-{% if node.has_role('admin') %}
-role-admin/cluster/{{ node.name }}*.sls
+{% if node.has_role('master') %}
 role-master/cluster/{{ node.name }}*.sls
 {% endif %}
 

--- a/seslib/templates/deepsea/nautilus_pre_stage_0.sh.j2
+++ b/seslib/templates/deepsea/nautilus_pre_stage_0.sh.j2
@@ -19,7 +19,7 @@ cat > /root/mds-get-name.patch <<EOF
      with "mds.".
      """
 -    if host[0].isdigit():
-+    if host[0].isdigit() or host == 'admin':
++    if host[0].isdigit() or host == 'master':
          return 'mds.{}'.format(host)
      return host
 EOF

--- a/seslib/templates/deepsea/ses5_policy.cfg.j2
+++ b/seslib/templates/deepsea/ses5_policy.cfg.j2
@@ -1,6 +1,7 @@
 cluster-ceph/cluster/*.sls
 config/stack/default/global.yml
 config/stack/default/ceph/cluster.yml
+role-admin/cluster/*.sls
 
 profile-default/cluster/*.sls
 profile-default/stack/default/ceph/minions/*yml
@@ -12,8 +13,7 @@ role-mon/cluster/{{ node.name }}*.sls
 role-mon/stack/default/ceph/minions/{{ node.name }}*.sls
 {% endif %}
 
-{% if node.has_role('admin') %}
-role-admin/cluster/{{ node.name }}*.sls
+{% if node.has_role('master') %}
 role-master/cluster/{{ node.name }}*.sls
 {% endif %}
 

--- a/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
+++ b/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
@@ -68,7 +68,7 @@ cat > /root/mds-get-name.patch <<EOF
      with "mds.".
      """
 -    if host[0].isdigit():
-+    if host[0].isdigit() or host == 'admin':
++    if host[0].isdigit() or host == 'master':
          return 'mds.{}'.format(host)
      return host
 EOF
@@ -96,7 +96,7 @@ patch -p0 < /root/mds-get-name.patch
 patch -p0 < /root/ntp.patch
 popd
 
-{% if num_osds < 6 %}
+{% if total_osds < 6 %}
 # we need to increase the number of max pg per osd for deepsea to work
 # correctly with this number of OSDs
 echo "mon_max_pg_per_osd = 500" >> /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -167,7 +167,7 @@ set -ex
 {% include "suma/suma_deployment.sh.j2" %}
 {% endif %}
 
-{% if node == admin and deployment_tool == "orchestrator" %}
+{% if node == admin and deployment_tool == "cephadm" %}
 {% include "ceph-salt/ceph_salt_deployment.sh.j2" %}
 {% endif %}
 

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -93,7 +93,7 @@ hostnamectl set-hostname {{ node.name }}
 
 {% if not suma %}
 zypper -n install salt-minion
-sed -i 's/^#master:.*/master: {{ admin.name }}/g' /etc/salt/minion
+sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
 
 # change salt log level to info
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/minion
@@ -108,8 +108,8 @@ zypper -n rm ntp
 
 touch /tmp/ready
 
-{% if node == admin or node == suma %}
-{% if node == admin %}
+{% if node == master or node == suma %}
+{% if node == master %}
 zypper -n install salt-master
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
 systemctl enable salt-master
@@ -128,7 +128,7 @@ while : ; do
 {% endfor %}
 done
 
-{% if node == admin %}
+{% if node == master %}
 while true; do
   sleep 1
   salt-key -L
@@ -167,10 +167,10 @@ set -ex
 {% include "suma/suma_deployment.sh.j2" %}
 {% endif %}
 
-{% if node == admin and deployment_tool == "cephadm" %}
+{% if node == master and deployment_tool == "cephadm" %}
 {% include "ceph-salt/ceph_salt_deployment.sh.j2" %}
 {% endif %}
 
-{% endif %} {# node == admin or node == suma #}
+{% endif %} {# node == master or node == suma #}
 
 {% endif %} {# version != caasp4 #}


### PR DESCRIPTION
Fixes: https://github.com/SUSE/sesdev/issues/160

---

To Do:

- [x] test does not break `sesdev list`
- [x] test does not break `sesdev destroy`
- [x] test does not break `sesdev create octopus`
- [x] test with `version_default_roles` stanza in `config.yaml`
- [x] test does not break `sesdev ssh` on newly deployed cluster
- [x] test does not break `sesdev create nautilus`
- [x] test does not break `sesdev ssh DEP_ID admin` on legacy cluster
- [x] test does not break `sesdev create caasp4`