### PR TITLE
ceph_salt_deployment: deploy OSDs from YAML (ServiceSpec) file

### DIFF
--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -2,6 +2,15 @@ class SesDevException(Exception):
     pass
 
 
+class BadMakeCheckRolesNodes(SesDevException):
+    def __init__(self):
+        super(BadMakeCheckRolesNodes, self).__init__(
+            "\"makecheck\" deployments only work with a single node with role "
+            "\"makecheck\". Since this is the default, you can simply omit "
+            "the --roles option when running \"sesdev create makecheck\"."
+            )
+
+
 class CmdException(SesDevException):
     def __init__(self, command, retcode, stderr):
         super(CmdException, self).__init__(
@@ -11,6 +20,21 @@ class CmdException(SesDevException):
         self.command = command
         self.retcode = retcode
         self.stderr = stderr
+
+
+class DepIDIllegalChars(SesDevException):
+    def __init__(self, dep_id):
+        super(DepIDIllegalChars, self).__init__(
+            "Deployment ID \"{}\" contains illegal characters. Valid characters for "
+            "hostnames are ASCII(7) letters from a to z, the digits from 0 to 9, and "
+            "the hyphen (-).".format(dep_id))
+
+
+class DepIDWrongLength(SesDevException):
+    def __init__(self, length):
+        super(DepIDWrongLength, self).__init__(
+            "Deployment ID must be from 1 to 63 characters in length "
+            "(yours had {} characters)".format(length))
 
 
 class DeploymentAlreadyExists(SesDevException):
@@ -25,37 +49,29 @@ class DeploymentDoesNotExists(SesDevException):
             "Deployment '{}' does not exist".format(dep_id))
 
 
-class VersionNotKnown(SesDevException):
-    def __init__(self, version):
-        super(VersionNotKnown, self).__init__(
-            "Unknown deployment version: '{}'".format(version))
+class DuplicateRolesNotSupported(SesDevException):
+    def __init__(self, role):
+        super(DuplicateRolesNotSupported, self).__init__(
+            "A node with more than one \"{r}\" role was detected. "
+            "sesdev does not support more than one \"{r}\" role per node.".format(r=role)
+            )
 
 
-class VersionOSNotSupported(SesDevException):
-    def __init__(self, version, os):
-        super(VersionOSNotSupported, self).__init__(
-            "Combination of version '{}' and OS '{}' not supported".format(version, os))
+class ExclusiveRoles(SesDevException):
+    def __init__(self, role_a, role_b):
+        super(ExclusiveRoles, self).__init__(
+            "Cannot have both roles '{}' and '{}' in the same deployment"
+            .format(role_a, role_b))
 
 
-class SettingIncompatibleError(SesDevException):
-    def __init__(self, setting1, value1, setting2, value2):
-        super(SettingIncompatibleError, self).__init__(
-            "Setting {} = {} and {} = {} are incompatible"
-            .format(setting1, value1, setting2, value2))
-
-
-class SettingTypeError(SesDevException):
-    def __init__(self, setting, expected_type, value):
-        super(SettingTypeError, self).__init__(
-            "Wrong value type for setting '{}': expected type: '{}', actual value='{}' ('{}')"
-            .format(setting, expected_type, value, type(value)))
-
-
-class OptionValueError(SesDevException):
-    def __init__(self, option, message, value):
-        super(OptionValueError, self).__init__(
-            "Wrong value for option '{}'. {}. Actual value: '{}'"
-            .format(option, message, value))
+class ExplicitAdminRoleNotAllowed(SesDevException):
+    def __init__(self):
+        super(ExplicitAdminRoleNotAllowed, self).__init__(
+            "Though it is still recognized in existing deployments, the explicit "
+            "\"admin\" role is deprecated and new deployments are not allowed to "
+            "have it. When sesdev deploys Ceph/SES versions that use an \"admin\" "
+            "role, all nodes in the deployment will get that role implicitly. "
+            "(TL;DR remove the \"admin\" role and try again!)")
 
 
 class OptionFormatError(SesDevException):
@@ -65,11 +81,11 @@ class OptionFormatError(SesDevException):
             .format(option, expected_type, value))
 
 
