### PR TITLE
seslib: force ses5 prometheus node to master

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1490,7 +1490,7 @@ class Deployment():
             )
 
     def _find_service_node(self, service):
-        if service == 'grafana' and self.settings.version == 'ses5':
+        if service in ('prometheus', 'grafana') and self.settings.version == 'ses5':
             return 'master'
         nodes = [name for name, node in self.nodes.items() if service in node.roles]
         return nodes[0] if nodes else None


### PR DESCRIPTION
The DeepSea version that is shipped with SES5 does not have any
"prometheus" or "grafana" roles. It always deploys these services and
there is no easy way to prevent it from doing that.

For port-forwarding purposes, sesdev forces the grafana node to be
"master" in ses5 deployments, and it should have been doing this for
prometheus as well.

Fixes: https://github.com/SUSE/sesdev/issues/231
Signed-off-by: Nathan Cutler <ncutler@suse.com>