### PR TITLE
ceph_salt_deployment: make it easier to install ceph-salt from source

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -520,6 +520,22 @@ def _gen_settings_dict(version,
         settings_dict['encrypted_osds'] = encrypted_osds
 
     if ceph_salt_repo:
+        if not ceph_salt_branch:
+            logger.debug(
+                "User explicitly specified only --ceph-salt-repo; assuming --ceph-salt-branch %s",
+                seslib.GlobalSettings.CEPH_SALT_BRANCH
+                )
+            ceph_salt_branch = seslib.GlobalSettings.CEPH_SALT_BRANCH
+
+    if ceph_salt_branch:
+        if not ceph_salt_repo:
+            logger.debug(
+                "User explicitly specified only --ceph-salt-branch; assuming --ceph-salt-repo %s",
+                seslib.GlobalSettings.CEPH_SALT_REPO
+                )
+            ceph_salt_repo = seslib.GlobalSettings.CEPH_SALT_REPO
+
+    if ceph_salt_repo:
         settings_dict['ceph_salt_git_repo'] = ceph_salt_repo
 
     if ceph_salt_branch:

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 
 class GlobalSettings():
     A_WORKING_DIR = os.path.join(Path.home(), '.sesdev')
+    CEPH_SALT_REPO = 'https://github.com/ceph/ceph-salt'
+    CEPH_SALT_BRANCH = 'master'
     CONFIG_FILE = os.path.join(A_WORKING_DIR, 'config.yaml')
     DEBUG = False
     SSH_KEY_NAME = 'sesdev'  # do NOT use 'id_rsa'
@@ -411,7 +413,7 @@ SETTINGS = {
     'ceph_salt_git_branch': {
         'type': str,
         'help': 'ceph-salt git branch to use',
-        'default': 'master',
+        'default': None,
     },
     'stop_before_ceph_salt_config': {
         'type': bool,

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -1,7 +1,7 @@
 
 set -ex
 
-{% if ceph_salt_git_repo %}
+{% if ceph_salt_git_repo and ceph_salt_git_branch %}
 # install ceph-salt
 cd /root
 git clone {{ ceph_salt_git_repo }}


### PR DESCRIPTION
Before, one had to provide both "--ceph-salt-repo" and
"--ceph-salt-branch" in order for sesdev to install ceph-salt from
source.

With this patch, only one or the other is required. When one of these
two options is given, the other will default to a sensible value.

The defaults are hard-coded to:

--ceph-salt-repo https://github.com/ceph/ceph-salt
--ceph-salt-branch master

Signed-off-by: Nathan Cutler <ncutler@suse.com>