-class VagrantBoxDoesNotExist(SesDevException):
-    def __init__(self, box):
-        super(VagrantBoxDoesNotExist, self).__init__(
-            "The vagrant box '{}' does not exist. Please add it with `vagrant box add ...` command"
-            .format(box))
+class OptionValueError(SesDevException):
+    def __init__(self, option, message, value):
+        super(OptionValueError, self).__init__(
+            "Wrong value for option '{}'. {}. Actual value: '{}'"
+            .format(option, message, value))
 
 
 class NodeDoesNotExist(SesDevException):
@@ -78,11 +94,30 @@ class NodeDoesNotExist(SesDevException):
             "Node '{}' does not exist in this deployment".format(node))
 
 
-class ServicePortForwardingNotSupported(SesDevException):
-    def __init__(self, service):
-        super(ServicePortForwardingNotSupported, self).__init__(
-            "Service '{}' not supported for port forwarding. Specify manually the service source "
-            "and destination ports".format(service))
+class NoPrometheusGrafanaInSES5(SesDevException):
+    def __init__(self):
+        super(NoPrometheusGrafanaInSES5, self).__init__(
+            "The DeepSea version used in SES5 does not recognize 'prometheus' "
+            "or 'grafana' as roles in policy.cfg (instead, it _always_ deploys "
+            "these two services on the Salt Master node. For this reason, sesdev "
+            "does not permit these roles to be used with ses5."
+            )
+
+
+class NoStorageRolesCephadm(SesDevException):
+    def __init__(self, offending_role):
+        super(NoStorageRolesCephadm, self).__init__(
+            "No \"storage\" roles were given, but currently sesdev does not "
+            "support this due to the presence of one or more {} roles in the "
+            "cluster configuration.".format(offending_role))
+
+
+class NoStorageRolesDeepsea(SesDevException):
+    def __init__(self, version):
+        super(NoStorageRolesDeepsea, self).__init__(
+            "No \"storage\" roles were given, but currently sesdev does not "
+            "support this configuration when deploying a {} "
+            "cluster.".format(version))
 
 
 class NoSourcePortForPortForwarding(SesDevException):
@@ -91,17 +126,10 @@ class NoSourcePortForPortForwarding(SesDevException):
             "No source port specified for port forwarding")
 
 
-class ServiceNotFound(SesDevException):
-    def __init__(self, service):
-        super(ServiceNotFound, self).__init__(
-            "Service '{}' was not found in this deployment".format(service))
-
-
-class ExclusiveRoles(SesDevException):
-    def __init__(self, role_a, role_b):
-        super(ExclusiveRoles, self).__init__(
-            "Cannot have both roles '{}' and '{}' in the same deployment"
-            .format(role_a, role_b))
+class NoSupportConfigTarballFound(SesDevException):
+    def __init__(self, node):
+        super(NoSupportConfigTarballFound, self).__init__(
+            "No supportconfig tarball found on node {}".format(node))
 
 
 class RoleNotKnown(SesDevException):
@@ -116,13 +144,56 @@ class RoleNotSupported(SesDevException):
             "Role '{}' is not supported in version '{}'".format(role, version))
 
 
-class NoPrometheusGrafanaInSES5(SesDevException):
+class ScpInvalidSourceOrDestination(SesDevException):
     def __init__(self):
