### PR TITLE
ses7, octopus, pacific: Deploy MDSs

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The following roles can be assigned:
 * `admin` - signifying that the node should get ceph.conf and keyring [1]
 * `bootstrap` - The node where `cephadm bootstrap` will be run
 * `client` - Various Ceph client utilities
-* `ganesha` - NFS Ganesha service
+* `nfs` - NFS (Ganesha) gateway
 * `grafana` - Grafana metrics visualization (requires Prometheus) [2]
 * `igw` - iSCSI target gateway
 * `mds` - CephFS MDS
@@ -332,11 +332,11 @@ The following example will generate a cluster with four nodes: the master (Salt
 Master) node that is also running a MON daemon; a storage (OSD) node that
 will also run a MON, a MGR and an MDS and serve as the bootstrap node; another
 storage (OSD) node with MON, MGR, and MDS; and a fourth node that will run an iSCSI
-gateway, an NFS-Ganesha gateway, and an RGW gateway.
+gateway, an NFS (Ganesha) gateway, and an RGW gateway.
 
 ```
 $ sesdev create nautilus --roles="[master, mon], [bootstrap, storage, mon, mgr, mds], \
-  [storage, mon, mgr, mds], [igw, ganesha, rgw]"
+  [storage, mon, mgr, mds], [igw, nfs, rgw]"
 ```
 
 #### On a remote libvirt server via SSH

