### PR TITLE
ceph-salt: guard fetching of all GitHub PRs with CLI option

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -67,6 +67,8 @@ def ceph_salt_options(func):
                      help='ceph-salt Git repo URL'),
         click.option('--ceph-salt-branch', type=str, default=None,
                      help='ceph-salt Git branch'),
+        click.option('--fetch-github-prs/--no-fetch-github-prs', default=False,
+                     help="Fetch all GitHub PRs when installing ceph-salt from source")
         click.option('--image-path', type=str, default=None,
                      help='registry path from which to download Ceph container image'),
         click.option('--cephadm-bootstrap/--no-cephadm-bootstrap', default=True,
@@ -409,6 +411,7 @@ def _gen_settings_dict(version,
                        deepsea_branch=None,
                        ceph_salt_repo=None,
                        ceph_salt_branch=None,
+                       fetch_github_prs=None,
                        stop_before_ceph_salt_config=False,
                        stop_before_ceph_salt_deploy=False,
                        image_path=None,
@@ -509,6 +512,9 @@ def _gen_settings_dict(version,
 
     if ceph_salt_branch:
         settings_dict['ceph_salt_git_branch'] = ceph_salt_branch
+
+    if fetch_github_prs:
+        settings_dict['ceph_salt_fetch_github_prs'] = fetch_github_prs
 
     if stop_before_ceph_salt_config:
         settings_dict['stop_before_ceph_salt_config'] = stop_before_ceph_salt_config

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -393,14 +393,19 @@ SETTINGS = {
         'help': 'ceph-salt git branch to use',
         'default': 'master'
     },
+    'ceph_salt_fetch_github_prs': {
+        'type': bool,
+        'help': 'Fetch all GitHub PRs when installing ceph-salt from source',
+        'default': False
+    },
     'stop_before_ceph_salt_config': {
         'type': bool,
-        'help': 'Stops deployment before ceph-salt config',
+        'help': 'Stop deployment just prior to "ceph-salt config"',
         'default': False
     },
     'stop_before_ceph_salt_deploy': {
         'type': bool,
-        'help': 'Stops deployment before ceph-salt deploy',
+        'help': 'Stop deployment just prior to "ceph-salt deploy"',
         'default': False
     },
     'image_path': {
@@ -1084,6 +1089,7 @@ class Deployment():
             'scc_password': self.settings.scc_password,
             'ceph_salt_git_repo': self.settings.ceph_salt_git_repo,
             'ceph_salt_git_branch': self.settings.ceph_salt_git_branch,
+            'ceph_salt_fetch_github_prs': self.settings.ceph_salt_fetch_github_prs,
             'stop_before_ceph_salt_config': self.settings.stop_before_ceph_salt_config,
             'stop_before_ceph_salt_deploy': self.settings.stop_before_ceph_salt_deploy,
             'image_path': self.settings.image_path,

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -7,8 +7,10 @@ cd /root
 git clone {{ ceph_salt_git_repo }}
 cd ceph-salt
 zypper -n in autoconf gcc python3-devel python3-pip python3-curses
+{% if ceph_salt_fetch_github_prs }}
 # fetch the available PRs from github. With that, "ceph_salt_git_branch" can be something like "origin/pr/127" to checkout a github PR
 git fetch origin "+refs/pull/*/head:refs/remotes/origin/pr/*"
+{% endif %}
 git checkout {{ ceph_salt_git_branch }}
 pip install .
 # install ceph-salt-formula


### PR DESCRIPTION
Fetching of all GitHub PRs is needed by the ceph-salt Jenkins CI, but not (or, at least, not in the typical case) by ordinary users, so guard it with a command-line option that defaults to False.
