### PR TITLE
templates: assert deepsea/ceph-salt executable present before trying to run it

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -60,6 +60,9 @@ sleep 2
 exit 0
 {% endif %}
 
+echo "$PATH"
+type ceph-salt
+
 MON_NODES_COMMA_SEPARATED_LIST=""
 MGR_NODES_COMMA_SEPARATED_LIST=""
 {% for node in nodes %}

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -56,6 +56,11 @@ sleep 5
 exit 0
 {% endif %}
 
+{% if use_deepsea_cli %}
+echo "$PATH"
+type deepsea
+{% endif %}
+
 echo ""
 echo "***** RUNNING stage.0 *******"
 {% if use_deepsea_cli %}


### PR DESCRIPTION
This will help debug issues like this one:

Deployment fails with:

    master: ++ ceph-salt config /Ceph_Cluster/Minions add master.octopus.com
    master: /tmp/vagrant-shell: line 143: ceph-salt: command not found

Yet, after subsequently SSHing in:

    master:~ # type ceph-salt
    ceph-salt is /usr/local/bin/ceph-salt
    master:~ # echo $PATH
    /sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin
    master:~ # ceph-salt
    Usage: ceph-salt [OPTIONS] COMMAND [ARGS]...

    ...

Signed-off-by: Nathan Cutler <ncutler@suse.com>