### PR TITLE
templates: extend --qa-test to DeepSea-deployed versions and fix issues preventing it from passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Pipfile
 build
 dist
 .tox
+typescript

--- a/contrib/run-standalone.sh
+++ b/contrib/run-standalone.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# run sesdev test script "contrib/standalone.sh" while leveraging
+# GNU script to capture all output in a file called "typescript"
+#
+SCRIPTNAME=$(basename ${0})
+BASEDIR=$(readlink -f "$(dirname ${0})")
+COMMAND="$BASEDIR/standalone.sh $@ ; exit"
+script -c "$COMMAND"

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+#
+# NOTE: This is a work in progress!
+#
+
+set -x
+
+SCRIPTNAME=$(basename ${0})
+FINAL_REPORT="$(mktemp)"
+
+function final_report {
+    echo -en "\n=====================================================================\n" >> $FINAL_REPORT
+    cat $FINAL_REPORT
+    rm $FINAL_REPORT
+    exit 0
+}
+
+trap final_report INT
+
+function usage {
+    echo "$SCRIPTNAME - sesdev regression testing"
+    echo
+    echo "Usage:"
+    echo "    --help                   Display this usage message"
+    echo "    --all                    Run all tests (the default)"
+    echo "    --ceph-salt-from-source  Install ceph-salt from source"
+    echo "                             (default: from RPM package)"
+    echo "    --makecheck              Run makecheck (install-deps.sh,"
+    echo "                             actually) tests"
+    echo "    --nautilus               Run nautilus deployment tests"
+    echo "    --octopus                Run octopus deployment tests"
+    echo "    --pacific                Run pacific deployment tests"
+    echo "    --ses5                   Run ses5 deployment tests"
+    echo "    --ses6                   Run ses6 deployment tests"
+    echo "    --ses7                   Run ses7 deployment tests"
+    echo
+    exit 1
+}
+
+function run_cmd {
+    local exit_status
+    local timestamp="$(date -Iminutes --utc)"
+    echo -en "\n${timestamp%+00:00}\n" >> $FINAL_REPORT
+    echo -en "=====================================================================\n" >> $FINAL_REPORT
+    echo -en "Command:\n\n    $@\n" >> $FINAL_REPORT
+    $@
+    exit_status="$?"
+    if [ "$exit_status" = "0" ] ; then
+        echo -en "\nExit status: 0 (PASS)\n" >> $FINAL_REPORT
+    else
+        echo -en "\nExit status: $exit_status (FAIL)\n" >> $FINAL_REPORT
+        final_report
+    fi  
+}
+
+TEMP=$(getopt -o h \
+--long "help,all,ceph-salt-from-source,makecheck,nautilus,octopus,pacific,ses5,ses6,ses7" \
+-n 'standalone.sh' -- "$@")
+
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+eval set -- "$TEMP"
+
+# process command-line options
+ALL="--all"
+CEPH_SALT_FROM_SOURCE=""
+MAKECHECK=""
+NAUTILUS=""
+OCTOPUS=""
+PACIFIC=""
+SES5=""
+SES6=""
+SES7=""
+while true ; do
+    case "$1" in
+        --all)                   ALL="$1" ; shift ;;
+        --ceph-salt-from-source) CEPH_SALT_FROM_SOURCE="--ceph-salt-branch=master" ; shift ;;
+        --makecheck)             MAKECHECK="$1" ; shift ;;
+        --nautilus)              NAUTILUS="$1" ; shift ;;
+        --octopus)               OCTOPUS="$1" ; shift ;;
+        --pacific)               PACIFIC="$1" ; shift ;;
+        --ses5)                  SES5="$1" ; shift ;;
+        --ses6)                  SES6="$1" ; shift ;;
+        --ses7)                  SES7="$1" ; shift ;;
+        -h|--help)               usage ;; # does not return
+        --) shift ; break ;;
+        *) echo "Internal error" ; exit 1 ;;
+    esac
+done
+
+if [ "$MAKECHECK" -o "$NAUTILUS" -o "$OCTOPUS" -o "$PACIFIC" -o "$SES5" -o "$SES6" -o "$SES7" ] ; then
+    ALL=""
+fi
+
+if [ "$ALL" ] ; then
+    # MAKECHECK="--makecheck"
+    NAUTILUS="--nautilus"
+    OCTOPUS="--octopus"
+    PACIFIC="--pacific"
+    SES5="--ses5"
+    SES6="--ses6"
+    SES7="--ses7"
+fi
+
+if [ "$SES5" ] ; then
+    run_cmd sesdev create ses5 --non-interactive --single-node --qa-test ses5-1node
+    run_cmd sesdev destroy --non-interactive ses5-1node
+    run_cmd sesdev create ses5 --non-interactive ses5-4node
+    run_cmd sesdev qa-test ses5-4node
+    run_cmd sesdev destroy --non-interactive ses5-4node
+fi
+
+if [ "$NAUTILUS" ] ; then
+    run_cmd sesdev create nautilus --non-interactive --single-node --qa-test nautilus-1node
+    run_cmd sesdev destroy --non-interactive nautilus-1node
+    run_cmd sesdev create nautilus --non-interactive nautilus-4node
+    run_cmd sesdev qa-test nautilus-4node
+    run_cmd sesdev destroy --non-interactive nautilus-4node
+fi
+
+if [ "$SES6" ] ; then
+    run_cmd sesdev create ses6 --non-interactive --single-node --qa-test ses6-1node
+    run_cmd sesdev destroy --non-interactive ses6-1node
+    run_cmd sesdev create ses6 --non-interactive ses6-4node
+    run_cmd sesdev qa-test ses6-4node
+    run_cmd sesdev destroy --non-interactive ses6-4node
+fi
+
+if [ "$OCTOPUS" ] ; then
+    run_cmd sesdev create octopus --non-interactive $CEPH_SALT_FROM_SOURCE --single-node --qa-test octopus-1node
+    run_cmd sesdev destroy --non-interactive octopus-1node
+    run_cmd sesdev create octopus --non-interactive $CEPH_SALT_FROM_SOURCE octopus-4node
+    run_cmd sesdev qa-test octopus-4node
+    run_cmd sesdev destroy --non-interactive octopus-4node
+fi
+
+if [ "$SES7" ] ; then
+    run_cmd sesdev create ses7 --non-interactive $CEPH_SALT_FROM_SOURCE --single-node --qa-test ses7-1node
+    run_cmd sesdev destroy --non-interactive ses7-1node
+    run_cmd sesdev create ses7 --non-interactive $CEPH_SALT_FROM_SOURCE ses7-4node
+    run_cmd sesdev qa-test ses7-4node
+    run_cmd sesdev destroy --non-interactive ses7-4node
+fi
+
+if [ "$PACIFIC" ] ; then
+    run_cmd sesdev create pacific --non-interactive $CEPH_SALT_FROM_SOURCE --single-node --qa-test pacific-1node
+    run_cmd sesdev destroy --non-interactive pacific-1node
+    run_cmd sesdev create pacific --non-interactive $CEPH_SALT_FROM_SOURCE pacific-4node
+    run_cmd sesdev qa-test pacific-4node
+    run_cmd sesdev destroy --non-interactive pacific-4node
+fi
+
+if [ "$MAKECHECK" ] ; then
+    # run_cmd sesdev create makecheck --non-interactive --stop-before-run-make-check --ram 4
+    # run_cmd sesdev create makecheck --non-interactive --os sles-12-sp3 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses5 --stop-before-run-make-check --ram 4
+    # run_cmd sesdev create makecheck --non-interactive --os sles-15-sp1 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses6 --stop-before-run-make-check --ram 4
+    # run_cmd sesdev create makecheck --non-interactive --os sles-15-sp2 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses7 --stop-before-run-make-check --ram 4
+    true
+fi
+
+final_report

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 #
+# contrib/standalone.sh - sesdev regression testing
+#
 # NOTE: This is a work in progress!