-        super(NoPrometheusGrafanaInSES5, self).__init__(
-            "The DeepSea version used in SES5 does not recognize 'prometheus' "
-            "or 'grafana' as roles in policy.cfg (instead, it _always_ deploys "
-            "these two services on the Salt Master node. For this reason, sesdev "
-            "does not permit these roles to be used with ses5."
+        super(ScpInvalidSourceOrDestination, self).__init__(
+            "Either source or destination must contain a ':' - not both or neither")
+
+
+class ServiceNotFound(SesDevException):
+    def __init__(self, service):
+        super(ServiceNotFound, self).__init__(
+            "Service '{}' was not found in this deployment".format(service))
+
+
+class ServicePortForwardingNotSupported(SesDevException):
+    def __init__(self, service):
+        super(ServicePortForwardingNotSupported, self).__init__(
+            "Service '{}' not supported for port forwarding. Specify manually the service source "
+            "and destination ports".format(service))
+
+
+class SettingIncompatibleError(SesDevException):
+    def __init__(self, setting1, value1, setting2, value2):
+        super(SettingIncompatibleError, self).__init__(
+            "Setting {} = {} and {} = {} are incompatible"
+            .format(setting1, value1, setting2, value2))
+
+
+class SettingNotKnown(SesDevException):
+    def __init__(self, setting):
+        super(SettingNotKnown, self).__init__(
+            "Setting '{}' is not known - please open a bug report!".format(setting))
+
+
+class SettingTypeError(SesDevException):
+    def __init__(self, setting, expected_type, value):
+        super(SettingTypeError, self).__init__(
+            "Wrong value type for setting '{}': expected type: '{}', actual value='{}' ('{}')"
+            .format(setting, expected_type, value, type(value)))
+
+
+class SubcommandNotSupportedInVersion(SesDevException):
+    def __init__(self, subcmd, version):
+        super(SubcommandNotSupportedInVersion, self).__init__(
+            "Subcommand {} not supported in '{}'".format(subcmd, version))
+
+
+class SupportconfigOnlyOnSLE(SesDevException):
+    def __init__(self):
+        super(SupportconfigOnlyOnSLE, self).__init__(
+            "sesdev supportconfig depends on the 'supportconfig' RPM, which is "
+            "available only on SUSE Linux Enterprise"
             )
 
 
@@ -134,6 +205,13 @@ class UniqueRoleViolation(SesDevException):
             )
 
 
+class VagrantBoxDoesNotExist(SesDevException):
+    def __init__(self, box):
+        super(VagrantBoxDoesNotExist, self).__init__(
+            "The vagrant box '{}' does not exist. Please add it with `vagrant box add ...` command"
+            .format(box))
+
+
 class VagrantSshConfigNoHostName(SesDevException):
     def __init__(self, name):
         super(VagrantSshConfigNoHostName, self).__init__(
@@ -141,75 +219,13 @@ class VagrantSshConfigNoHostName(SesDevException):
             .format(name))
 
 
