### PR TITLE
ceph_salt_deployment: do not provision client-only nodes

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -447,10 +447,14 @@ def _gen_settings_dict(version,
     if not single_node and roles:
         settings_dict['roles'] = _parse_roles(roles)
     elif single_node:
-        if version in ('ses7', 'octopus', 'pacific'):
+        if version in ['ses7', 'octopus', 'pacific']:
             settings_dict['roles'] = _parse_roles(
                 "[ master, bootstrap, storage, mon, mgr, prometheus, grafana, mds, "
                 "igw, rgw, ganesha ]"
+                )
+        elif version in ['ses5']:
+            settings_dict['roles'] = _parse_roles(
+                "[ master, bootstrap, storage, mon, mgr, mds, igw, rgw, ganesha ]"
                 )
         else:
             settings_dict['roles'] = _parse_roles(

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -124,28 +124,34 @@ def common_create_options(func):
 
 
 def _parse_roles(roles):
-    roles = [r.strip() for r in roles.split(",")]
+    roles = "".join(roles.split())
+    if roles.startswith('[[') and roles.endswith(']]'):
+        roles = roles[1:-1]
+    roles = roles.split(",")
+    log_msg = "_parse_roles: raw roles from user: {}".format(roles)
+    logger.debug(log_msg)
+    log_msg = "_parse_roles: pre-processed roles array: {}".format(roles)
+    logger.debug(log_msg)
     _roles = []
     _node = None
     for role in roles:
-        role = role.strip()
         if role.startswith('['):
             _node = []
             if role.endswith(']'):
-                role = role[1:-1].strip()
-                _node.append(role)
-                _node = list(set(_node))  # eliminate duplicate roles
+                role = role[1:-1]
+                if role:
+                    _node.append(role)
+                    _node = list(set(_node))  # eliminate duplicate roles
                 _roles.append(_node)
             else:
-                role = role[1:].strip()
+                role = role[1:]
                 _node.append(role)
         elif role.endswith(']'):
-            role = role[:-1].strip()
+            role = role[:-1]
             _node.append(role)
             _node = list(set(_node))  # eliminate duplicate roles
             _roles.append(_node)
         else:
-            role = role.strip()
             _node.append(role)
     return _roles
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -142,6 +142,7 @@ def _parse_roles(roles):
                 if role:
                     _node.append(role)
                     _node = list(set(_node))  # eliminate duplicate roles
+                _node.sort()
                 _roles.append(_node)
             else:
                 role = role[1:]
@@ -150,6 +151,7 @@ def _parse_roles(roles):
             role = role[:-1]
             _node.append(role)
             _node = list(set(_node))  # eliminate duplicate roles
+            _node.sort()
             _roles.append(_node)
         else:
             _node.append(role)

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -760,9 +760,13 @@ class Node():
         return role in self.roles
 
     def has_roles(self):
+        log_msg = "Node {}: has_roles: self.roles: {}".format(self.fqdn, self.roles)
+        logger.debug(log_msg)
         return bool(self.roles)
 
     def has_exclusive_role(self, role):
+        log_msg = "Node {}: has_exclusive_role: self.roles: {}".format(self.fqdn, self.roles)
+        logger.debug(log_msg)
         if role not in KNOWN_ROLES:
             raise RoleNotKnown(role)
         return self.roles == [role]
@@ -1343,8 +1347,8 @@ class Deployment():
             if k == 'master':
                 result += "     - deployment_tool:  {}\n".format(self.settings.deployment_tool)
             result += "     - roles:            {}\n".format(v.roles)
-            if self.settings.version in ["octopus", "ses7", "master"]:
-                if 'admin' not in v.roles:
+            if self.settings.version in ["octopus", "ses7", "pacific"]:
+                if 'admin' not in v.roles and v.roles != [] and v.roles != ['client']:
                     result += (
                         "                         (CAVEAT: the 'admin' role is assumed"
                         " even though not explicitly given!)\n"

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -84,6 +84,12 @@ class ExclusiveRoles(SesDevException):
             .format(role_a, role_b))
 
 
+class RoleNotKnown(SesDevException):
+    def __init__(self, role):
+        super(RoleNotKnown, self).__init__(
+            "Role '{}' is not supported by sesdev".format(role))
+
+
 class RoleNotSupported(SesDevException):
     def __init__(self, role, version):
         super(RoleNotSupported, self).__init__(

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -61,8 +61,10 @@ type ceph-salt
 MON_NODES_COMMA_SEPARATED_LIST=""
 MGR_NODES_COMMA_SEPARATED_LIST=""
 {% for node in nodes %}
+{% if node.has_roles() and not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
+{% endif %}
 {% if node.has_role('bootstrap') %}
 ceph-salt config /ceph_cluster/roles/bootstrap set {{ node.fqdn }}
 {% endif %}

--- a/tests/test_sesdev_parse_roles.py
+++ b/tests/test_sesdev_parse_roles.py
@@ -1,0 +1,18 @@
+import pytest
+
+from sesdev import _parse_roles
+
+def test_pytest_parse_roles():
+    assert _parse_roles('[master]') == [["master"]], "test failed"
+    assert _parse_roles('[[master]]') == [["master"]], "test failed"
+    assert _parse_roles('[foo]') == [["foo"]], "test failed"
+    assert _parse_roles('[[foo]]') == [["foo"]], "test failed"
+    assert _parse_roles('[[foo],  []]') == [["foo"], []], "test failed"
+    assert _parse_roles('  [    [ ],[foo],  []]') == [[], ["foo"], []], "test failed"
+    assert _parse_roles("""
+      [ ],
+  [foo],
+  []
+""") == [[], ["foo"], []], "test failed"
+    assert _parse_roles('[bootstrap, fortel, client],[client]') == \
+        [["bootstrap", "client", "fortel"], ["client"]], "test failed"


### PR DESCRIPTION
ceph_salt_deployment.sh should not ask ceph-salt to provision:

- nodes with no roles at all
- nodes that have the "client" role and *only* the "client" role

because these nodes might be used later for QA testing.

---

seslib: refuse to process unknown roles

Also implement Node class helper methods "has_roles" and
"has_exclusive_role".

---

sesdev/_parse_roles: handle node with no roles

Fixes: https://github.com/SUSE/sesdev/issues/245

---

tests/test_sesdev_parse_roles.py: unit tests for _parse_roles