### PR TITLE
seslib: install sesdev-generated keypair under non-default name

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -214,7 +214,7 @@ $ sesdev create octopus --roles="[master, mon, mgr], \\
 
     if work_path:
         logger.info("Working path: %s", work_path)
-        seslib.GlobalSettings.WORKING_DIR = work_path
+        seslib.GlobalSettings.A_WORKING_DIR = work_path
 
     if config_file:
         logger.info("Config file: %s", config_file)

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 
 
 class GlobalSettings():
-    WORKING_DIR = os.path.join(Path.home(), '.sesdev')
-    CONFIG_FILE = os.path.join(WORKING_DIR, 'config.yaml')
+    A_WORKING_DIR = os.path.join(Path.home(), '.sesdev')
+    CONFIG_FILE = os.path.join(A_WORKING_DIR, 'config.yaml')
     DEBUG = False
     VAGRANT_DEBUG = False
 
@@ -804,7 +804,7 @@ class Deployment():
 
     @property
     def dep_dir(self):
-        return os.path.join(GlobalSettings.WORKING_DIR, self.dep_id)
+        return os.path.join(GlobalSettings.A_WORKING_DIR, self.dep_id)
 
     def _needs_cluster_network(self):
         if len(self.settings.roles) == 1:  # there is only 1 node
@@ -1560,7 +1560,7 @@ class Deployment():
 
     @classmethod
     def create(cls, dep_id, settings):
-        dep_dir = os.path.join(GlobalSettings.WORKING_DIR, dep_id)
+        dep_dir = os.path.join(GlobalSettings.A_WORKING_DIR, dep_id)
         if os.path.exists(dep_dir):
             raise DeploymentAlreadyExists(dep_id)
 
@@ -1571,7 +1571,7 @@ class Deployment():
 
     @classmethod
     def load(cls, dep_id, load_status=True):
-        dep_dir = os.path.join(GlobalSettings.WORKING_DIR, dep_id)
+        dep_dir = os.path.join(GlobalSettings.A_WORKING_DIR, dep_id)
         if not os.path.exists(dep_dir) or not os.path.isdir(dep_dir):
             logger.debug("%s does not exist or is not a directory", dep_dir)
             raise DeploymentDoesNotExists(dep_id)
@@ -1591,9 +1591,9 @@ class Deployment():
     @classmethod
     def list(cls, load_status=False):
         deps = []
-        if not os.path.exists(GlobalSettings.WORKING_DIR):
+        if not os.path.exists(GlobalSettings.A_WORKING_DIR):
             return deps
-        for dep_id in os.listdir(GlobalSettings.WORKING_DIR):
+        for dep_id in os.listdir(GlobalSettings.A_WORKING_DIR):
             if dep_id.startswith("config.yaml"):
                 logger.debug("Skipping %s (obviously not a deployment)", dep_id)
                 continue

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -32,6 +32,7 @@ class GlobalSettings():
     A_WORKING_DIR = os.path.join(Path.home(), '.sesdev')
     CONFIG_FILE = os.path.join(A_WORKING_DIR, 'config.yaml')
     DEBUG = False
+    SSH_KEY_NAME = 'sesdev'  # do NOT use 'id_rsa'
     VAGRANT_DEBUG = False
 
     @classmethod
