### PR TITLE
ceph_salt_deployment: use --prefix /usr with "pip install"

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -19,7 +19,7 @@ git fetch origin "+refs/pull/*/merge:refs/remotes/origin/pr-merged/*"
 
 git checkout {{ ceph_salt_git_branch }}
 
-pip install .
+pip install --prefix /usr .
 # install ceph-salt-formula
 cp -r ceph-salt-formula/salt/* /srv/salt/
 chown -R salt:salt /srv

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -60,6 +60,9 @@ sleep 2
 exit 0
 {% endif %}
 
+echo "PATH is $PATH"
+type ceph-salt
+
 MON_NODES_COMMA_SEPARATED_LIST=""
 MGR_NODES_COMMA_SEPARATED_LIST=""
 {% for node in nodes %}

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -56,6 +56,11 @@ sleep 5
 exit 0
 {% endif %}
 
+{% if use_deepsea_cli %}
+echo "PATH is $PATH"
+type deepsea
+{% endif %}
+
 echo ""
 echo "***** RUNNING stage.0 *******"
 {% if use_deepsea_cli %}


### PR DESCRIPTION
Deployment fails with:

    master: ++ ceph-salt config /Ceph_Cluster/Minions add master.octopus.com
    master: /tmp/vagrant-shell: line 143: ceph-salt: command not found

Yet, after subsequently SSHing in:

    master:~ # type ceph-salt
    ceph-salt is /usr/local/bin/ceph-salt
    master:~ # echo $PATH
    /sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin
    master:~ # ceph-salt
    Usage: ceph-salt [OPTIONS] COMMAND [ARGS]...

    ...

The reason is that `ceph_salt_deployment.sh` is not running in a login shell, so `/usr/local/bin` does not get added to the PATH.

For whatever reason, `pip install` does not behave this way in Leap 15.2 and earlier. This issue is only seen in `--os=tumbleweed` deployments.

Fixes: https://github.com/SUSE/sesdev/issues/220