### PR TITLE
Failed to setup a SES5 single-node cluster

### DIFF
--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -107,9 +107,11 @@ exit 0
 {% endif %}
 
 {% if encrypted_osds %}
-echo "  encryption: True" >> /srv/salt/ceph/configuration/files/drive_groups.yml
+if [ -e "/srv/salt/ceph/configuration/files/drive_groups.yml" ] ; then
+  echo "  encryption: True" >> /srv/salt/ceph/configuration/files/drive_groups.yml
+fi
 {% endif %}
-cat /srv/salt/ceph/configuration/files/drive_groups.yml
+cat /srv/salt/ceph/configuration/files/drive_groups.yml || true
 
 echo ""
 echo "***** RUNNING stage.3 *******"


### PR DESCRIPTION
Harden the script by checking if /srv/salt/ceph/configuration/files/drive_groups.yml exists.

Fixes: https://github.com/SUSE/sesdev/issues/228

Signed-off-by: Volker Theile <vtheile@suse.com>