@@ -1075,6 +1076,7 @@ class Deployment():
             ceph_salt_fetch_github_pr_merges = True
 
         context = {
+            'ssh_key_name': GlobalSettings.SSH_KEY_NAME,
             'sesdev_path_to_qa': GlobalSettings.PATH_TO_QA,
             'dep_id': self.dep_id,
             'os': self.settings.os,
@@ -1161,13 +1163,13 @@ class Deployment():
         keys_dir = os.path.join(self.dep_dir, 'keys')
         os.makedirs(keys_dir)
 
-        with open(os.path.join(keys_dir, 'id_rsa'), 'w') as file:
+        with open(os.path.join(keys_dir, GlobalSettings.SSH_KEY_NAME), 'w') as file:
             file.write(private_key.decode('utf-8'))
-        os.chmod(os.path.join(keys_dir, 'id_rsa'), 0o600)
+        os.chmod(os.path.join(keys_dir, GlobalSettings.SSH_KEY_NAME), 0o600)
 
-        with open(os.path.join(keys_dir, 'id_rsa.pub'), 'w') as file:
-            file.write(public_key.decode('utf-8'))
-        os.chmod(os.path.join(keys_dir, 'id_rsa.pub'), 0o600)
+        with open(os.path.join(keys_dir, str(GlobalSettings.SSH_KEY_NAME + '.pub')), 'w') as file:
+            file.write(str(public_key.decode('utf-8') + " sesdev\n"))
+        os.chmod(os.path.join(keys_dir, str(GlobalSettings.SSH_KEY_NAME + '.pub')), 0o600)
 
         # bin dir with helper scripts
         bin_dir = os.path.join(self.dep_dir, 'bin')
@@ -1372,7 +1374,7 @@ class Deployment():
         if address is None:
             raise VagrantSshConfigNoHostName(name)
 
-        dep_private_key = os.path.join(self.dep_dir, "keys/id_rsa")
+        dep_private_key = os.path.join(self.dep_dir, str("keys/" + GlobalSettings.SSH_KEY_NAME))
 
         return (address, proxycmd, dep_private_key)
 

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -15,10 +15,10 @@ Vagrant.configure("2") do |config|
 
 {% include "engine/" + vm_engine + "/vagrant.node.j2" %}
 
-    node.vm.provision "file", source: "keys/id_rsa",
-                              destination:".ssh/id_rsa"
-    node.vm.provision "file", source: "keys/id_rsa.pub",
-                              destination:".ssh/id_rsa.pub"
+    node.vm.provision "file", source: "keys/{{ ssh_key_name }}",
+                              destination:".ssh/{{ ssh_key_name }}"
+    node.vm.provision "file", source: "keys/{{ ssh_key_name }}.pub",
+                              destination:".ssh/{{ ssh_key_name }}.pub"
 
 {% if node == master %}
     node.vm.provision "file", source: "bin/", destination: "/home/vagrant/"

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -87,11 +87,13 @@ zypper mr -p {{ repo.priority }} {{ repo.name }}
 zypper --gpg-auto-import-keys ref
 {% endif %}
 
-cat /home/vagrant/.ssh/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
+cat /home/vagrant/.ssh/{{ ssh_key_name }}.pub >> /home/vagrant/.ssh/authorized_keys
 [ ! -e "/root/.ssh" ] && mkdir /root/.ssh
-chmod 600 /home/vagrant/.ssh/id_rsa
-cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
-cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+chmod 600 /home/vagrant/.ssh/{{ ssh_key_name }}
+cp /home/vagrant/.ssh/{{ ssh_key_name }}* /root/.ssh/
+ln -s /root/.ssh/{{ ssh_key_name }} /root/.ssh/id_rsa
+ln -s /root/.ssh/{{ ssh_key_name }}.pub /root/.ssh/id_rsa.pub
+cat /root/.ssh/{{ ssh_key_name }}.pub >> /root/.ssh/authorized_keys
 hostnamectl set-hostname {{ node.name }}
 
 {% if version == 'caasp4' %}


### PR DESCRIPTION
For each deployment, sesdev generates an SSH keypair and:

1. uploads it as /home/vagrant/.ssh/id_rsa{.pub} to all the VMs
2. copies it to /root/.ssh/id_rsa{.pub}
3. appends the public part to /home/vagrant/.ssh/authorized_keys
4. appends the public part of /root/.ssh/authorized_keys

This is problematic because /root/.ssh/id_rsa{.pub} is prone to being
rewritten by "other software" (e.g. ceph-salt was rewriting it).

This patch makes sesdev install its keypair under a different name:
".ssh/sesdev{.pub}".

To avoid losing the ability to ssh from any node of the cluster to any
other node simply by issuing the command "ssh $NODE_ID" as root, we
create "/root/.ssh/id_rsa{.pub}" as a symlink to sesdev's keypair.

Fixes: https://github.com/SUSE/sesdev/issues/206