### PR TITLE
Jenkinsfile.integration: split qa-test into separate stage

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -56,7 +56,7 @@ def sesdev_create_cmd(ceph_salt_git_repo, ceph_salt_git_branch, extra_repo_urls)
         }
     }
 
-    cmd += " --qa-test --single-node mini"
+    cmd += " --single-node mini"
     return cmd
 }
 
@@ -127,6 +127,7 @@ pipeline {
                 sh 'zypper -n in vagrant vagrant-libvirt libvirt gcc git-core libvirt-devel python3-devel python3-virtualenv'
             }
         }
+
         stage('Setup libvirt') {
             agent { label "${jenkins_slave_name}" }
             steps {
@@ -151,6 +152,18 @@ pipeline {
                     ansiColor('xterm') {
                         sh sesdev_create_cmd(params.CEPH_SALT_GIT_REPO, params.CEPH_SALT_GIT_BRANCH, params.EXTRA_REPO_URLS)
                     }
+                }
+            }
+        }
+
+        stage('Run QA tests on the cluster') {
+            agent { label "${jenkins_slave_name}" }
+            steps {
+                sh "./bootstrap.sh"
+                sh "source venv/bin/activate; sesdev --version"
+                sh "source venv/bin/activate; sesdev list"
+                timeout(time: 90, unit: 'MINUTES') {
+                    sh "source venv/bin/activate; sesdev qa-test mini"
                 }
             }
         }


### PR DESCRIPTION
This provides more clarity, simply by looking at the Jenkins pipeline
diagram, whether the job failed in creating the cluster or in the
subsequent QA test phase.

Signed-off-by: Nathan Cutler <ncutler@suse.com>