### PR TITLE
Vagrantfile,sesdev.spec: require vagrant > 2.2.2

### DIFF
--- a/sesdev.spec
+++ b/sesdev.spec
@@ -46,7 +46,7 @@ Requires:       python3-pyyaml >= 3.13
 Requires:       python3-click >= 6.7
 Requires:       python3-pycryptodomex >= 3.4.6
 Requires:       python3-setuptools
-Requires:       vagrant
+Requires:       vagrant > 2.2.2
 Requires:       vagrant-libvirt
 Requires:       sesdev-qa
 

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version "> 2.2.2"
+
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
   config.vm.box = "{{ vagrant_box }}"


### PR DESCRIPTION
sesdev is known to require a recent vagrant version, but it's not
entirely clear how recent.

From https://github.com/SUSE/sesdev/issues/155 we know that 2.2.0 will
not work.

Virtualization:vagrant/vagrant was updated to 2.2.2 on January 4, 2019.
This is probably also too old, so enforce vagrant > 2.2.2

Signed-off-by: Nathan Cutler <ncutler@suse.com>
