### PR TITLE
provision.sh: do not fail ses5 deployment if ntp not installed

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -108,7 +108,7 @@ systemctl start salt-minion
 {% endif %}
 
 {% if version == 'ses5' %}
-zypper -n rm ntp
+zypper -n rm ntp || true
 {% endif %}
 
 touch /tmp/ready


### PR DESCRIPTION
Fixes: https://github.com/SUSE/sesdev/issues/172
Signed-off-by: Nathan Cutler <ncutler@suse.com>