### PR TITLE
Stop, start, and destroy globbing

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -818,6 +818,7 @@ def destroy(deployment_id, non_interactive, destroy_networks):
                      deployment_id,
                      destroy_networks)
         dep.destroy(_print_log, destroy_networks)
+        click.echo("Deployment {} destroyed!".format(dep.dep_id))
 
 
 @cli.command()
@@ -929,6 +930,7 @@ def stop(deployment_id, node=None):
         node = None
     for dep in matching_deployments:
         dep.stop(_print_log, node)
+        click.echo("Deployment {} stopped!".format(dep.dep_id))
 
 
 @cli.command()
@@ -952,6 +954,7 @@ def start(deployment_id, node=None):
         node = None
     for dep in matching_deployments:
         dep.start(_print_log, node)
+        click.echo("Deployment {} started!".format(dep.dep_id))
 
 
 @cli.command()

--- a/tests/test_is_a_glob.py
+++ b/tests/test_is_a_glob.py
@@ -1,0 +1,11 @@
+import pytest
+
+from sesdev import _is_a_glob
+
+def test_pytest_is_a_glob():
+    assert _is_a_glob("*"), "test failed"
+    assert _is_a_glob("foo*"), "test failed"
+    assert _is_a_glob("node[123]"), "test failed"
+    assert _is_a_glob("{foo,bar}"), "test failed"
+    assert not _is_a_glob("bamboozle"), "test failed"
+    assert _is_a_glob("node?"), "test failed"


### PR DESCRIPTION
The idea behind this commit is that commands like "sesdev stop" should
do something reasonable if called like this:

    sesdev stop '*'

Fixes: https://github.com/SUSE/sesdev/issues/193
Signed-off-by: Nathan Cutler <ncutler@suse.com>