### PR TITLE
seslib: raise exception if more, or less, than one master/bootstrap role

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ nodes are separated by commas, too.
 The following roles can be assigned:
 
 * `master` - The master node, running management components like the Salt master
+* `bootstrap` - The node where `cephadm bootstrap` will be run
 * `client` - Various Ceph client utilities
 * `ganesha` - NFS Ganesha service
 * `grafana` - Grafana metrics visualization (requires Prometheus)
@@ -300,12 +301,13 @@ The following roles can be assigned:
 * `suma` - SUSE Manager (octopus only)
 
 The following example will generate a cluster with four nodes: the master (Salt
-Master) node that is also running a MON daemon, two storage (OSD) nodes that
-will also run a MON, a MGR and an MDS, and another node that will run an iSCSI
+Master) node that is also running a MON daemon; a storage (OSD) node that
+will also run a MON, a MGR and an MDS and serve as the bootstrap node; another
+storage (OSD) node with MON, MGR, and MDS; and a fourth node that will run an iSCSI
 gateway, an NFS-Ganesha gateway, and an RGW gateway.
 
 ```
-$ sesdev create nautilus --roles="[master, mon], [storage, mon, mgr, mds], \
+$ sesdev create nautilus --roles="[master, mon], [bootstrap, storage, mon, mgr, mds], \
   [storage, mon, mgr, mds], [igw, ganesha, rgw]" big_cluster
 ```
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -4,7 +4,7 @@ import sys
 import click
 import pkg_resources
 import seslib
-from seslib.exceptions import SesDevException, NoMasterRoleInRoles
+from seslib.exceptions import SesDevException
 
 
 logger = logging.getLogger(__name__)
@@ -124,13 +124,9 @@ def common_create_options(func):
 
 
 def _parse_roles(roles):
-    log_msg = "Parsing role string ->{}<-".format(roles)
     roles = [r.strip() for r in roles.split(",")]
-    logger.info("_parse_roles: " + log_msg)
-    click.echo(log_msg)
     _roles = []
     _node = None
-    master_present = False
     for role in roles:
         role = role.strip()
         if role.startswith('['):
@@ -151,12 +147,6 @@ def _parse_roles(roles):
         else:
             role = role.strip()
             _node.append(role)
-        if role == 'master':
-            master_present = True
-    if master_present:
-        logger.debug("_parse_roles: master role detected - good!")
-    else:
-        raise NoMasterRoleInRoles()
     return _roles
 
 

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -90,10 +90,12 @@ class RoleNotSupported(SesDevException):
             "Role '{}' is not supported in version '{}'".format(role, version))
 
 
-class TooManyMasters(SesDevException):
-    def __init__(self, number):
-        super(TooManyMasters, self).__init__(
-            "There can only be one 'master' role (you gave {})'".format(number))
+class UniqueRoleViolation(SesDevException):
+    def __init__(self, role, number):
+        super(UniqueRoleViolation, self).__init__(
+            "There must be one, and only one, '{role}' role "
+            "(you gave {number} '{role}' roles)".format(role=role, number=number)
+            )
 
 
 class VagrantSshConfigNoHostName(SesDevException):
@@ -120,12 +122,4 @@ class SupportconfigOnlyOnSLE(SesDevException):
         super(SupportconfigOnlyOnSLE, self).__init__(
             "sesdev supportconfig depends on the 'supportconfig' RPM, which is "
             "available only on SUSE Linux Enterprise"
-            )
-
-
-class NoMasterRoleInRoles(SesDevException):
-    def __init__(self):
-        super(NoMasterRoleInRoles, self).__init__(
-            "No 'master' role specified - please check the roles and make sure one, "
-            "and only one, node has the 'master' role"
             )


### PR DESCRIPTION
A check that quickly bails out if someone omits the "master" role was
implemented by ddd4d91 but that commit
is being reverted and replaced by this solution which implements the
check in a less intrusive way, later in the "sesdev create" process.