-class ScpInvalidSourceOrDestination(SesDevException):
-    def __init__(self):
-        super(ScpInvalidSourceOrDestination, self).__init__(
-            "Either source or destination must contain a ':' - not both or neither")
+class VersionNotKnown(SesDevException):
+    def __init__(self, version):
+        super(VersionNotKnown, self).__init__(
+            "Unknown deployment version: '{}'".format(version))
 
 
-class SettingNotKnown(SesDevException):
-    def __init__(self, setting):
-        super(SettingNotKnown, self).__init__(
-            "Setting '{}' is not known - please open a bug report!".format(setting))
-
-
-class SupportconfigOnlyOnSLE(SesDevException):
-    def __init__(self):
-        super(SupportconfigOnlyOnSLE, self).__init__(
-            "sesdev supportconfig depends on the 'supportconfig' RPM, which is "
-            "available only on SUSE Linux Enterprise"
-            )
-
-
-class BadMakeCheckRolesNodes(SesDevException):
-    def __init__(self):
-        super(BadMakeCheckRolesNodes, self).__init__(
-            "\"makecheck\" deployments only work with a single node with role "
-            "\"makecheck\". Since this is the default, you can simply omit "
-            "the --roles option when running \"sesdev create makecheck\"."
-            )
-
-
-class DuplicateRolesNotSupported(SesDevException):
-    def __init__(self, role):
-        super(DuplicateRolesNotSupported, self).__init__(
-            "A node with more than one \"{r}\" role was detected. "
-            "sesdev does not support more than one \"{r}\" role per node.".format(r=role)
-            )
-
-
-class NoSupportConfigTarballFound(SesDevException):
-    def __init__(self, node):
-        super(NoSupportConfigTarballFound, self).__init__(
-            "No supportconfig tarball found on node {}".format(node))
-
-
-class ExplicitAdminRoleNotAllowed(SesDevException):
-    def __init__(self):
-        super(ExplicitAdminRoleNotAllowed, self).__init__(
-            "Though it is still recognized in existing deployments, the explicit "
-            "\"admin\" role is deprecated and new deployments are not allowed to "
-            "have it. When sesdev deploys Ceph/SES versions that use an \"admin\" "
-            "role, all nodes in the deployment will get that role implicitly. "
-            "(TL;DR remove the \"admin\" role and try again!)")
-
-
-class SubcommandNotSupportedInVersion(SesDevException):
-    def __init__(self, subcmd, version):
-        super(SubcommandNotSupportedInVersion, self).__init__(
-            "Subcommand {} not supported in '{}'".format(subcmd, version))
-
-
-class DepIDWrongLength(SesDevException):
-    def __init__(self, length):
-        super(DepIDWrongLength, self).__init__(
-            "Deployment ID must be from 1 to 63 characters in length "
-            "(yours had {} characters)".format(length))
-
-
-class DepIDIllegalChars(SesDevException):
-    def __init__(self, dep_id):
-        super(DepIDIllegalChars, self).__init__(
-            "Deployment ID \"{}\" contains illegal characters. Valid characters for "
-            "hostnames are ASCII(7) letters from a to z, the digits from 0 to 9, and "
-            "the hyphen (-).".format(dep_id))
+class VersionOSNotSupported(SesDevException):
+    def __init__(self, version, os):
+        super(VersionOSNotSupported, self).__init__(
+            "Combination of version '{}' and OS '{}' not supported".format(version, os))

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -104,12 +104,26 @@ ceph orch apply mon "{{ mon_node_list }}"
 ceph orch apply mgr "{{ mgr_node_list }}"
 {% endif %} {# mgr_nodes > 1 #}
 
-ceph orch device ls --refresh
+{% if storage_nodes > 0 %}
+{% set service_spec_osd = "service_spec_osd.yml" %}
+cat > {{ service_spec_osd }} << EOF
+service_type: osd
+placement:
+    hosts:
 {% for node in nodes %}
 {% if node.has_role('storage') %}
-echo "{\"service_type\": \"osd\", \"placement\": {\"host_pattern\": \"{{ node.name }}*\"}, \"service_id\": \"testing_dg_{{ node.name }}\", \"data_devices\": {\"all\": True}}" | ceph orch apply osd -i -
+        - '{{ node.name }}'
 {% endif %}
 {% endfor %}
+service_id: generic_osd_deployment
+data_devices:
+    all: True
+EOF
+cat {{ service_spec_osd }}
+
+ceph orch device ls --refresh
+ceph orch apply osd -i {{ service_spec_osd }}
+{% endif %} {# storage_nodes > 0 #}
 
 {% if mds_nodes > 0 %}
 ceph fs volume create myfs "{{ mds_node_list }}"


### PR DESCRIPTION
CAVEAT: THIS NEEDS https://github.com/ceph/ceph/pull/33954 and https://github.com/ceph/ceph/pull/34860 - OTHERWISE IT DOESN'T WORK!

---

YAML is nicer than JSON

---

To Do:

- [x] https://github.com/ceph/ceph/pull/33954 merged
- [x] OBS/IBS build of `master` branch contains https://github.com/ceph/ceph/pull/33954
- [x] determine whether service_spec will support glob matching of hostnames
- [x] open new bug report https://tracker.ceph.com/issues/45203
- [x] monitor https://tracker.ceph.com/issues/45203 for activity
- [x] https://github.com/ceph/ceph/pull/34860 merged into master
- [x] this PR passes `pacific` single-node deployment test
- [x] this PR passes `pacific` 4-node deployment test
- [x] https://github.com/ceph/ceph/pull/34860 backported to octopus via https://github.com/ceph/ceph/pull/35475
- [x] ses7 rebased on top of latest upstream octopus
- [x] new ses7 build triggered in `filesystems:ceph:octopus` and `Devel:Storage:7.0`
- [x] ses7 build completes in `filesystems:ceph:octopus` and `Devel:Storage:7.0`
- [x] at least 24 hours elapses since ses7 build completed in `filesystems:ceph:octopus` and `Devel:Storage:7.0` (to allow for media and container images to build)
- [x] this PR passes `contrib/standalone.sh --full`
- [x] this PR passes `contrib/standalone.sh --full` again