### PR TITLE
Use "filesystems:ceph:octopus:upstream" for default cephadm/container build

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ sesdev create octopus \
     octopus
 ```
 
-##### octopus from filesystems:ceph:master:upstream
+##### octopus from filesystems:ceph:octopus:upstream
 
 No config.yaml changes are needed, because this is the default configuration.
 

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -106,7 +106,7 @@ OS_REPOS = {
 
 IMAGE_PATHS = {
     'ses7': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
-    'octopus': 'registry.opensuse.org/filesystems/ceph/master/upstream/images/ceph/ceph',
+    'octopus': 'registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph',
 }
 
 VERSION_PREFERRED_OS = {
@@ -179,11 +179,11 @@ VERSION_OS_REPO_MAPPING = {
             'openSUSE_Leap_15.1'
         ],
         'leap-15.2': [
-            'https://download.opensuse.org/repositories/filesystems:/ceph:/master:/upstream/'
+            'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/'
             'openSUSE_Leap_15.2'
         ],
         'tumbleweed': [
-            'https://download.opensuse.org/repositories/filesystems:/ceph:/master:/upstream/'
+            'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/'
             'openSUSE_Tumbleweed'
         ],
     },


### PR DESCRIPTION
The upstream "octopus" branch was recently split from "master", so there
is no longer any reason to track the latter branch.

Signed-off-by: Nathan Cutler <ncutler@suse.com>