### PR TITLE
ceph_salt_deployment.sh: do not refresh/sync pillar data

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -51,11 +51,6 @@ while true ; do
 done
 set -ex
 
-salt '*' saltutil.pillar_refresh
-salt '*' saltutil.sync_all
-
-sleep 2
-
 {% if stop_before_ceph_salt_config %}
 exit 0
 {% endif %}


### PR DESCRIPTION
As of https://github.com/ceph/ceph-salt/pull/157 ceph-salt should take
care of this itself.

Also, since these steps might not be included in the documentation, it's
possible that a user will omit them and run into bugs that, because of
these two lines, are not seen with sesdev.

Signed-off-by: Nathan Cutler <ncutler@suse.com>