### PR TITLE
seslib: ceph_salt_git_branch might be None

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1079,15 +1079,16 @@ class Deployment():
         # detect whether we need to fetch github PRs
         ceph_salt_fetch_github_pr_heads = False
         ceph_salt_fetch_github_pr_merges = False
-        if self.settings.ceph_salt_git_branch.startswith('origin/pr/'):
+        ceph_salt_git_branch = self.settings.ceph_salt_git_branch
+        if ceph_salt_git_branch and ceph_salt_git_branch.startswith('origin/pr/'):
             log_msg = ("Detected special ceph-salt GitHub PR (HEAD) branch {}"
-                       .format(self.settings.ceph_salt_git_branch)
+                       .format(ceph_salt_git_branch)
                        )
             logger.info(log_msg)
             ceph_salt_fetch_github_pr_heads = True
-        elif self.settings.ceph_salt_git_branch.startswith('origin/pr-merged/'):
+        elif ceph_salt_git_branch and ceph_salt_git_branch.startswith('origin/pr-merged/'):
             log_msg = ("Detected special ceph-salt GitHub PR (MERGE) branch {}"
-                       .format(self.settings.ceph_salt_git_branch)
+                       .format(ceph_salt_git_branch)
                        )
             logger.info(log_msg)
             ceph_salt_fetch_github_pr_merges = True


### PR DESCRIPTION
231e50d41c62a8c62485fd59b3ca79503cd264c2 changed the default value of
this setting to None, which caused a regression.

Fixes: 231e50d41c62a8c62485fd59b3ca79503cd264c2
Fixes: https://github.com/SUSE/sesdev/issues/216
Signed-off-by: Nathan Cutler <ncutler@suse.com>