### PR TITLE
bootstrap.sh: explicitly use python3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+function abort_missing_dep {
+    local executable="$1"
+    local provided_by="$2"
+    if type $executable > /dev/null 2>&1 ; then
+        true
+    else
+        >&2 echo "ERROR: $executable not available"
+        >&2 echo "Please install the $provided_by package for your OS, and try again."
+        exit 1
+    fi
+}
+
 if [ -d ./sesdev ] ; then
     true
 else
@@ -8,20 +20,15 @@ else
     exit 1
 fi
 
-if type virtualenv > /dev/null 2>&1 ; then
-    true
-else
-    >&2 echo "ERROR: virtualenv not available"
-    >&2 echo "Please install the python3-virtualenv package for your OS, and try again."
-    exit 1
-fi
+abort_missing_dep python3 python3-base
+abort_missing_dep virtualenv python3-virtualenv
 
 if [ -d ./venv ] ; then
     >&2 echo "Detected an existing virtual environment - blowing it away!"
     rm -rf ./venv
 fi
 
-virtualenv venv
+virtualenv --python=python3 venv
 source venv/bin/activate
 pip install --editable .
 


### PR DESCRIPTION
Under some circumstances that are not 100% clear to me -- for example
when virtualenv is coming from the python2-virtualenv RPM -- virtualenv
might default to Python 2 even though Python 3 is also installed in the
system.

Fixes: https://github.com/SUSE/sesdev/issues/194
Signed-off-by: Nathan Cutler <ncutler@suse.com>