### PR TITLE
qa: better MGR counting

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -230,6 +230,14 @@ function maybe_wait_for_osd_nodes_test {
     echo
 }
 
+function mgr_is_available_test {
+    echo
+    echo "WWWW: mgr_is_available_test"
+    test "$(json_mgr_is_available)"
+    echo "mgr_is_available_test: OK"
+    echo
+}
+
 function number_of_nodes_actual_vs_expected_test {
     echo
     echo "WWWW: number_of_nodes_actual_vs_expected_test"

--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -14,16 +14,43 @@ function json_osd_nodes {
         jq '[.nodes[] | select(.type == "host")] | length'
 }
 
+function json_mgr_is_available {
+    if [ "$(ceph status --format json | jq -r .mgrmap.available)" = "true" ] ; then
+        echo "not_the_empty_string"
+    else
+        echo ""
+    fi
+}
+
 function json_total_mgrs {
+    #
+    # I have not found any straightforward way of obtaining the number of
+    # running MGRs from the "ceph status --format json" output. What I'm
+    # doing is:
+    #
+    # (1) if the mgrmap has "available: true" then "number of active MGRs"
+    #     is 1, otherwise 0
+    #
+    # (2) obtain the number of standby MGRs by consulting the mgrmap
+    #
+    # (3) total number of MGRs = number of active MGRs + number of standby MGRs
+    #
+    local ceph_status_json="$(ceph status --format json)"
+    local active_mgrs=""
+    if [ "$(echo "$ceph_status_json" | jq -r .mgrmap.available)" = "true" ] ; then
+        active_mgrs="1"
+    else
+        active_mgrs="0"
+    fi
     if [ "$VERSION_ID" = "15.2" ] ; then
         # SES7
-        echo "$(($(ceph status --format json | jq -r .mgrmap.num_standbys) + 1))"
+        echo "$(("$(echo "$ceph_status_json" | jq -r .mgrmap.num_standbys)" + "$active_mgrs"))"
     elif [ "$VERSION_ID" = "15.1" ] ; then
         # SES6
-        echo "$(($(ceph status --format json | jq -r ".mgrmap.standbys | length") + 1))"
+        echo "$(("$(echo "$ceph_status_json" | jq -r ".mgrmap.standbys | length")" + "$active_mgrs"))"
     elif [ "$VERSION_ID" = "12.3" ] ; then
         # SES5
-        echo "$(($(ceph status --format json | jq -r ".mgrmap.standbys | length") + 1))"
+        echo "$(("$(echo "$ceph_status_json" | jq -r ".mgrmap.standbys | length")" + "$active_mgrs"))"
     else
         echo "0"
     fi

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -116,5 +116,6 @@ ceph_rpm_version_test
 ceph_cluster_running_test
 ceph_daemon_versions_test "$STRICT_VERSIONS"
 ceph_health_test
+mgr_is_available_test
 maybe_wait_for_osd_nodes_test "$OSD_NODES"  # it might take a long time for OSD nodes to show up
 number_of_nodes_actual_vs_expected_test


### PR DESCRIPTION
I have not found any straightforward way of obtaining the number of
running MGRs from the "ceph status --format json" output. This commit
makes it more explicit how the MGR count is arrived at. First, a new
test is implemented, which fails if the mgrmap does not have "available:
false", since this seems like it would indicate a problem with the MGR
deployment. Second, iff that test passes, the total number of MGRs is
calculated as follows:

(1) if the mgrmap has "available: true" then "number of active MGRs"
    is 1, otherwise 0

(2) obtain the number of standby MGRs by consulting the mgrmap

(3) total number of MGRs = number of active MGRs + number of standby MGRs

Signed-off-by: Nathan Cutler <ncutler@suse.com>