### PR TITLE
Remove "disable cephadm bootstrap" functionality

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -76,9 +76,6 @@ def ceph_salt_options(func):
                      help='ceph-salt Git branch'),
         click.option('--image-path', type=str, default=None,
                      help='registry path from which to download Ceph container image'),
-        click.option('--cephadm-bootstrap/--no-cephadm-bootstrap', default=True,
-                     help='Run cephadm bootstrap during deployment. '
-                          '(If false all other --deploy-* options will be disabled)'),
         click.option('--deploy-mons/--no-deploy-mons', default=True, help='Deploy Ceph MONs'),
         click.option('--deploy-mgrs/--no-deploy-mgrs', default=True, help='Deploy Ceph MGRs'),
         click.option('--deploy-osds/--no-deploy-osds', default=True, help='Deploy Ceph OSDs'),
@@ -474,7 +471,6 @@ def _gen_settings_dict(version,
                        stop_before_ceph_salt_config=False,
                        stop_before_ceph_salt_deploy=False,
                        image_path=None,
-                       cephadm_bootstrap=None,
                        deploy_mons=None,
                        deploy_mgrs=None,
                        deploy_osds=None,
@@ -649,14 +645,6 @@ def _gen_settings_dict(version,
 
     if deploy_mdss is not None:
         settings_dict['ceph_salt_deploy_mdss'] = deploy_mdss
-
-    if cephadm_bootstrap is not None:
-        settings_dict['ceph_salt_cephadm_bootstrap'] = cephadm_bootstrap
-        if cephadm_bootstrap is False:
-            settings_dict['ceph_salt_deploy_mons'] = False
-            settings_dict['ceph_salt_deploy_mgrs'] = False
-            settings_dict['ceph_salt_deploy_osds'] = False
-            settings_dict['ceph_salt_deploy_mdss'] = False
 
     for folder in synced_folder:
         try:

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -558,11 +558,6 @@ SETTINGS = {
         'help': 'Stop before running run-make-check.sh (make check)',
         'default': False,
     },
-    'ceph_salt_cephadm_bootstrap': {
-        'type': bool,
-        'help': 'Tell ceph-salt to run "cephadm bootstrap" during deployment',
-        'default': True,
-    },
     'ceph_salt_deploy_mons': {
         'type': bool,
         'help': 'Tell ceph-salt to deploy Ceph MONs',
@@ -1273,7 +1268,6 @@ class Deployment():
             'stop_before_ceph_salt_config': self.settings.stop_before_ceph_salt_config,
             'stop_before_ceph_salt_deploy': self.settings.stop_before_ceph_salt_deploy,
             'image_path': self.settings.image_path,
-            'ceph_salt_cephadm_bootstrap': self.settings.ceph_salt_cephadm_bootstrap,
             'ceph_salt_deploy_mons': self.settings.ceph_salt_deploy_mons,
             'ceph_salt_deploy_mgrs': self.settings.ceph_salt_deploy_mgrs,
             'ceph_salt_deploy_osds': self.settings.ceph_salt_deploy_osds,

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -71,9 +71,6 @@ ceph-salt config /containers/images/ceph set {{ image_path }}
 {% endif %}
 ceph-salt config /time_server/server_hostname set {{ master.fqdn }}
 ceph-salt config /time_server/external_servers add 0.pt.pool.ntp.org
-{% if not ceph_salt_cephadm_bootstrap %}
-ceph-salt config /deployment/bootstrap disable
-{% endif %}
 
 {% if ceph_salt_deploy_osds %}
 {% if storage_nodes < 3 %}


### PR DESCRIPTION
Since https://github.com/ceph/ceph-salt/pull/184, it's no longer possible to to disable cephadm bootstrap in `ceph-salt`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>

---

~~After https://github.com/ceph/ceph-salt/pull/184~~
~~After https://github.com/SUSE/sesdev/pull/258~~