--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ the VMs and run the deployment scripts.
 * [Usage](#usage)
    * [Create/deploy a cluster](#createdeploy-a-cluster)
       * [On a remote libvirt server via SSH](#on-a-remote-libvirt-server-via-ssh)
-      * [With a custom zypper repo (to be added together with the default repos)](#with-a-custom-zypper-repo-to-be-a
-  ether-with-the-default-repos)
-      * [With custom zypper repos (completely replacing the default repos)](#with-custom-zypper-repos-completely-rep
-  he-default-repos)
+      * [With an additional custom zypper repo](#with-an-additional-custom-zypper-repo)
+      * [With a set of custom zypper repos completely replacing the default repos](#with-a-set-of-custom-zypper-repos-completely-replacing-the-default-repos)
       * [With custom image paths](#with-custom-image-paths)
       * [With custom default roles](#with-custom-default-roles)
       * [config.yaml examples](#configyaml-examples)
@@ -355,7 +353,7 @@ libvirt_host: <hostname|ip address>
 Note that passwordless SSH access to this user@host combination needs to be
 configured and enabled.
 
-#### With a custom zypper repo (to be added together with the default repos)
+#### With an additional custom zypper repo
 
 Each deployment version (e.g. "octopus", "nautilus") is associated with
 a set of zypper repos which are added on each VM that is created.
@@ -373,11 +371,11 @@ to ensure that packages from these repos will be installed even if higher
 RPM versions of those packages exist. If this behavior is not desired,
 add `--no-repo-priority` to disable it.
 
-#### With custom zypper repos (completely replacing the default repos)
+#### With a set of custom zypper repos completely replacing the default repos
 
-If the default zypper repos that are added to each VM
-prior to deployment are completely wrong for your use case, you can override
-them via `~/.sesdev/config.yaml`.
+If the default zypper repos that are added to each VM prior to deployment are
+completely wrong for your use case, you can override them via
+`~/.sesdev/config.yaml`.
 
 To do this, you have to be familiar with two of sesdev's internal dictionaries:
 `OS_REPOS` and `VERSION_OS_REPO_MAPPING`. The former specifies repos that are

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -39,11 +39,11 @@ function usage {
     echo
     echo "Usage:"
     echo "    --help                   Display this usage message"
-    echo "    --all                    Run all tests (the default)"
+    echo "    --all                    Run all tests except makecheck (the default)"
     echo "    --ceph-salt-from-source  Install ceph-salt from source"
-    echo "                             (default: from RPM package)"
-    echo "    --makecheck              Run makecheck (install-deps.sh,"
-    echo "                             actually) tests"
+    echo "                             (default: from package)"
+    echo "    --makecheck              Run makecheck (install-deps.sh, actually)"
+    echo "                             tests"
     echo "    --nautilus               Run nautilus deployment tests"
     echo "    --octopus                Run octopus deployment tests"
     echo "    --pacific                Run pacific deployment tests"
@@ -109,7 +109,6 @@ if [ "$MAKECHECK" -o "$NAUTILUS" -o "$OCTOPUS" -o "$PACIFIC" -o "$SES5" -o "$SES
 fi
 
 if [ "$ALL" ] ; then
-    # MAKECHECK="--makecheck"
     NAUTILUS="--nautilus"
     OCTOPUS="--octopus"
     PACIFIC="--pacific"

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -118,9 +118,10 @@ if [ "$ALL" ] ; then
 fi
 
 if [ "$SES5" ] ; then
-    run_cmd sesdev create ses5 --non-interactive --single-node --qa-test ses5-1node
+    # deploy ses5 without igw, so as not to hit https://github.com/SUSE/sesdev/issues/239
+    run_cmd sesdev create ses5 --non-interactive --roles [master,storage,mon,mgr,mds,rgw,nfs] --qa-test ses5-1node
     run_cmd sesdev destroy --non-interactive ses5-1node
-    run_cmd sesdev create ses5 --non-interactive ses5-4node
+    run_cmd sesdev create ses5 --non-interactive --roles [master,client,openattic],[storage,mon,mgr,rgw],[storage,mon,mgr,mds,nfs],[storage,mon,mgr,mds,rgw,nfs] ses5-4node
     run_cmd sesdev qa-test ses5-4node
     run_cmd sesdev destroy --non-interactive ses5-4node
 fi

--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -1,9 +1,23 @@
+#!/bin/bash
 #
 # This file is part of the sesdev-qa integration test suite.
 # It contains various cluster introspection functions.
 #
 
 set -e
+
+function _json_total_svcs_ses7 {
+    local svc_type="$1"
+    local ceph_orch_ls
+    local running
+    ceph_orch_ls="$(ceph orch ls --service-type "$svc_type" --format json)"
+    running="$(echo "$ceph_orch_ls" | jq -r '.[] | .running')"
+    if [ "$running" = "null" ] ; then
+        # we have fallen victim to ongoing Orchestrator refactoring
+        running="$(echo "$ceph_orch_ls" | jq -r '.[] | .status.running')"
+    fi
+    echo "$running"
+}
 
 function json_total_nodes {
     salt --static --out json '*' test.ping 2>/dev/null | jq '. | length'
@@ -14,34 +28,86 @@ function json_osd_nodes {
         jq '[.nodes[] | select(.type == "host")] | length'
 }
 
+function json_mgr_is_available {
+    if [ "$(ceph status --format json | jq -r .mgrmap.available)" = "true" ] ; then
+        echo "not_the_empty_string"
+    else
+        echo ""
+    fi
+}
+
+function json_metadata_mgrs {
+    ceph mgr metadata | jq -r '. | length'
+}
+
 function json_total_mgrs {
+    local ceph_status_json
+    ceph_status_json="$(ceph status --format json)"
+    local active_mgrs
     if [ "$VERSION_ID" = "15.2" ] ; then
         # SES7
-        echo "$(($(ceph status --format json | jq -r .mgrmap.num_standbys) + 1))"
-    elif [ "$VERSION_ID" = "15.1" ] ; then
-        # SES6
-        echo "$(($(ceph status --format json | jq -r ".mgrmap.standbys | length") + 1))"
-    elif [ "$VERSION_ID" = "12.3" ] ; then
-        # SES5
-        echo "$(($(ceph status --format json | jq -r ".mgrmap.standbys | length") + 1))"
+        _json_total_svcs_ses7 mgr
+    elif [ "$VERSION_ID" = "15.1" ] || [ "$VERSION_ID" = "12.3" ] ; then
+        # SES6, SES5
+        if [ "$(echo "$ceph_status_json" | jq -r .mgrmap.available)" = "true" ] ; then
+            active_mgrs="1"
+        else
+            active_mgrs="0"
+        fi
+        echo "$(($(echo "$ceph_status_json" | jq -r ".mgrmap.standbys | length") + active_mgrs))"
     else
-        echo "0"
+        echo "ERROR"
     fi
+}
+
+function json_metadata_mons {
+    ceph mon metadata | jq -r '. | length'
 }
 
 function json_total_mons {
     if [ "$VERSION_ID" = "15.2" ] ; then
         # SES7
-        echo "$(ceph status --format json | jq -r .monmap.num_mons)"
-    elif [ "$VERSION_ID" = "15.1" ] ; then
-        # SES6
-        echo "$(ceph status --format json | jq -r ".monmap.mons | length")"
-    elif [ "$VERSION_ID" = "12.3" ] ; then
-        # SES5
-        echo "$(ceph status --format json | jq -r ".monmap.mons | length")"
+        _json_total_svcs_ses7 mon
+    elif [ "$VERSION_ID" = "15.1" ] || [ "$VERSION_ID" = "12.3" ] ; then
+        # SES6, SES5
+        ceph status --format json | jq -r ".monmap.mons | length"
     else
-        echo "0"
+        echo "ERROR"
     fi
+}
+
+function json_metadata_mdss {
+    ceph mds metadata | jq -r '. | length'
+}
+
+function json_total_mdss {
+    local ceph_status_json
+    ceph_status_json="$(ceph status --format json)"
+    local ins
+    local ups
+    local standbys
+    local actives
+    if [ "$VERSION_ID" = "15.2" ] ; then
+        # SES7
+        _json_total_svcs_ses7 mds
+    elif [ "$VERSION_ID" = "15.1" ] || [ "$VERSION_ID" = "12.3" ] ; then
+        # SES6, SES5
+        ins="$(echo "$ceph_status_json" | jq -r .fsmap.in)"
+        ups="$(echo "$ceph_status_json" | jq -r .fsmap.up)"
+        standbys="$(echo "$ceph_status_json" | jq -r '."fsmap"."up:standby"')"
+        if [ "$ins" = "$ups" ] ; then
+            actives="$ins"
+        else
+            actives="0"
+        fi
+        echo "$((actives + standbys))"
+    else
+        echo "ERROR"
+    fi
+}
+
+function json_metadata_osds {
+    ceph osd metadata | jq -r '. | length'
 }
 
 function json_total_osds {

--- a/qa/common/zypper.sh
+++ b/qa/common/zypper.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file is part of the sesdev-qa integration test suite
 
 set -e

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -115,9 +115,9 @@ support_cop_out_test
 ceph_rpm_version_test
 ceph_cluster_running_test
 ceph_daemon_versions_test "$STRICT_VERSIONS"
-ceph_health_test
 mgr_is_available_test
 maybe_wait_for_osd_nodes_test "$OSD_NODES"  # it might take a long time for OSD nodes to show up
 maybe_wait_for_mdss_test "$MDS_NODES"  # it might take a long time for MDSs to be ready
 number_of_daemons_expected_vs_metadata_test
 number_of_nodes_actual_vs_expected_test
+ceph_health_test

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -6,13 +6,15 @@
 set -e
 trap 'catch $?' EXIT
 
-SCRIPTNAME=$(basename ${0})
-BASEDIR=$(readlink -f "$(dirname ${0})")
-test -d $BASEDIR
+SCRIPTNAME="$(basename "${0}")"
+BASEDIR="$(readlink -f "$(dirname "${0}")")"
+test -d "$BASEDIR"
 # [[ $BASEDIR =~ \/sesdev-qa$ ]]
 
+# shellcheck disable=SC1091
 source /etc/os-release
-source $BASEDIR/common/common.sh
+# shellcheck source=common/common.sh
+source "$BASEDIR/common/common.sh"
 
 function catch {
     echo
@@ -30,7 +32,7 @@ function usage {
     echo
     echo "Usage:"
     echo "  $SCRIPTNAME [-h,--help] [--igw=X] [--mds=X] [--mgr=X]"
-    echo "  [--mon=X] [--nfs-ganesha=X] [--strict-versions] [--rgw=X]"
+    echo "  [--mon=X] [--nfs=X] [--strict-versions] [--rgw=X]"
     echo "  [--total-nodes=X]"
     echo
     echo "Options:"
@@ -39,7 +41,7 @@ function usage {
     echo "    --mds-nodes          expected number of nodes with MDS"
     echo "    --mgr-nodes          expected number of nodes with MGR"
     echo "    --mon-nodes          expected number of nodes with MON"
-    echo "    --nfs-ganesha-nodes  expected number of nodes with NFS-Ganesha"
+    echo "    --nfs-nodes          expected number of nodes with NFS"
     echo "    --osd-nodes          expected number of nodes with OSD"
     echo "    --osds               expected total number of OSDs in cluster"
     echo "    --strict-versions    Insist that daemon versions match \"ceph --version\""
@@ -51,10 +53,8 @@ function usage {
 assert_enhanced_getopt
 
 TEMP=$(getopt -o h \
---long "help,igw-nodes:,mds-nodes:,mgr-nodes:,mon-nodes:,nfs-ganesha-nodes:,osd-nodes:,osds:,strict-versions,rgw-nodes:,total-nodes:" \
--n 'health-ok.sh' -- "$@")
-
-if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+--long "help,igw-nodes:,mds-nodes:,mgr-nodes:,mon-nodes:,nfs-nodes:,osd-nodes:,osds:,strict-versions,rgw-nodes:,total-nodes:" \
+-n 'health-ok.sh' -- "$@") || ( echo "Terminating..." >&2 ; exit 1 )
 eval set -- "$TEMP"
 
 # process command-line options
@@ -62,7 +62,7 @@ IGW_NODES=""
 MDS_NODES=""
 MGR_NODES=""
 MON_NODES=""
-NFS_GANESHA_NODES=""
+NFS_NODES=""
 OSD_NODES=""
 OSDS=""
 STRICT_VERSIONS=""
@@ -74,7 +74,7 @@ while true ; do
         --mds-nodes) shift ; MDS_NODES="$1" ; shift ;;
         --mgr-nodes) shift ; MGR_NODES="$1" ; shift ;;
         --mon-nodes) shift ; MON_NODES="$1" ; shift ;;
-        --nfs-ganesha-nodes) shift ; NFS_GANESHA_NODES="$1" ; shift ;;
+        --nfs-nodes) shift ; NFS_NODES="$1" ; shift ;;
         --osd-nodes) shift ; OSD_NODES="$1" ; shift ;;
         --osds) shift ; OSDS="$1" ; shift ;;
         --strict-versions) STRICT_VERSIONS="$1"; shift ;;
@@ -116,5 +116,8 @@ ceph_rpm_version_test
 ceph_cluster_running_test
 ceph_daemon_versions_test "$STRICT_VERSIONS"
 ceph_health_test
+mgr_is_available_test
 maybe_wait_for_osd_nodes_test "$OSD_NODES"  # it might take a long time for OSD nodes to show up
+maybe_wait_for_mdss_test "$MDS_NODES"  # it might take a long time for MDSs to be ready
+number_of_daemons_expected_vs_metadata_test
 number_of_nodes_actual_vs_expected_test

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -458,16 +458,16 @@ def _gen_settings_dict(version,
         if version in ['ses7', 'octopus', 'pacific']:
             settings_dict['roles'] = _parse_roles(
                 "[ master, bootstrap, storage, mon, mgr, prometheus, grafana, mds, "
-                "igw, rgw, ganesha ]"
+                "igw, rgw, nfs ]"
                 )
         elif version in ['ses5']:
             settings_dict['roles'] = _parse_roles(
-                "[ master, bootstrap, storage, mon, mgr, mds, igw, rgw, ganesha ]"
+                "[ master, storage, mon, mgr, mds, igw, rgw, nfs ]"
                 )
         else:
             settings_dict['roles'] = _parse_roles(
                 "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
-                "ganesha ]"
+                "nfs ]"
                 )
 
     if single_node:

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -75,9 +75,10 @@ def ceph_salt_options(func):
         click.option('--cephadm-bootstrap/--no-cephadm-bootstrap', default=True,
                      help='Run cephadm bootstrap during deployment. '
                           '(If false all other --deploy-* options will be disabled)'),
-        click.option('--deploy-mons/--no-deploy-mons', default=True, help='Deploy Ceph Mons'),
-        click.option('--deploy-mgrs/--no-deploy-mgrs', default=True, help='Deploy Ceph Mgrs'),
+        click.option('--deploy-mons/--no-deploy-mons', default=True, help='Deploy Ceph MONs'),
+        click.option('--deploy-mgrs/--no-deploy-mgrs', default=True, help='Deploy Ceph MGRs'),
         click.option('--deploy-osds/--no-deploy-osds', default=True, help='Deploy Ceph OSDs'),
+        click.option('--deploy-mdss/--no-deploy-mdss', default=True, help='Deploy Ceph MDSs'),
         click.option('--ceph-salt-deploy/--no-ceph-salt-deploy', default=True,
                      help='Use `ceph-salt deploy` command to run ceph-salt formula'),
     ]
@@ -442,11 +443,12 @@ def _gen_settings_dict(version,
                        stop_before_ceph_salt_config=False,
                        stop_before_ceph_salt_deploy=False,
                        image_path=None,
-                       cephadm_bootstrap=True,
-                       deploy_mons=True,
-                       deploy_mgrs=True,
-                       deploy_osds=True,
-                       ceph_salt_deploy=True,
+                       cephadm_bootstrap=None,
+                       ceph_salt_deploy=None,
+                       deploy_mons=None,
+                       deploy_mgrs=None,
+                       deploy_osds=None,
+                       deploy_mdss=None,
                        ):
 
     settings_dict = {}
@@ -577,11 +579,18 @@ def _gen_settings_dict(version,
     if image_path:
         settings_dict['image_path'] = image_path
 
-    if not cephadm_bootstrap:
+    if cephadm_bootstrap:
+        settings_dict['ceph_salt_cephadm_bootstrap'] = True
+        settings_dict['ceph_salt_deploy_mons'] = True
+        settings_dict['ceph_salt_deploy_mgrs'] = True
+        settings_dict['ceph_salt_deploy_osds'] = True
+        settings_dict['ceph_salt_deploy_mdss'] = True
+    else:
         settings_dict['ceph_salt_cephadm_bootstrap'] = False
         settings_dict['ceph_salt_deploy_mons'] = False
         settings_dict['ceph_salt_deploy_mgrs'] = False
         settings_dict['ceph_salt_deploy_osds'] = False
+        settings_dict['ceph_salt_deploy_mdss'] = False
 
     if not deploy_mons:
         settings_dict['ceph_salt_deploy_mons'] = False
@@ -591,6 +600,9 @@ def _gen_settings_dict(version,
 
     if not deploy_osds:
         settings_dict['ceph_salt_deploy_osds'] = False
+
+    if not deploy_mdss:
+        settings_dict['ceph_salt_deploy_mdss'] = False
 
     if not ceph_salt_deploy:
         settings_dict['ceph_salt_deploy'] = False

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -137,7 +137,7 @@ KNOWN_ROLES = [
     "admin",
     "bootstrap",
     "client",
-    "ganesha",
+    "ganesha",       # deprecated (replaced by "nfs")
     "grafana",
     "igw",
     "loadbalancer",
@@ -146,6 +146,7 @@ KNOWN_ROLES = [
     "mds",
     "mgr",
     "mon",
+    "nfs",
     "openattic",
     "prometheus",
     "rgw",
@@ -156,18 +157,18 @@ KNOWN_ROLES = [
 
 LUMINOUS_DEFAULT_ROLES = [["master", "client", "openattic"],
                           ["storage", "mon", "mgr", "rgw", "igw"],
-                          ["storage", "mon", "mgr", "mds", "ganesha"],
-                          ["storage", "mon", "mgr", "mds", "rgw", "ganesha"]]
+                          ["storage", "mon", "mgr", "mds", "nfs"],
+                          ["storage", "mon", "mgr", "mds", "rgw", "nfs"]]
 
 NAUTILUS_DEFAULT_ROLES = [["master", "client", "prometheus", "grafana"],
                           ["storage", "mon", "mgr", "rgw", "igw"],
-                          ["storage", "mon", "mgr", "mds", "igw", "ganesha"],
-                          ["storage", "mon", "mgr", "mds", "rgw", "ganesha"]]
+                          ["storage", "mon", "mgr", "mds", "igw", "nfs"],
+                          ["storage", "mon", "mgr", "mds", "rgw", "nfs"]]
 
 OCTOPUS_DEFAULT_ROLES = [["master", "client", "prometheus", "grafana"],
                          ["bootstrap", "storage", "mon", "mgr", "rgw", "igw"],
-                         ["storage", "mon", "mgr", "mds", "igw", "ganesha"],
-                         ["storage", "mon", "mgr", "mds", "rgw", "ganesha"]]
+                         ["storage", "mon", "mgr", "mds", "igw", "nfs"],
+                         ["storage", "mon", "mgr", "mds", "rgw", "nfs"]]
 
 VERSION_DEFAULT_ROLES = {
     'ses5': LUMINOUS_DEFAULT_ROLES,
@@ -1132,14 +1133,14 @@ class Deployment():
             'os_base_repos': os_base_repos,
             'repo_priority': self.settings.repo_priority,
             'qa_test': self.settings.qa_test,
-            'ganesha_nodes': self.node_counts["ganesha"],
+            'nfs_nodes': self.node_counts["nfs"],
             'igw_nodes': self.node_counts["igw"],
             'mds_nodes': self.node_counts["mds"],
             'mgr_nodes': self.node_counts["mgr"],
             'mon_nodes': self.node_counts["mon"],
             'rgw_nodes': self.node_counts["rgw"],
             'storage_nodes': self.node_counts["storage"],
-            'deepsea_need_stage_4': bool(self.node_counts["ganesha"] or self.node_counts["igw"]
+            'deepsea_need_stage_4': bool(self.node_counts["nfs"] or self.node_counts["igw"]
                                          or self.node_counts["mds"] or self.node_counts["rgw"]),
             'total_osds': self.settings.num_disks * self.node_counts["storage"],
             'encrypted_osds': self.settings.encrypted_osds,

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -472,6 +472,11 @@ SETTINGS = {
         'help': 'Tell ceph-salt to deploy Ceph OSDs',
         'default': True,
     },
+    'ceph_salt_deploy_mdss': {
+        'type': bool,
+        'help': 'Tell ceph-salt to deploy Ceph MDSs',
+        'default': True,
+    },
     'ceph_salt_deploy': {
         'type': bool,
         'help': 'Use "ceph-salt deploy" instead of applying the ceph-salt highstate directly',
@@ -1151,6 +1156,7 @@ class Deployment():
             'ceph_salt_deploy_mons': self.settings.ceph_salt_deploy_mons,
             'ceph_salt_deploy_mgrs': self.settings.ceph_salt_deploy_mgrs,
             'ceph_salt_deploy_osds': self.settings.ceph_salt_deploy_osds,
+            'ceph_salt_deploy_mdss': self.settings.ceph_salt_deploy_mdss,
             'ceph_salt_deploy': self.settings.ceph_salt_deploy,
             'node_manager': NodeManager(list(self.nodes.values())),
             'caasp_deploy_ses': self.settings.caasp_deploy_ses,

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -40,6 +40,7 @@ type ceph-salt
 
 MON_NODES_COMMA_SEPARATED_LIST=""
 MGR_NODES_COMMA_SEPARATED_LIST=""
+MDS_NODES_COMMA_SEPARATED_LIST=""
 {% for node in nodes %}
 {% if node.has_roles() and not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
@@ -54,9 +55,13 @@ MON_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
 {% if node.has_role('mgr') %}
 MGR_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
 {% endif %}
+{% if node.has_role('mds') %}
+MDS_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
+{% endif %}
 {% endfor %}
 MON_NODES_COMMA_SEPARATED_LIST="${MON_NODES_COMMA_SEPARATED_LIST%,*}"
 MGR_NODES_COMMA_SEPARATED_LIST="${MGR_NODES_COMMA_SEPARATED_LIST%,*}"
+MDS_NODES_COMMA_SEPARATED_LIST="${MDS_NODES_COMMA_SEPARATED_LIST%,*}"
 
 ceph-salt config /system_update/packages disable
 ceph-salt config /system_update/reboot disable
@@ -125,5 +130,9 @@ echo "{\"service_type\": \"osd\", \"placement\": {\"host_pattern\": \"{{ node.na
 {% endif %}
 {% endfor %}
 {% endif %} {# if ceph_salt_deploy_osds #}
+
+{% if ceph_salt_deploy_mdss %}
+ceph fs volume create myfs "$MDS_NODES_COMMA_SEPARATED_LIST"
+{% endif %} {# if ceph_salt_deploy_mdss #}
 
 {% include "qa_test.sh" %}

--- a/seslib/templates/deepsea/nautilus_policy.cfg.j2
+++ b/seslib/templates/deepsea/nautilus_policy.cfg.j2
@@ -32,7 +32,7 @@ role-rgw/cluster/{{ node.name }}*.sls
 role-igw/cluster/{{ node.name }}*.sls
 {% endif %}
 
-{% if node.has_role('ganesha') %}
+{% if node.has_role('nfs') %}
 role-ganesha/cluster/{{ node.name }}*.sls
 {% endif %}
 

--- a/seslib/templates/deepsea/ses5_policy.cfg.j2
+++ b/seslib/templates/deepsea/ses5_policy.cfg.j2
@@ -33,7 +33,7 @@ role-rgw/cluster/{{ node.name }}*.sls
 role-igw/cluster/{{ node.name }}*.sls
 {% endif %}
 
-{% if node.has_role('ganesha') %}
+{% if node.has_role('nfs') %}
 role-ganesha/cluster/{{ node.name }}*.sls
 {% endif %}
 

--- a/seslib/templates/qa_test.sh
+++ b/seslib/templates/qa_test.sh
@@ -2,7 +2,7 @@
 {% set qa_test_script = "/home/vagrant/qa-test.sh" %}
 {%- set qa_test_cmd = "/home/vagrant/sesdev-qa/health-ok.sh"
     ~ " --total-nodes=" ~ nodes|length
-    ~ " --nfs-ganesha-nodes=" ~ ganesha_nodes
+    ~ " --nfs-nodes=" ~ nfs_nodes
     ~ " --igw-nodes=" ~ igw_nodes
     ~ " --mds-nodes=" ~ mds_nodes
     ~ " --mgr-nodes=" ~ mgr_nodes


### PR DESCRIPTION
Until now, MDSs were not deployed in ses7, octopus, pacific, even if the
user specified one or more "mds" roles.

Fixes: https://github.com/SUSE/sesdev/issues/250

---

Rename "ganesha" role to "nfs"

"ceph -s" calls it "nfs", so we should, too.

---

qa: counting of nodes, daemons, services

With three different major versions of Ceph to support, and different
ways of counting in each one, this is a somewhat complicated
work-in-progress.

Also, take this opportunity to make the qa/ code shellcheck [1]-clean.

[1] https://github.com/koalaman/shellcheck
