### PR TITLE
Set "osd crush chooseleaf type = 0" via bootstrap ceph.conf in very small clusters

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -88,6 +88,10 @@ ceph-salt config /Storage/Drive_Groups add value="{\"service_type\": \"osd\", \"
 
 {% endif %}
 {% endfor %}
+{% if storage_nodes < 3 %}
+ceph-salt config /Deployment/Bootstrap_Ceph_Conf add global
+ceph-salt config /Deployment/Bootstrap_Ceph_Conf/global set osd crush chooseleaf type = 0
+{% endif %}
 {% endif %} {# if ceph_salt_deploy_osds #}
 
 ceph-salt config /Deployment/Dashboard/username set admin


### PR DESCRIPTION
Set "osd crush chooseleaf type = 0"

After https://github.com/ceph/ceph-salt/pull/129

Signed-off-by: Ricardo Marques <rimarques@suse.com>