### PR TITLE
Implement feature "sesdev create makecheck"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the VMs and run the deployment scripts.
    * [Install sesdev from source](#install-sesdev-from-source)
       * [Running the unit tests](#running-the-unit-tests)
 * [Usage](#usage)
-   * [Create/deploy a cluster](#createdeploy-a-cluster)
+   * [Create/deploy a Ceph cluster](#createdeploy-a-ceph-cluster)
       * [On a remote libvirt server via SSH](#on-a-remote-libvirt-server-via-ssh)
       * [With an additional custom zypper repo](#with-an-additional-custom-zypper-repo)
       * [With a set of custom zypper repos completely replacing the default repos](#with-a-set-of-custom-zypper-repos-completely-replacing-the-default-repos)
@@ -33,7 +33,7 @@ the VMs and run the deployment scripts.
       * [With custom default roles](#with-custom-default-roles)
       * [config.yaml examples](#configyaml-examples)
          * [octopus from filesystems:ceph:octopus](#octopus-from-filesystemscephoctopus)
-         * [octopus from filesystems:ceph:master:upstream](#octopus-from-filesystemscephmasterupstream)
+         * [octopus from filesystems:ceph:octopus:upstream](#octopus-from-filesystemscephoctopusupstream)
          * [ses7 from Devel:Storage:7.0](#ses7-from-develstorage70)
          * [ses7 from Devel:Storage:7.0:CR](#ses7-from-develstorage70cr)
    * [List existing deployments](#list-existing-deployments)
@@ -42,6 +42,11 @@ the VMs and run the deployment scripts.
    * [Services port-forwarding](#services-port-forwarding)
    * [Temporarily stop a cluster](#temporarily-stop-a-cluster)
    * [Destroy a cluster](#destroy-a-cluster)
+   * [Run "make check"](#run-make-check)
+      * [Run "make check" on Tumbleweed from upstream "master" branch](#run-make-check-on-tumbleweed-from-upstream-master-branch)
+      * [Run "make check" on openSUSE Leap 15.2 from upstream "octopus" branch](#run-make-check-on-opensuse-leap-152-from-upstream-octopus-branch)
+      * [Run "make check" on SLE-15-SP2 from downstream "ses7" branch](#run-make-check-on-sle-15-sp2-from-downstream-ses7-branch)
+      * [Other "make check" scenarios](#other-make-check-scenarios)
 * [Common pitfalls](#common-pitfalls)
    * [Domain about to create is already taken](#domain-about-to-create-is-already-taken)
    * [Storage pool not found: no storage pool with matching name 'default'](#storage-pool-not-found-no-storage-pool-with-matching-name-default)
@@ -282,7 +287,7 @@ tox -e py36,lint
 Run `sesdev --help` or `sesdev <command> --help` to get the available
 options and description of the commands.
 
-### Create/deploy a cluster
+### Create/deploy a Ceph cluster
 
 To create a single node Ceph cluster based on nautilus/leap-15.1 on your local
 system, run the following command:
@@ -579,6 +584,65 @@ $ sesdev destroy <deployment_id>
 It has been reported that vagrant-libvirt sometimes leaves networks behind when
 destroying domains (i.e. the VMs associated with a sesdev deployment). If this
 bothers you, `sesdev destroy` has a `--destroy-networks` option you can use.
+
+### Run "make check"
+
+If your libvirtd machine has enough memory, you can use sesdev to run "make
+check" in various environments. Use
+
+```
+$ sesdev create makecheck --help
+```
+
+to see the available options.
+
+RAM CAVEAT: the default RAM amount for the makecheck might not be sufficient.
+If you have plenty of memory on your libvirtd machine, running with higher
+values of `--ram` (the higher, the better) is recommended.
+
+CPUS CAVEAT: using the `--cpus` option, it is also possible increase the number
+of (virtual) CPUs available for the build, but values greater than four have not
+been well tested.
+
+The `sesdev create makecheck` command will (1) deploy a VM, (2) create an
+"ordinary" (non-root) user with passwordless sudo privileges and, as this
+user (3) clone the specified Ceph repo and check out the specified branch,
+(4) run `install-deps.sh`, and (5) run `run-make-check.sh`.
+
+The following sub-sections provide instructions on how to reproduce some
+common "make check" scenarios.
+
+#### Run "make check" on Tumbleweed from upstream "master" branch
+
+This is the default. Just:
+
+```
+$ sesdev create makecheck
+```
+
+#### Run "make check" on openSUSE Leap 15.2 from upstream "octopus" branch
+
+```
+$ sesdev create makecheck --os leap-15.2 --ceph-branch octopus
+```
+
+(It is not necessary to give `--ceph-repo https://github.com/ceph/ceph` here,
+since that is the default.)
+
+#### Run "make check" on SLE-15-SP2 from downstream "ses7" branch
+
+```
+$ sesdev create makecheck --os sles-15-sp2 \
+      --ceph-repo https://github.com/SUSE/ceph \
+      --ceph-branch ses7
+```
+
+#### Other "make check" scenarios
+
+More combinations are supported than are described here. Compiling
+the respective `sesdev create makecheck` commands for these environments is left
+as an exercise for the reader.
+
 
 ## Common pitfalls
 

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -118,6 +118,7 @@ if [ "$ALL" ] ; then
 fi
 
 if [ "$SES5" ] ; then
+    run_cmd sesdev box remove --non-interactive sles-12-sp3 || true
     # deploy ses5 without igw, so as not to hit https://github.com/SUSE/sesdev/issues/239
     run_cmd sesdev create ses5 --non-interactive --roles [master,storage,mon,mgr,mds,rgw,nfs] --qa-test ses5-1node
     run_cmd sesdev destroy --non-interactive ses5-1node
@@ -127,6 +128,7 @@ if [ "$SES5" ] ; then
 fi
 
 if [ "$NAUTILUS" ] ; then
+    run_cmd sesdev box remove --non-interactive leap-15.1 || true
     run_cmd sesdev create nautilus --non-interactive --single-node --qa-test nautilus-1node
     run_cmd sesdev destroy --non-interactive nautilus-1node
     run_cmd sesdev create nautilus --non-interactive nautilus-4node
@@ -135,6 +137,7 @@ if [ "$NAUTILUS" ] ; then
 fi
 
 if [ "$SES6" ] ; then
+    run_cmd sesdev box remove --non-interactive sles-15-sp1 || true
     run_cmd sesdev create ses6 --non-interactive --single-node --qa-test ses6-1node
     run_cmd sesdev destroy --non-interactive ses6-1node
     run_cmd sesdev create ses6 --non-interactive ses6-4node
@@ -143,6 +146,7 @@ if [ "$SES6" ] ; then
 fi
 
 if [ "$OCTOPUS" ] ; then
+    run_cmd sesdev box remove --non-interactive leap-15.2 || true
     run_cmd sesdev create octopus --non-interactive $CEPH_SALT_FROM_SOURCE --single-node --qa-test octopus-1node
     run_cmd sesdev destroy --non-interactive octopus-1node
     run_cmd sesdev create octopus --non-interactive $CEPH_SALT_FROM_SOURCE octopus-4node
@@ -151,6 +155,7 @@ if [ "$OCTOPUS" ] ; then
 fi
 
 if [ "$SES7" ] ; then
+    run_cmd sesdev box remove --non-interactive sles-15-sp2 || true
     run_cmd sesdev create ses7 --non-interactive $CEPH_SALT_FROM_SOURCE --single-node --qa-test ses7-1node
     run_cmd sesdev destroy --non-interactive ses7-1node
     run_cmd sesdev create ses7 --non-interactive $CEPH_SALT_FROM_SOURCE ses7-4node
@@ -159,19 +164,24 @@ if [ "$SES7" ] ; then
 fi
 
 if [ "$PACIFIC" ] ; then
+    run_cmd sesdev box remove --non-interactive leap-15.2 || true
     run_cmd sesdev create pacific --non-interactive $CEPH_SALT_FROM_SOURCE --single-node --qa-test pacific-1node
     run_cmd sesdev destroy --non-interactive pacific-1node
-    run_cmd sesdev create pacific --non-interactive $CEPH_SALT_FROM_SOURCE pacific-4node
-    run_cmd sesdev qa-test pacific-4node
-    run_cmd sesdev destroy --non-interactive pacific-4node
+    # commented out pending resolution of https://tracker.ceph.com/issues/45093
+    # run_cmd sesdev create pacific --non-interactive $CEPH_SALT_FROM_SOURCE pacific-4node
+    # run_cmd sesdev qa-test pacific-4node
+    # run_cmd sesdev destroy --non-interactive pacific-4node
 fi
 
 if [ "$MAKECHECK" ] ; then
-    # run_cmd sesdev create makecheck --non-interactive --stop-before-run-make-check --ram 4
-    # run_cmd sesdev create makecheck --non-interactive --os sles-12-sp3 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses5 --stop-before-run-make-check --ram 4
-    # run_cmd sesdev create makecheck --non-interactive --os sles-15-sp1 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses6 --stop-before-run-make-check --ram 4
-    # run_cmd sesdev create makecheck --non-interactive --os sles-15-sp2 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses7 --stop-before-run-make-check --ram 4
-    true
+    run_cmd sesdev create makecheck --non-interactive --stop-before-run-make-check --ram 4
+    run_cmd sesdev destroy --non-interactive makecheck_tumbleweed
+    run_cmd sesdev create makecheck --non-interactive --os sles-12-sp3 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses5 --stop-before-run-make-check --ram 4
+    run_cmd sesdev destroy --non-interactive makecheck_sles-12-sp3
+    run_cmd sesdev create makecheck --non-interactive --os sles-15-sp1 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses6 --stop-before-run-make-check --ram 4
+    run_cmd sesdev destroy --non-interactive makecheck_sles-15-sp1
+    run_cmd sesdev create makecheck --non-interactive --os sles-15-sp2 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses7 --stop-before-run-make-check --ram 4
+    run_cmd sesdev destroy --non-interactive makecheck_sles-15-sp2
 fi
 
 final_report

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -449,10 +449,18 @@ def _gen_settings_dict(version,
                        deploy_mgrs=None,
                        deploy_osds=None,
                        deploy_mdss=None,
+                       ceph_repo=None,
+                       ceph_branch=None,
+                       username=None,
+                       stop_before_git_clone=None,
+                       stop_before_install_deps=None,
+                       stop_before_run_make_check=None,
                        ):
 
     settings_dict = {}
-    if not single_node and roles:
+    if version == 'makecheck':
+        settings_dict['roles'] = _parse_roles("[ makecheck ]")
+    elif not single_node and roles:
         settings_dict['roles'] = _parse_roles(roles)
     elif single_node:
         if version in ['ses7', 'octopus', 'pacific']:
@@ -478,9 +486,15 @@ def _gen_settings_dict(version,
 
     if cpus:
         settings_dict['cpus'] = cpus
+        settings_dict['explicit_cpus'] = True
+    else:
+        settings_dict['explicit_cpus'] = False
 
     if ram:
         settings_dict['ram'] = ram
+        settings_dict['explicit_ram'] = True
+    else:
+        settings_dict['explicit_ram'] = False
 
     if num_disks:
         settings_dict['num_disks'] = num_disks
@@ -578,6 +592,24 @@ def _gen_settings_dict(version,
 
     if image_path:
         settings_dict['image_path'] = image_path
+
+    if ceph_repo:
+        settings_dict['makecheck_ceph_repo'] = ceph_repo
+
+    if ceph_branch:
+        settings_dict['makecheck_ceph_branch'] = ceph_branch
+
+    if username:
+        settings_dict['makecheck_username'] = username
+
+    if stop_before_git_clone:
+        settings_dict['makecheck_stop_before_git_clone'] = stop_before_git_clone
+
+    if stop_before_install_deps:
+        settings_dict['makecheck_stop_before_install_deps'] = stop_before_install_deps
+
+    if stop_before_run_make_check:
+        settings_dict['makecheck_stop_before_run_make_check'] = stop_before_run_make_check
 
     if cephadm_bootstrap:
         settings_dict['ceph_salt_cephadm_bootstrap'] = True
@@ -794,6 +826,33 @@ def caasp4(deployment_id, deploy, deploy_ses, **kwargs):
     deployment_id = _maybe_gen_dep_id('caasp4', deployment_id, settings_dict)
     if deploy_ses:
         settings_dict['caasp_deploy_ses'] = True
+    _create_command(deployment_id, deploy, settings_dict)
+
+
+@create.command()
+@click.argument('deployment_id', required=False)
+@common_create_options
+@libvirt_options
+@click.option("--ceph-repo", default='https://github.com/ceph/ceph',
+              help='repo from which to clone Ceph source code')
+@click.option("--ceph-branch", default='master',
+              help='ceph branch on which to run "make check"')
+@click.option("--username", default='sesdev',
+              help='name of ordinary user that will run make check')
+@click.option("--stop-before-git-clone", is_flag=True, default=False,
+              help="Stop before cloning the git repo")
+@click.option("--stop-before-install-deps", is_flag=True, default=False,
+              help="Stop before running install-deps.sh")
+@click.option("--stop-before-run-make-check", is_flag=True, default=False,
+              help="Stop before running run-make-check.sh")
+def makecheck(deployment_id, deploy, **kwargs):
+    """
+    Creates a makecheck cluster
+    """
+    settings_dict = _gen_settings_dict('makecheck', **kwargs)
+    if not deployment_id:
+        os = settings_dict['os'] if 'os' in settings_dict else 'tumbleweed'
+        deployment_id = 'makecheck_{}'.format(os)
     _create_command(deployment_id, deploy, settings_dict)
 
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -7,7 +7,8 @@ from os.path import isabs, exists, isdir
 import click
 import pkg_resources
 import seslib
-from seslib.exceptions import SesDevException, OptionFormatError, OptionValueError
+from seslib.exceptions import SesDevException, OptionFormatError, OptionValueError, \
+                              VersionNotKnown
 
 
 logger = logging.getLogger(__name__)
@@ -458,25 +459,22 @@ def _gen_settings_dict(version,
                        ):
 
     settings_dict = {}
+
     if version == 'makecheck':
         settings_dict['roles'] = _parse_roles("[ makecheck ]")
     elif not single_node and roles:
         settings_dict['roles'] = _parse_roles(roles)
     elif single_node:
+        roles_string = ""
         if version in ['ses7', 'octopus', 'pacific']:
-            settings_dict['roles'] = _parse_roles(
-                "[ master, bootstrap, storage, mon, mgr, prometheus, grafana, mds, "
-                "igw, rgw, nfs ]"
-                )
+            roles_string = seslib.GlobalSettings.ROLES_SINGLE_NODE_OCTOPUS
+        elif version in ['ses6', 'nautilus']:
+            roles_string = seslib.GlobalSettings.ROLES_SINGLE_NODE_NAUTILUS
         elif version in ['ses5']:
-            settings_dict['roles'] = _parse_roles(
-                "[ master, storage, mon, mgr, mds, igw, rgw, nfs ]"
-                )
+            roles_string = seslib.GlobalSettings.ROLES_SINGLE_NODE_LUMINOUS
         else:
-            settings_dict['roles'] = _parse_roles(
-                "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
-                "nfs ]"
-                )
+            raise VersionNotKnown(version)
+        settings_dict['roles'] = _parse_roles(roles_string)
 
     if single_node:
         settings_dict['single_node'] = single_node

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -36,6 +36,17 @@ class GlobalSettings():
     CONFIG_FILE = os.path.join(A_WORKING_DIR, 'config.yaml')
     DEBUG = False
     MAKECHECK_DEFAULT_RAM = 8
+    ROLES_SINGLE_NODE_LUMINOUS = (
+        "[ master, storage, mon, mgr, mds, igw, rgw, nfs, openattic ]"
+        )
+    ROLES_SINGLE_NODE_NAUTILUS = (
+        "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
+        "nfs ]"
+        )
+    ROLES_SINGLE_NODE_OCTOPUS = (
+        "[ master, bootstrap, storage, mon, mgr, prometheus, grafana, mds, "
+        "igw, rgw, nfs ]"
+        )
     SSH_KEY_NAME = 'sesdev'  # do NOT use 'id_rsa'
     VAGRANT_DEBUG = False
 
@@ -916,10 +927,6 @@ class Deployment():
         self.suma = None
         self.box = Box(settings)
 
-        if self.settings.version == 'ses5' and self.settings.roles and self.settings.single_node:
-            new_roles = self.settings.roles
-            new_roles[0].append("openattic")
-            self.settings.override('roles', new_roles)
         if self.settings.roles:
             pass
         else:

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -153,3 +153,12 @@ class SupportconfigOnlyOnSLE(SesDevException):
             "sesdev supportconfig depends on the 'supportconfig' RPM, which is "
             "available only on SUSE Linux Enterprise"
             )
+
+
+class BadMakeCheckRolesNodes(SesDevException):
+    def __init__(self):
+        super(BadMakeCheckRolesNodes, self).__init__(
+            "\"makecheck\" deployments only work with a single node with role "
+            "\"makecheck\". Since this is the default, you can simply omit "
+            "the --roles option when running \"sesdev create makecheck\"."
+            )

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -25,6 +25,12 @@ class DeploymentDoesNotExists(SesDevException):
             "Deployment '{}' does not exist".format(dep_id))
 
 
+class VersionNotKnown(SesDevException):
+    def __init__(self, version):
+        super(VersionNotKnown, self).__init__(
+            "Unknown deployment version: '{}'".format(version))
+
+
 class VersionOSNotSupported(SesDevException):
     def __init__(self, version, os):
         super(VersionOSNotSupported, self).__init__(

--- a/seslib/templates/caasp/provision.sh.j2
+++ b/seslib/templates/caasp/provision.sh.j2
@@ -1,3 +1,6 @@
+
+set -ex
+
 useradd -m sles
 usermod -v 10000000-20000000 -w 10000000-20000000 sles
 

--- a/seslib/templates/makecheck/provision.sh.j2
+++ b/seslib/templates/makecheck/provision.sh.j2
@@ -1,0 +1,35 @@
+
+set -ex
+
+useradd -m {{ makecheck_username }}
+echo "{{ makecheck_username }} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+pam-config -a --nullok
+passwd -d {{ makecheck_username }}
+cat << 'EOF' > /root/.bashrc
+#!/bin/bash
+CLONE_DIR="/home/{{ makecheck_username }}/ceph"
+if [ -d "$CLONE_DIR" ] ; then
+    echo "ceph source code repo can be found in $CLONE_DIR"
+fi
+echo "Starting a login shell as user {{ makecheck_username }} ..."
+su - {{ makecheck_username }}
+EOF
+
+{% if makecheck_stop_before_git_clone %}
+exit 0
+{% endif %}
+{% if os == "sles-12-sp3" %}
+su {{ makecheck_username }} -c 'git config --global http.sslVerify false'
+{% endif %}
+su {{ makecheck_username }} -c 'git clone --branch {{ makecheck_ceph_branch }} --progress {{ makecheck_ceph_repo }} /home/{{ makecheck_username }}/ceph'
+
+{% if makecheck_stop_before_install_deps %}
+exit 0
+{% endif %}
+
+su {{ makecheck_username }} -c 'cd /home/{{ makecheck_username }}/ceph ; sed -i -e "s/^set -e$/set -ex/" install-deps.sh ; FOR_MAKE_CHECK=true ./install-deps.sh'
+
+{% if makecheck_stop_before_run_make_check %}
+exit 0
+{% endif %}
+su {{ makecheck_username }} -c 'cd /home/{{ makecheck_username }}/ceph ; sed -i -e "s/^set -e$/set -ex/" run-make-check.sh ; ./run-make-check.sh'

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -39,12 +39,12 @@ zypper addrepo
 
 {% if os.startswith("sle") %}
 zypper addrepo --refresh
-{%- if version == 'ses7' %}
+{%- if os == 'sles-15-sp2' %}
  http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo
-{%- elif version == 'ses6' or version == 'caasp4' %}
+{%- elif os == 'sles-15-sp1' %}
  http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo
-{%- elif version == 'ses5' %}
- http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo
+{%- elif os == 'sles-12-sp3' %}
+ http://download.suse.de/ibs/SUSE:/CA/SLE_12_SP3/SUSE:CA.repo
 {% endif %}
 {% endif %}
 
@@ -66,7 +66,7 @@ zypper --non-interactive install --from update --force libncurses5 libncurses6
        'man',
        'command-not-found',
    ] %}
-{% if version == 'ses5' %}
+{% if os == 'sles-12-sp3' %}
 zypper -n install {{ basic_pkgs_to_install | join(' ') }} ntp
 {% else %}
 zypper -n install {{ basic_pkgs_to_install | join(' ') }} chrony hostname

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -102,9 +102,9 @@ hostnamectl set-hostname {{ node.name }}
 
 {% if version == 'caasp4' %}
 {% include "caasp/provision.sh.j2" %}
-{% endif %}
-
-{% if not suma and version != "caasp4" %}
+{% elif version == 'makecheck' %}
+{% include "makecheck/provision.sh.j2" %}
+{% elif not suma %}
 zypper -n install salt-minion
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
 
@@ -118,7 +118,7 @@ systemctl start salt-minion
 {% include "sync_clocks.sh.j2" ignore missing %}
 {% endif %}
 
-{% endif %} {# not suma and version != "caasp4" #}
+{% endif %} {# not suma #}
 
 touch /tmp/ready
 


### PR DESCRIPTION
When the command is issued, sesdev will create and provision a single
VM, and inside that VM it will create an ordinary user and grant it
passwordless sudo privileges. That user will then clone the git repo,
check out the branch, and run install-deps.sh and run-make-check.sh
inside it.

Originally, this feature was envisioned as "sesdev make-check VERSION",
but during the course of implementation the following was found to be
more expedient:

    sesdev create makecheck \
        --os leap-15.2 \
        --ceph-repo https://github.com/ceph/ceph \
        --ceph-branch octopus

(The main reason is that "make check" is tied more to operating system
than to SES version.)

Fixes: https://github.com/SUSE/sesdev/issues/82
Signed-off-by: Nathan Cutler <ncutler@suse.com>