### PR TITLE
deepsea_deployment: run Stage 4 only if justified by roles

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1121,6 +1121,8 @@ class Deployment():
             'mon_nodes': self.node_counts["mon"],
             'rgw_nodes': self.node_counts["rgw"],
             'storage_nodes': self.node_counts["storage"],
+            'deepsea_need_stage_4': bool(self.node_counts["ganesha"] or self.node_counts["igw"]
+                                         or self.node_counts["mds"] or self.node_counts["rgw"]),
             'total_osds': self.settings.num_disks * self.node_counts["storage"],
             'encrypted_osds': self.settings.encrypted_osds,
             'scc_username': self.settings.scc_username,

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -136,6 +136,7 @@ ceph config set global mon_max_pg_per_osd 500
 exit 0
 {% endif %}
 
+{% if deepsea_need_stage_4 %}
 echo ""
 echo "***** RUNNING stage.4 *******"
 {% if use_deepsea_cli %}
@@ -144,6 +145,6 @@ deepsea stage run --simple-output ceph.stage.4
 salt-run state.orch ceph.stage.4
 {% endif %}
 sleep 5
+{% endif %} {# deepsea_need_stage_4 #}
 
 echo "deployment complete!"
-


### PR DESCRIPTION
Stage 4 is not needed, and is a noop, on basic "MON, MGR, OSD" clusters, so omit it in such cases.
