### PR TITLE
libvirt/vagrant.provider.j2: Use less VRAM for VMs

### DIFF
--- a/seslib/templates/engine/libvirt/vagrant.provider.j2
+++ b/seslib/templates/engine/libvirt/vagrant.provider.j2
@@ -15,6 +15,7 @@
 {% if libvirt_storage_pool %}
     lv.storage_pool_name = "{{ libvirt_storage_pool }}"
 {% endif %}
+    lv.video_vram = 2048
     lv.nic_model_type = "e1000"
     lv.cpu_mode = 'host-passthrough'
   end


### PR DESCRIPTION
By default Vagrant creates libvirt VMs with 9MB of Video RAM.
We don't need that much memory for headless VMs, so we're
instructing libvirt to create VMs with just 2MB of VRAM.

Signed-off-by: Christos Varelas <cvarelas@suse.de>