### PR TITLE
seslib: systemically vet roles on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,18 +314,27 @@ nodes are separated by commas, too.
 The following roles can be assigned:
 
 * `master` - The master node, running management components like the Salt master
+* `admin` - signifying that the node should get ceph.conf and keyring [1]
 * `bootstrap` - The node where `cephadm bootstrap` will be run
 * `client` - Various Ceph client utilities
 * `ganesha` - NFS Ganesha service
-* `grafana` - Grafana metrics visualization (requires Prometheus)
+* `grafana` - Grafana metrics visualization (requires Prometheus) [2]
 * `igw` - iSCSI target gateway
 * `mds` - CephFS MDS
 * `mgr` - Ceph Manager instance
 * `mon` - Ceph Monitor instance
-* `prometheus` - Prometheus monitoring
+* `prometheus` - Prometheus monitoring [2]
 * `rgw` - Ceph Object Gateway
 * `storage` - OSD storage daemon
 * `suma` - SUSE Manager (octopus only)
+
+[1] CAVEAT: sesdev applies the "admin" role to all nodes, regardless of whether
+or not the user specified it explicitly on the command line or in `config.yaml`.
+
+[2] CAVEAT: Do not specify "prometheus"/"grafana" roles for ses5 deployments.
+The DeepSea version shipped with SES5 always deploys Prometheus and Grafana
+instances on the master node, but does not recognize "prometheus"/"grafana"
+roles in policy.cfg.
 
 The following example will generate a cluster with four nodes: the master (Salt
 Master) node that is also running a MON daemon; a storage (OSD) node that
@@ -337,9 +346,6 @@ gateway, an NFS-Ganesha gateway, and an RGW gateway.
 $ sesdev create nautilus --roles="[master, mon], [bootstrap, storage, mon, mgr, mds], \
   [storage, mon, mgr, mds], [igw, ganesha, rgw]" big_cluster
 ```
-
-CAVEAT: sesdev applies the "admin" role to all nodes, regardless of whether or
-not the user specified it explicitly on the command line or in `config.yaml`.
 
 #### Custom zypper repo (to be added together with the default repos)
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -587,6 +587,7 @@ def _create_command(deployment_id, deploy, settings_dict):
                 )
         try:
             if really_want_to:
+                dep.vet_configuration()
                 dep.start(_print_log)
                 click.echo("=== Deployment Finished ===")
                 click.echo()

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -90,6 +90,16 @@ class RoleNotSupported(SesDevException):
             "Role '{}' is not supported in version '{}'".format(role, version))
 
 
+class NoPrometheusGrafanaInSES5(SesDevException):
+    def __init__(self):
+        super(NoPrometheusGrafanaInSES5, self).__init__(
+            "The DeepSea version used in SES5 does not recognize 'prometheus' "
+            "or 'grafana' as roles in policy.cfg (instead, it _always_ deploys "
+            "these two services on the Salt Master node. For this reason, sesdev "
+            "does not permit these roles to be used with ses5."
+            )
+
+
 class UniqueRoleViolation(SesDevException):
     def __init__(self, role, number):
         super(UniqueRoleViolation, self).__init__(


### PR DESCRIPTION
Unfortunately, this change has gone through several iterations already.
I think I finally have it right this time.

This commit more-or-less reverts/replaces the following three commits:

"seslib: check bootstrap role only when it is relevant"
5100786d82de471146223182a9d30ded9c0491d7

"seslib: raise exception more, or less, than one master/bootstrap role"
a52f94eb3faa24fe1505cf8f6ded620f743d8f52

"sesdev: fail when master role is missing"
ddd4d91ca08f3e4ea993d9cba9431373c62fed8b

It introduces a new "vet_configuration" method in the "Deployment" class, explicitly for the purpose of vetting roles, and concentrates all of the role vetting code into that method.