### PR TITLE
sesdev: make deployment_id argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,9 @@ system, run the following command:
 $ sesdev create nautilus --single-node mini
 ```
 
-The `mini` argument is the ID of the deployment. You can create many deployments
-by giving them different IDs.
+The `mini` argument is the ID of the deployment. It is optional: if you omit it,
+sesdev will assign an ID as it sees fit. You can create many deployments by
+giving them different IDs.
 
 If you would like to start the cluster VMs on a remote server via libvirt/SSH,
 create a configuration file `$HOME/.sesdev/config.yaml` with the following
@@ -344,7 +345,7 @@ gateway, an NFS-Ganesha gateway, and an RGW gateway.
 
 ```
 $ sesdev create nautilus --roles="[master, mon], [bootstrap, storage, mon, mgr, mds], \
-  [storage, mon, mgr, mds], [igw, ganesha, rgw]" big_cluster
+  [storage, mon, mgr, mds], [igw, ganesha, rgw]"
 ```
 
 #### Custom zypper repo (to be added together with the default repos)
@@ -357,7 +358,7 @@ to all the VMs prior to deployment. In such a case, add one or more `--repo`
 options to the command line, e.g.:
 
 ```
-$ sesdev create nautilus --single-node --repo [URL_OF_REPO] mini
+$ sesdev create nautilus --single-node --repo [URL_OF_REPO]
 ```
 
 By default, the custom repo(s) will be added with an elevated priority,
@@ -463,8 +464,7 @@ sesdev create octopus \
     --ceph-salt-repo https://github.com/ceph/ceph-salt.git \
     --ceph-salt-branch master \
     --qa-test \
-    --single-node \
-    octopus
+    --single-node
 ```
 
 ##### octopus from filesystems:ceph:octopus:upstream
@@ -482,8 +482,7 @@ sesdev create ses7 \
     --ceph-salt-repo https://github.com/ceph/ceph-salt.git \
     --ceph-salt-branch master \
     --qa-test \