+#
+# contrib/standalone.sh is a script which
+#
+# - deploys 1- and 4-node clusters of each of the main deployment types
+#   (ses5, nautilus, ses6, octopus, ses7, pacific)
+# - runs basic QA tests on each cluster after deployment is finished
+# - if QA tests succeed, cluster is destroyed before moving on to the next one
+# - when a failure occurs, the script aborts and post-mortem can be performed
+#
+# The script sends all output (its own and that of sesdev) to the screen,
+# and there is typically so much of it that it will overflow any ordinary
+# scrollback buffer. To facilitate capture of the output into a file for
+# later analysis, a simple companion script is provided. See:
+#
+#     contrib/run-standalone.sh
 #
 
 set -x

--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -15,11 +15,33 @@ function json_osd_nodes {
 }
 
 function json_total_mgrs {
-    echo "$(($(ceph status --format json | jq -r .mgrmap.num_standbys) + 1))"
+    if [ "$VERSION_ID" = "15.2" ] ; then
+        # SES7
+        echo "$(($(ceph status --format json | jq -r .mgrmap.num_standbys) + 1))"
+    elif [ "$VERSION_ID" = "15.1" ] ; then
+        # SES6
+        echo "$(($(ceph status --format json | jq -r ".mgrmap.standbys | length") + 1))"
+    elif [ "$VERSION_ID" = "12.3" ] ; then
+        # SES5
+        echo "$(($(ceph status --format json | jq -r ".mgrmap.standbys | length") + 1))"
+    else
+        echo "0"
+    fi
 }
 
 function json_total_mons {
-    ceph status --format json | jq -r .monmap.num_mons
+    if [ "$VERSION_ID" = "15.2" ] ; then
+        # SES7
+        echo "$(ceph status --format json | jq -r .monmap.num_mons)"
+    elif [ "$VERSION_ID" = "15.1" ] ; then
+        # SES6
+        echo "$(ceph status --format json | jq -r ".monmap.mons | length")"
+    elif [ "$VERSION_ID" = "12.3" ] ; then
+        # SES5
+        echo "$(ceph status --format json | jq -r ".monmap.mons | length")"
+    else
+        echo "0"
+    fi
 }
 
 function json_total_osds {

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -135,7 +135,7 @@ VERSION_PREFERRED_DEPLOYMENT_TOOL = {
 
 LUMINOUS_DEFAULT_ROLES = [["master", "client", "prometheus", "grafana", "openattic"],
                           ["storage", "mon", "mgr", "rgw", "igw"],
-                          ["storage", "mon", "mgr", "mds", "igw", "ganesha"],
+                          ["storage", "mon", "mgr", "mds", "ganesha"],
                           ["storage", "mon", "mgr", "mds", "rgw", "ganesha"]]
 
 NAUTILUS_DEFAULT_ROLES = [["master", "client", "prometheus", "grafana"],

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -28,11 +28,13 @@ Vagrant.configure("2") do |config|
     node.vm.synced_folder ".", "/vagrant", disabled: true
 
     node.vm.provision "shell", path: "provision_{{ node.name }}.sh"
-  end
+{% if node == master %}
 
+    node.vm.provision "qa-test", type: "shell", run: "never" do |s|
+      s.inline = "/home/vagrant/qa-test.sh"
+    end
+{% endif %}
+  end
 {% endfor %}
 
-  config.vm.provision "qa-test", type: "shell", run: "never" do |s|
-    s.inline = "/home/vagrant/qa-test.sh"
-  end
 end

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -149,29 +149,4 @@ echo "{\"service_type\": \"osd\", \"placement\": {\"host_pattern\": \"{{ node.na
 {% endfor %}
 {% endif %} {# if ceph_salt_deploy_osds #}
 
-{% set qa_test_script = "/home/vagrant/qa-test.sh" %}
-{%- set qa_test_cmd = "/home/vagrant/sesdev-qa/health-ok.sh"
-    ~ " --total-nodes=" ~ nodes|length
-    ~ " --nfs-ganesha-nodes=" ~ ganesha_nodes
-    ~ " --igw-nodes=" ~ igw_nodes
-    ~ " --mds-nodes=" ~ mds_nodes
-    ~ " --mgr-nodes=" ~ mgr_nodes
-    ~ " --mon-nodes=" ~ mon_nodes
-    ~ " --osd-nodes=" ~ storage_nodes
-    ~ " --osds=" ~ total_osds
-    ~ " --rgw-nodes=" ~ rgw_nodes
--%}
-
-cat > {{ qa_test_script }} << EOF
-#!/bin/bash
-set -x
-if [[ $(hostname) == master* ]] ; then
-    {{ qa_test_cmd }}
-fi
-EOF
-chmod 755 {{ qa_test_script }}
-
-{% if qa_test is sameas true %}
-{{ qa_test_cmd }}
-{% endif %}
-
+{% include "qa_test.sh" %}

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -155,3 +155,5 @@ sleep 5
 {% endif %} {# deepsea_need_stage_4 #}
 
 echo "deployment complete!"
+
+{% include "qa_test.sh" %}

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -106,12 +106,16 @@ sleep 5
 exit 0
 {% endif %}
 
-{% if encrypted_osds %}
-if [ -e "/srv/salt/ceph/configuration/files/drive_groups.yml" ] ; then
-  echo "  encryption: True" >> /srv/salt/ceph/configuration/files/drive_groups.yml
+{% if version != 'ses5' %}
+if [ ! -e "/srv/salt/ceph/configuration/files/drive_groups.yml" ] ; then
+    echo "FATAL: /srv/salt/ceph/configuration/files/drive_groups.yml unexpectedly missing!"
+    exit 1
 fi
+{% if encrypted_osds %}
+echo "  encryption: True" >> /srv/salt/ceph/configuration/files/drive_groups.yml
 {% endif %}
-cat /srv/salt/ceph/configuration/files/drive_groups.yml || true
+cat /srv/salt/ceph/configuration/files/drive_groups.yml
+{% endif %}
 
 echo ""
 echo "***** RUNNING stage.3 *******"

--- a/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
+++ b/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
@@ -9,7 +9,6 @@ fi
 zypper -n install ntp SuSEfirewall2
 SuSEfirewall2 off
 
-zypper -n install ntp
 systemctl enable ntpd
 cat > /etc/ntp.conf <<EOF
 server 0.europe.pool.ntp.org

--- a/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
+++ b/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
@@ -6,18 +6,8 @@ if [ ! -e /etc/fstab ]; then
     echo "$uuid $partial" > /etc/fstab
 fi
 
-zypper -n install ntp SuSEfirewall2
+zypper -n install SuSEfirewall2
 SuSEfirewall2 off
-
-systemctl enable ntpd
-cat > /etc/ntp.conf <<EOF
-server 0.europe.pool.ntp.org
-server 1.europe.pool.ntp.org
-server 2.europe.pool.ntp.org
-EOF
-ntpd -gq
-systemctl start ntpd
-ntpq -p
 
 sed -i 's/#worker_threads: 5/worker_threads: 10/g' /etc/salt/master
 systemctl restart salt-master
@@ -101,7 +91,7 @@ popd
 echo "mon_max_pg_per_osd = 500" >> /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf
 {% endif %}
 
-{% for node in nodes: %}
+{% for node in nodes %}
 {% if node.has_role('rgw') and node.has_role('openattic') %}
 # we need to change RGW port to not conflict with openATTIC port
 sed -i 's/port=80"/port=8080"/g' /srv/salt/ceph/configuration/files/rgw.conf

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -111,10 +111,6 @@ systemctl enable salt-minion
 systemctl start salt-minion
 {% endif %}
 
-{% if version == 'ses5' %}
-zypper -n rm ntp
-{% endif %}
-
 touch /tmp/ready
 
 {% if node == master or node == suma %}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -7,16 +7,15 @@ ls -lR /home/vagrant
 # remove the first line introduced by vagrant
 head -1 /etc/hosts | grep -q '127.*' && sed -i '1d' /etc/hosts
 
-{% for _node in nodes %}
-
 # remove "which" RPM because testing environments typically don't have it installed
 zypper -n rm which || true
 
 # remove Python 2 so it doesn't pollute the environment
-{% if os == 'leap-15.1' or os == 'leap-15.2' or os == 'sles-15-sp1' or os == 'sles-15-sp2' %}
+{% if os != 'sles-12-sp3' %}
 zypper -n rm python-base || true
 {% endif %}
 
+{% for _node in nodes %}
 {% if _node.public_address %}
 echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/hosts
 {% endif %}
@@ -63,9 +62,9 @@ zypper --gpg-auto-import-keys ref
        'command-not-found',
    ] %}
 {% if version == 'ses5' %}
-zypper -n install {{ basic_pkgs_to_install | join(' ') }}
+zypper -n install {{ basic_pkgs_to_install | join(' ') }} ntp
 {% else %}
-zypper -n install {{ basic_pkgs_to_install | join(' ') }} hostname
+zypper -n install {{ basic_pkgs_to_install | join(' ') }} chrony hostname
 {% endif %}
 
 {% if os.startswith("sle") %}
@@ -98,9 +97,9 @@ hostnamectl set-hostname {{ node.name }}
 
 {% if version == 'caasp4' %}
 {% include "caasp/provision.sh.j2" %}
-{% else %}
+{% endif %}
 
-{% if not suma %}
+{% if not suma and version != "caasp4" %}
 zypper -n install salt-minion
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
 
@@ -109,11 +108,17 @@ sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/minion
 
 systemctl enable salt-minion
 systemctl start salt-minion
+
+{% if version == "ses5" or version == "nautilus" or version == "ses6" %}
+{% include "sync_clocks.sh.j2" ignore missing %}
 {% endif %}
+
+{% endif %} {# not suma and version != "caasp4" #}
 
 touch /tmp/ready
 
 {% if node == master or node == suma %}
+
 {% if node == master %}
 zypper -n install salt-master
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
@@ -121,7 +126,7 @@ systemctl enable salt-master
 systemctl start salt-master
 sleep 5
 systemctl restart salt-minion
-{% endif %}
+{% endif %} {# node == master #}
 
 while : ; do
   PROVISIONED_NODES=`ls -l /tmp/ready-* 2>/dev/null | wc -l`
@@ -162,20 +167,20 @@ while true ; do
   set +x
 done
 set -ex
+{% endif %} {# node == master #}
 
 {% if deployment_tool == "deepsea" %}
+{% if node == master %}
 {% include "deepsea/deepsea_deployment.sh.j2" %}
-{% endif %}
-{% endif %}
+{% endif %} {# node == master #}
+{% endif %} {# deployment_tool == "deepsea" #}
 
 {% if node == suma %}
 {% include "suma/suma_deployment.sh.j2" %}
 {% endif %}
 
-{% if node == master and deployment_tool == "cephadm" %}
+{% if deployment_tool == "cephadm" %}
 {% include "ceph-salt/ceph_salt_deployment.sh.j2" %}
 {% endif %}
 
 {% endif %} {# node == master or node == suma #}
-
-{% endif %} {# version != caasp4 #}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -112,7 +112,7 @@ systemctl start salt-minion
 {% endif %}
 
 {% if version == 'ses5' %}
-zypper -n rm ntp || true
+zypper -n rm ntp
 {% endif %}
 
 touch /tmp/ready

--- a/seslib/templates/qa_test.sh
+++ b/seslib/templates/qa_test.sh
@@ -1,0 +1,26 @@
+
+{% set qa_test_script = "/home/vagrant/qa-test.sh" %}
+{%- set qa_test_cmd = "/home/vagrant/sesdev-qa/health-ok.sh"
+    ~ " --total-nodes=" ~ nodes|length
+    ~ " --nfs-ganesha-nodes=" ~ ganesha_nodes
+    ~ " --igw-nodes=" ~ igw_nodes
+    ~ " --mds-nodes=" ~ mds_nodes
+    ~ " --mgr-nodes=" ~ mgr_nodes
+    ~ " --mon-nodes=" ~ mon_nodes
+    ~ " --osd-nodes=" ~ storage_nodes
+    ~ " --osds=" ~ total_osds
+    ~ " --rgw-nodes=" ~ rgw_nodes
+-%}
+
+cat > {{ qa_test_script }} << EOF
+#!/bin/bash
+set -x
+if [[ $(hostname) == master* ]] ; then
+    {{ qa_test_cmd }}
+fi
+EOF
+chmod 755 {{ qa_test_script }}
+
+{% if qa_test is sameas true %}
+{{ qa_test_cmd }}
+{% endif %}

--- a/seslib/templates/sync_clocks.sh.j2
+++ b/seslib/templates/sync_clocks.sh.j2
@@ -1,0 +1,120 @@
+
+{% if version == "ses5" %}
+systemctl enable ntpd.service
+cat > /etc/ntp.conf <<EOF
+interface listen all
+{% if node == master %}
+server 0.europe.pool.ntp.org burst iburst
+server 1.europe.pool.ntp.org burst iburst
+server 2.europe.pool.ntp.org burst iburst
+{% else %}
+server master
+{% endif %}
+EOF
+{% if node == master %}
+{% set ntp_script = "ntp_sync_start.sh" %}
+cat > {{ ntp_script }} << 'EOF'
+#!/bin/bash
+NTP_SERVER="$1"
+
+function try_wait {
+    local cmd="$1"
+    local tries="$2"
+    local sleep_secs="$3"
+    for i in $(seq 1 "$tries") ; do
+        set -x
+        $cmd
+        set +x
+        SAVED_STATUS="$?"
+        test "$SAVED_STATUS" = "0" && break
+        set -x
+        sleep "$sleep_secs"
+        set +x
+    done
+}
+
+try_wait "ntpdate -b $NTP_SERVER" 10 5
+try_wait "sntp --timeout=15 --step $NTP_SERVER" 10 5
+try_wait "timeout 10s ntpd -gq" 10 0
+systemctl start ntpd.service
+sleep 1
+ntpq -pn
+EOF
+chmod 755 {{ ntp_script }}
+./{{ ntp_script }} 0.europe.pool.ntp.org
+{% for _node in nodes %}
+{% if _node != master %}
+scp -o StrictHostKeyChecking=no {{ ntp_script }} {{ _node.name }}:
+{% endif %}
+{% endfor %}
+{% for _node in nodes %}
+{% if _node != master %}
+ssh -o StrictHostKeyChecking=no {{ _node.name }} ./{{ ntp_script }} master &
+{% endif %}
+{% endfor %}
+wait
+{% endif %} {# node == master #}
+{% endif %} {# version == "ses5" #}
+{% if version == "ses6" or version == "nautilus" %}
+systemctl enable chronyd.service
+cat > /etc/chrony.conf <<EOF
+{% if node == master %}
+pool 0.europe.pool.ntp.org iburst
+{% else %}
+pool master
+{% endif %}
+local stratum 10
+manual
+allow
+driftfile /var/lib/chrony/drift
+makestep 0.1 3
+rtcsync
+logdir /var/log/chrony
+EOF
+{% if node == master %}
+{% set chrony_script = "chrony_sync_start.sh" %}
+cat > {{ chrony_script }} << 'EOF'
+#!/bin/bash
+
+set -x
+
+function try_wait {
+    local cmd="$1"
+    local tries="$2"
+    local sleep_secs="$3"
+    set +x
+    for i in $(seq 1 "$tries") ; do
+        set -x
+        $cmd
+        set +x
+        SAVED_STATUS="$?"
+        test "$SAVED_STATUS" = "0" && break
+        set -x
+        sleep "$sleep_secs"
+        set +x
+    done
+    set -x
+}
+
+systemctl start chronyd.service
+chronyc makestep
+stdbuf -o0 chronyc waitsync
+try_wait "chronyc -n sources" 10 5
+EOF
+chmod 755 {{ chrony_script }}
+./{{ chrony_script }}
+{% for _node in nodes %}
+{% if _node != master %}
+scp -o StrictHostKeyChecking=no {{ chrony_script }} {{ _node.name }}:
+{% endif %}
+{% endfor %}
+{% for _node in nodes %}
+{% if _node != master %}
+CURRENT_TIME="$(date --iso=seconds)"
+ssh -o StrictHostKeyChecking=no {{ _node.name }} date --set "$CURRENT_TIME"
+ssh -o StrictHostKeyChecking=no {{ _node.name }} ./{{ chrony_script }} &
+{% endif %}
+{% endfor %}
+wait
+{% endif %} {# node == master #}
+{% endif %} {# if version == "ses6" or version == "nautilus" #}


### PR DESCRIPTION
Until now, `--qa-test` and `sesdev qa-test` have only worked when ceph-salt is used for deployment, but there is no good reason for that.