### PR TITLE
Jenkinsfile.integration: Add timeout for "sesdev create"

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -114,7 +114,9 @@ pipeline {
                 pip install --editable .
                 """
                 sh "source venv/bin/activate; sesdev --help"
-                sh "source venv/bin/activate; sesdev create octopus --non-interactive --ceph-salt-repo https://github.com/ceph/ceph-salt.git --ceph-salt-branch master --qa-test --single-node mini"
+                timeout(time: 90, unit: 'MINUTES') {
+                    sh "source venv/bin/activate; sesdev create octopus --non-interactive --ceph-salt-repo https://github.com/ceph/ceph-salt.git --ceph-salt-branch master --qa-test --single-node mini"
+                }
             }
         }
     }


### PR DESCRIPTION
Some builds seem to hang forever. Adding a timeout makes sure that we
don't pay for endless running servers.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>