-    --single-node \
-    ses7
+    --single-node
 ```
 
 Note that this will work even if there is no ceph package visible at

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -164,6 +164,15 @@ def _abort_if_false(ctx, _, value):
         ctx.abort()
 
 
+def _maybe_gen_dep_id(version, dep_id, settings_dict):
+    if not dep_id:
+        single_node = settings_dict['single_node'] if 'single_node' in settings_dict else False
+        dep_id = version
+        if single_node:
+            dep_id += "_mini"
+    return dep_id
+
+
 @click.group()
 @click.option('-w', '--work-path', required=False,
               type=click.Path(exists=True, dir_okay=True, file_okay=False),
@@ -575,7 +584,9 @@ def _create_command(deployment_id, deploy, settings_dict):
     settings = seslib.Settings(**settings_dict)
     dep = seslib.Deployment.create(deployment_id, settings)
     really_want_to = None
-    click.echo("=== Creating deployment with the following configuration ===")
+    click.echo("=== Creating deployment \"{}\" with the following configuration ==="
+               .format(deployment_id)
+               )
     click.echo(dep.status())
     if deploy:
         if getattr(settings, 'non_interactive', False):
@@ -618,7 +629,7 @@ def _create_command(deployment_id, deploy, settings_dict):
 
 
 @create.command()
-@click.argument('deployment_id')
+@click.argument('deployment_id', required=False)
 @common_create_options
 @deepsea_options
 @libvirt_options
@@ -627,11 +638,12 @@ def ses5(deployment_id, deploy, **kwargs):
     Creates a SES5 cluster using SLES-12-SP3
     """
     settings_dict = _gen_settings_dict('ses5', **kwargs)
+    deployment_id = _maybe_gen_dep_id('ses5', deployment_id, settings_dict)
     _create_command(deployment_id, deploy, settings_dict)
 
 
 @create.command()
-@click.argument('deployment_id')
+@click.argument('deployment_id', required=False)
 @common_create_options
 @deepsea_options
 @libvirt_options
@@ -640,11 +652,12 @@ def ses6(deployment_id, deploy, **kwargs):
     Creates a SES6 cluster using SLES-15-SP1
     """
     settings_dict = _gen_settings_dict('ses6', **kwargs)
+    deployment_id = _maybe_gen_dep_id('ses6', deployment_id, settings_dict)
     _create_command(deployment_id, deploy, settings_dict)
 
 
 @create.command()
-@click.argument('deployment_id')
+@click.argument('deployment_id', required=False)
 @common_create_options
 @deepsea_options
 @ceph_salt_options
@@ -653,30 +666,33 @@ def ses6(deployment_id, deploy, **kwargs):
               help="Use deepsea to deploy SES7 instead of cephadm")
 def ses7(deployment_id, deploy, use_deepsea, **kwargs):
     """
-    Creates a SES7 cluster using SLES-15-SP2
+    Creates a SES7 cluster using SLES-15-SP2 and packages (and container image)
+    from the Devel:Storage:7.0 IBS project
     """
     settings_dict = _gen_settings_dict('ses7', **kwargs)
+    deployment_id = _maybe_gen_dep_id('ses7', deployment_id, settings_dict)
     if use_deepsea:
         settings_dict['deployment_tool'] = 'deepsea'
     _create_command(deployment_id, deploy, settings_dict)
 
 
 @create.command()
-@click.argument('deployment_id')
+@click.argument('deployment_id', required=False)
 @common_create_options
 @deepsea_options
 @libvirt_options
 def nautilus(deployment_id, deploy, **kwargs):
     """
     Creates a Ceph Nautilus cluster using openSUSE Leap 15.1 and packages
-    from filesystems:ceph:nautilus OBS project.
+    from filesystems:ceph:nautilus OBS project
     """
     settings_dict = _gen_settings_dict('nautilus', **kwargs)
+    deployment_id = _maybe_gen_dep_id('nautilus', deployment_id, settings_dict)
     _create_command(deployment_id, deploy, settings_dict)
 
 
 @create.command()
-@click.argument('deployment_id')
+@click.argument('deployment_id', required=False)
 @common_create_options
 @deepsea_options
 @ceph_salt_options
@@ -686,16 +702,17 @@ def nautilus(deployment_id, deploy, **kwargs):
 def octopus(deployment_id, deploy, use_deepsea, **kwargs):
     """
     Creates a Ceph Octopus cluster using openSUSE Leap 15.2 and packages
-    from filesystems:ceph:octopus OBS project.
+    (and container image) from filesystems:ceph:octopus:upstream OBS project
     """
     settings_dict = _gen_settings_dict('octopus', **kwargs)
+    deployment_id = _maybe_gen_dep_id('octopus', deployment_id, settings_dict)
     if use_deepsea:
         settings_dict['deployment_tool'] = 'deepsea'
     _create_command(deployment_id, deploy, settings_dict)
 
 
 @create.command()
-@click.argument('deployment_id')
+@click.argument('deployment_id', required=False)
 @common_create_options
 @deepsea_options
 @ceph_salt_options
@@ -705,16 +722,17 @@ def octopus(deployment_id, deploy, use_deepsea, **kwargs):
 def pacific(deployment_id, deploy, use_deepsea, **kwargs):
     """
     Creates a Ceph Pacific cluster using openSUSE Leap 15.2 and packages
-    from filesystems:ceph:master:upstream OBS project.
+    (and container image) from filesystems:ceph:master:upstream OBS project
     """
     settings_dict = _gen_settings_dict('pacific', **kwargs)
+    deployment_id = _maybe_gen_dep_id('pacific', deployment_id, settings_dict)
     if use_deepsea:
         settings_dict['deployment_tool'] = 'deepsea'
     _create_command(deployment_id, deploy, settings_dict)
 
 
 @create.command()
-@click.argument('deployment_id')
+@click.argument('deployment_id', required=False)
 @common_create_options
 @libvirt_options
 @click.option("--deploy-ses", is_flag=True, default=False,
@@ -726,6 +744,7 @@ def caasp4(deployment_id, deploy, deploy_ses, **kwargs):
     if kwargs['num_disks'] is None:
         kwargs['num_disks'] = 2 if deploy_ses else 0
     settings_dict = _gen_settings_dict('caasp4', **kwargs)
+    deployment_id = _maybe_gen_dep_id('caasp4', deployment_id, settings_dict)
     if deploy_ses:
         settings_dict['caasp_deploy_ses'] = True
     _create_command(deployment_id, deploy, settings_dict)


### PR DESCRIPTION
When one is accustomed to creating and destroying lots of clusters,
it can be tiresome to type in the deployment_id argument, always the
same one, for each invocation.

Make the argument optional and have it default to something sane.

Signed-off-by: Nathan Cutler <ncutler@suse.com>