### PR TITLE
ceph_salt_deployment.sh: Fetch github PRs when installing from src

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -7,6 +7,8 @@ cd /root
 git clone {{ ceph_salt_git_repo }}
 cd ceph-salt
 zypper -n in autoconf gcc python3-devel python3-pip python3-curses
+# fetch the available PRs from github. With that, "ceph_salt_git_branch" can be something like "origin/pr/127" to checkout a github PR
+git fetch origin "+refs/pull/*/head:refs/remotes/origin/pr/*"
 git checkout {{ ceph_salt_git_branch }}
 pip install .
 # install ceph-salt-formula


### PR DESCRIPTION
Fetch also the available github PRs when installing ceph-salt from
source. With that, it's possible to git "ceph_salt_git_branch" a value
like "origin/pr/127" which will then checkout the github pull request
127 and use that for installation.
That is useful for testing pull requests against ceph-salt together
with sesdev.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>