### PR TITLE
Require bootstrap role only for SES7/Octopus

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1017,7 +1017,7 @@ class Deployment():
         if not self.from_load:
             if self.node_counts['master'] != 1:
                 raise UniqueRoleViolation('master', self.node_counts['master'])
-            if self.node_counts['bootstrap'] != 1:
+            if (self.settings.version in ["octopus", "ses7"]) and (self.node_counts['bootstrap'] != 1):
                 raise UniqueRoleViolation('bootstrap', self.node_counts['bootstrap'])
 
         if self.master and self.suma:


### PR DESCRIPTION
Checking for the presence of role 'bootstrap' makes sense for SES7/Octopus clusters only.