### PR TITLE
provisioning: set fqdn through vagrant and leave /etc/hosts alone

### DIFF
--- a/seslib/templates/engine/libvirt/vagrant.node.j2
+++ b/seslib/templates/engine/libvirt/vagrant.node.j2
@@ -1,6 +1,6 @@
     {{ node.networks }}
 
-    node.vm.hostname = "{{ node.name }}"
+    node.vm.hostname = "{{ node.fqdn }}"
 
     node.vm.provider "libvirt" do |lv|
       lv.memory = {{ node.ram }}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -4,9 +4,6 @@ set -ex
 
 ls -lR /home/vagrant
 
-# remove the first line introduced by vagrant
-head -1 /etc/hosts | grep -q '127.*' && sed -i '1d' /etc/hosts
-
 {% for _node in nodes %}
 {% if _node.public_address %}
 echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/hosts


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes: https://github.com/SUSE/sesdev/issues/181

Not sure why we only set the name as the hostname when we have the fqdn. Alos can't hurt to set the minion id explicitly.