### PR TITLE
provision.sh: reinstall certain packages from the update repos

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -48,7 +48,12 @@ zypper addrepo --refresh
 {% endif %}
 {% endif %}
 
-zypper --gpg-auto-import-keys ref
+zypper --gpg-auto-import-keys refresh
+
+{% if os == "sles-12-sp3" %}
+zypper --non-interactive install --from storage-update --force python-base python-xml
+zypper --non-interactive install --from update --force libncurses5 libncurses6
+{% endif %}
 
 {% set basic_pkgs_to_install = [
        'vim',
@@ -83,7 +88,7 @@ zypper mr -p {{ repo.priority }} {{ repo.name }}
 {% endif %}
 {% endfor %}
 {% if node.repos|length > 0 %}
-zypper --gpg-auto-import-keys ref
+zypper --gpg-auto-import-keys refresh
 {% endif %}
 
 cat /home/vagrant/.ssh/{{ ssh_key_name }}.pub >> /home/vagrant/.ssh/authorized_keys


### PR DESCRIPTION
The SLE-12-SP3 Vagrant Box has newer versions of the python-base,
python-xml, libncurses5, and libncurses6 packages than are available in
the standard repos. This is a Bad Thing and, I might add, a bug in the
SLE-12-SP3 Vagrant Box. It also makes install-deps.sh fail. Work around
the bug by reverting these four packages to the latest version that is
in the repos.

Fixes: https://github.com/SUSE/sesdev/issues/242
Signed-off-by: Nathan Cutler <ncutler@suse.com>