### PR TITLE
Jenkinsfile.integration: Retry jenkins slave deletion

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -167,7 +167,10 @@ pipeline {
             node("${jenkins_slave_base}") {
                 sh "virtualenv venv"
                 sh "source venv/bin/activate; pip install git+https://github.com/toabctl/jcs.git#egg=jcs[openstack,obs,jenkins]"
-                sh "source venv/bin/activate; jcs delete --cloud openstack ${jenkins_slave_name}"
+                retry(10) {
+                    sh "source venv/bin/activate; jcs delete --cloud openstack ${jenkins_slave_name}"
+                    sleep 10
+                }
             }
         }
     }


### PR DESCRIPTION
In case the node delete fails, retry it. We don't want to have running
nodes on OVH after a job finished.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>