### PR TITLE
qa: fix maybe_wait_for_mdss test

### DIFF
--- a/qa/README.rst
+++ b/qa/README.rst
@@ -44,3 +44,17 @@ Caveats
 The following caveats apply:
 
 1. Ceph will not work properly unless the nodes have (at least) short hostnames. That means the health-ok.sh script won't pass, either. There are two options: ``/etc/hosts`` or DNS
+
+
+Linting
+-------
+
+When it comes to bash scripting, we run a tight ship. For linting, we use
+ShellCheck [1] which can be installed in an openSUSE Leap 15.1 environment
+by issuing the command:
+
+    zypper -n install ShellCheck
+
+To facilitate running ShellCheck on `health-ok.sh`, a script `shellcheck.sh` is provided.
+
+[1] https://www.shellcheck.net/

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -6,11 +6,14 @@
 set -e
 
 # BASEDIR is set by the calling script
-# shellcheck source=common/helper.sh
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 source "$BASEDIR/common/helper.sh"
-# shellcheck source=common/json.sh
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 source "$BASEDIR/common/json.sh"
-# shellcheck source=common/zypper.sh
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 source "$BASEDIR/common/zypper.sh"
 
 
@@ -97,8 +100,10 @@ function ceph_log_grep_enoent_eaccess {
 
 function support_cop_out_test {
     set +x
-    local supported="sesdev-qa supports this OS"
-    local not_supported="ERROR: sesdev-qa does not currently support this OS"
+    local supported
+    supported="sesdev-qa supports this OS"
+    local not_supported
+    not_supported="ERROR: sesdev-qa does not currently support this OS"
     echo
     echo "WWWW: ceph_version_test"
     echo "Detected operating system $NAME $VERSION_ID"
@@ -120,6 +125,34 @@ function support_cop_out_test {
     esac
     set +x
     echo "support_cop_out_test: OK"
+    echo
+}
+
+function make_salt_master_an_admin_node_test {
+    local arbitrary_mon_node
+    echo
+    echo "WWWW: make_salt_master_an_admin_node_test"
+    _zypper_install_on_master ceph-common
+    mkdir -p "/etc/ceph"
+    if [ -f "$ADMIN_KEYRING" ] || [ -f "$CEPH_CONF" ] ; then
+        true
+    else
+        set -x
+        arbitrary_mon_node="$(_first_x_node mon)"
+        if [ ! -f "$ADMIN_KEYRING" ] ; then
+            _copy_file_from_minion_to_master "$arbitrary_mon_node" "$ADMIN_KEYRING"
+            chmod 0600 "$ADMIN_KEYRING"
+        fi
+        if [ ! -f "$CEPH_CONF" ] ; then
+            _copy_file_from_minion_to_master "$arbitrary_mon_node" "$CEPH_CONF"
+        fi
+        set +x
+    fi
+    set -x
+    test -f "$ADMIN_KEYRING"
+    test -f "$CEPH_CONF"
+    set +x
+    echo "make_salt_master_an_admin_node_test: OK"
     echo
 }
 
@@ -155,8 +188,8 @@ function ceph_rpm_version_test {
 
 function ceph_daemon_versions_test {
     local strict_versions="$1"
-    local version_host=""
-    local version_daemon=""
+    local version_host
+    local version_daemon
     echo
     echo "WWWW: ceph_daemon_versions_test"
     set -x
@@ -186,8 +219,11 @@ function ceph_health_test {
 # wait for up to some minutes for cluster to reach HEALTH_OK
     echo
     echo "WWWW: ceph_health_test"
-    local minutes_to_wait="5"
-    local cluster_status=""
+    local minutes_to_wait
+    minutes_to_wait="5"
+    local cluster_status
+    local minute
+    local i
     for minute in $(seq 1 "$minutes_to_wait") ; do
         for i in $(seq 1 4) ; do
             set -x
@@ -197,45 +233,59 @@ function ceph_health_test {
             if [ "$cluster_status" = "HEALTH_OK" ] ; then
                 break 2
             else
-                _grace_period 15
+                _grace_period 15 "$i"
             fi
         done
         echo "Minutes left to wait: $((minutes_to_wait - minute))"
     done
-    if [ "$cluster_status" != "HEALTH_OK" ] ; then
-        echo "Failed to reach HEALTH_OK even after waiting for $minutes_to_wait minutes"
-        exit 1
+    if [ "$cluster_status" = "HEALTH_OK" ] ; then
+        echo "ceph_health_test: OK"
+        echo
+    else
+        echo "HEALTH_OK not reached even after waiting for $minutes_to_wait minutes"
+        echo "ceph_health_test: FAIL"
+        echo
+        false
     fi
-    echo "ceph_health_test: OK"
-    echo
 }
 
 function maybe_wait_for_osd_nodes_test {
     local expected_osd_nodes="$1"
-    local actual_osd_nodes=""
-    local minutes_to_wait="5"
+    local actual_osd_nodes
+    local minutes_to_wait
+    minutes_to_wait="5"
+    local minute
+    local i
+    local success
     echo
     echo "WWWW: maybe_wait_for_osd_nodes_test"
     if [ "$expected_osd_nodes" ] ; then
-        echo "Waiting up to $minutes_to_wait minutes for OSD nodes to show up..."
+        echo "Waiting up to $minutes_to_wait minutes for all $expected_osd_nodes OSD node(s) to show up..."
         for minute in $(seq 1 "$minutes_to_wait") ; do
             for i in $(seq 1 4) ; do
                 set -x
                 actual_osd_nodes="$(json_osd_nodes)"
                 set +x
                 if [ "$actual_osd_nodes" = "$expected_osd_nodes" ] ; then
+                    success="not_empty"
                     break 2
                 else
-                    _grace_period 15
+                    _grace_period 15 "$i"
                 fi
             done
             echo "Minutes left to wait: $((minutes_to_wait - minute))"
         done
     else
+        success="not_empty"
         echo "No OSD nodes expected: nothing to wait for."
     fi
-    echo "maybe_wait_for_osd_nodes_test: OK"
-    echo
+    if [ "$success" ] ; then
+        echo "maybe_wait_for_osd_nodes_test: OK"
+        echo
+    else
+        echo "maybe_wait_for_osd_nodes_test: FAIL"
+        false
+    fi
 }
 
 function maybe_wait_for_mdss_test {
@@ -301,30 +351,41 @@ function number_of_daemons_expected_vs_metadata_test {
     local metadata_osds
     metadata_osds="$(json_metadata_osds)"
     set +x
-    local all_green
-    all_green="yes"
+    local success
+    success="yes"
     local expected_mgrs
     local expected_mons
     local expected_mdss
     local expected_osds
-    [ -z "$MGR_NODES" ] && expected_mgrs="$metadata_mgrs" || expected_mgrs="$MGR_NODES"
-    [ -z "$MON_NODES" ] && expected_mons="$metadata_mons" || expected_mons="$MON_NODES"
-    [ -z "$MDS_NODES" ] && expected_mdss="$metadata_mdss" || expected_mdss="$MDS_NODES"
-    [ -z "$OSDS" ]      && expected_osds="$metadata_osds" || expected_osds="$OSDS"
-    echo "MONs metadata/expected: $metadata_mons/$expected_mons"
-    [ "$metadata_mons" = "$expected_mons" ] || all_green=""
-    echo "MGRs metadata/expected: $metadata_mgrs/$expected_mgrs"
-    [ "$metadata_mgrs" = "$expected_mgrs" ] || all_green=""
-    echo "MDSs metadata/expected: $metadata_mdss/$expected_mdss"
-    [ "$metadata_mdss" = "$expected_mdss" ] || all_green=""
-    echo "OSDs metadata/expected: $metadata_osds/$expected_osds"
-    [ "$metadata_osds" = "$expected_osds" ] || all_green=""
-    if [ -z "$all_green" ] ; then
-        echo "ERROR: Detected disparity between expected number of MONs/MGRs/MDSs/OSDs and cluster metadata!"
-        exit 1
+    [ "$MGR_NODES" ] && expected_mgrs="$MGR_NODES"
+    [ "$MON_NODES" ] && expected_mons="$MON_NODES"
+    [ "$MDS_NODES" ] && expected_mdss="$MDS_NODES"
+    [ "$OSDS" ]      && expected_osds="$OSDS"
+    if [ "$expected_mons" ] ; then
+        echo "MONs metadata/expected: $metadata_mons/$expected_mons"
+        [ "$metadata_mons" = "$expected_mons" ] || success=""
     fi
-    echo "number_of_daemons_expected_vs_metadata_test: OK"
-    echo
+    if [ "$expected_mgrs" ] ; then
+        echo "MGRs metadata/expected: $metadata_mgrs/$expected_mgrs"
+        [ "$metadata_mgrs" = "$expected_mgrs" ] || success=""
+    fi
+    if [ "$expected_mdss" ] ; then
+        echo "MDSs metadata/expected: $metadata_mdss/$expected_mdss"
+        [ "$metadata_mdss" = "$expected_mdss" ] || success=""
+    fi
+    if [ "$expected_osds" ] ; then
+        echo "OSDs metadata/expected: $metadata_osds/$expected_osds"
+        [ "$metadata_osds" = "$expected_osds" ] || success=""
+    fi
+    if [ "$success" ] ; then
+        echo "number_of_daemons_expected_vs_metadata_test: OK"
+        echo
+    else
+        echo "ERROR: Detected disparity between expected number of daemons and cluster metadata!"
+        echo "number_of_daemons_expected_vs_metadata_test: FAIL"
+        echo
+        false
+    fi
 }
 
 function number_of_nodes_actual_vs_expected_test {
@@ -344,39 +405,54 @@ function number_of_nodes_actual_vs_expected_test {
     local actual_osds
     actual_osds="$(json_total_osds)"
     set +x
-    local all_green
-    all_green="yes"
+    local success
+    success="yes"
     local expected_total_nodes
     local expected_mgr_nodes
     local expected_mon_nodes
     local expected_mds_nodes
     local expected_osd_nodes
     local expected_osds
-    [ -z "$TOTAL_NODES" ] && expected_total_nodes="$actual_total_nodes" || expected_total_nodes="$TOTAL_NODES"
-    [ -z "$MGR_NODES" ] && expected_mgr_nodes="$actual_mgr_nodes" || expected_mgr_nodes="$MGR_NODES"
-    [ -z "$MON_NODES" ] && expected_mon_nodes="$actual_mon_nodes" || expected_mon_nodes="$MON_NODES"
-    [ -z "$MDS_NODES" ] && expected_mds_nodes="$actual_mds_nodes" || expected_mds_nodes="$MDS_NODES"
-    [ -z "$OSD_NODES" ] && expected_osd_nodes="$actual_osd_nodes" || expected_osd_nodes="$OSD_NODES"
-    [ -z "$OSDS" ] && expected_osds="$actual_osds" || expected_osds="$OSDS"
-    echo "total nodes actual/expected:  $actual_total_nodes/$expected_total_nodes"
-    [ "$actual_total_nodes" = "$expected_total_nodes" ] || all_green=""
-    echo "MON nodes actual/expected:    $actual_mon_nodes/$expected_mon_nodes"
-    [ "$actual_mon_nodes" = "$expected_mon_nodes" ] || all_green=""
-    echo "MGR nodes actual/expected:    $actual_mgr_nodes/$expected_mgr_nodes"
-    [ "$actual_mgr_nodes" = "$expected_mgr_nodes" ] || all_green=""
-    echo "MDS nodes actual/expected:    $actual_mds_nodes/$expected_mds_nodes"
-    [ "$actual_mds_nodes" = "$expected_mds_nodes" ] || all_green=""
-    echo "OSD nodes actual/expected:    $actual_osd_nodes/$expected_osd_nodes"
-    [ "$actual_osd_nodes" = "$expected_osd_nodes" ] || all_green=""
-    echo "total OSDs actual/expected:   $actual_osds/$expected_osds"
-    [ "$actual_osds" = "$expected_osds" ] || all_green=""
+    [ "$TOTAL_NODES" ] && expected_total_nodes="$TOTAL_NODES"
+    [ "$MGR_NODES" ]   && expected_mgr_nodes="$MGR_NODES"
+    [ "$MON_NODES" ]   && expected_mon_nodes="$MON_NODES"
+    [ "$MDS_NODES" ]   && expected_mds_nodes="$MDS_NODES"
+    [ "$OSD_NODES" ]   && expected_osd_nodes="$OSD_NODES"
+    [ "$OSDS" ]        && expected_osds="$OSDS"
+    if [ "$expected_total_nodes" ] ; then
+        echo "total nodes actual/expected:  $actual_total_nodes/$expected_total_nodes"
+        [ "$actual_total_nodes" = "$expected_total_nodes" ] || success=""
+    fi
+    if [ "$expected_mon_nodes" ] ; then
+        echo "MON nodes actual/expected:    $actual_mon_nodes/$expected_mon_nodes"
+        [ "$actual_mon_nodes" = "$expected_mon_nodes" ] || success=""
+    fi
+    if [ "$expected_mgr_nodes" ] ; then
+        echo "MGR nodes actual/expected:    $actual_mgr_nodes/$expected_mgr_nodes"
+        [ "$actual_mgr_nodes" = "$expected_mgr_nodes" ] || success=""
+    fi
+    if [ "$expected_mds_nodes" ] ; then
+        echo "MDS nodes actual/expected:    $actual_mds_nodes/$expected_mds_nodes"
+        [ "$actual_mds_nodes" = "$expected_mds_nodes" ] || success=""
+    fi
+    if [ "$expected_osd_nodes" ] ; then
+        echo "OSD nodes actual/expected:    $actual_osd_nodes/$expected_osd_nodes"
+        [ "$actual_osd_nodes" = "$expected_osd_nodes" ] || success=""
+    fi
+    if [ "$expected_osds" ] ; then
+        echo "total OSDs actual/expected:   $actual_osds/$expected_osds"
+        [ "$actual_osds" = "$expected_osds" ] || success=""
+    fi
 #    echo "RGW nodes expected:     $RGW_NODES"
 #    echo "IGW nodes expected:     $IGW_NODES"
 #    echo "NFS nodes expected:     $NFS_NODES"
-    if [ -z "$all_green" ] ; then
-        echo "Actual number of nodes/node types/OSDs differs from expected number"
-        exit 1
+    if [ "$success" ] ; then
+        echo "number_of_nodes_actual_vs_expected_test: OK"
+        echo
+    else
+        echo "ERROR: Detected disparity between expected and actual numbers of nodes/daemons"
+        echo "number_of_nodes_actual_vs_expected_test: FAIL"
+        echo
+        false
     fi
-    echo "number_of_nodes_actual_vs_expected_test: OK"
-    echo
 }

--- a/qa/shellcheck.sh
+++ b/qa/shellcheck.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# set -x
+
+SCRIPTS_TO_SHELLCHECK="shellcheck.sh
+health-ok.sh
+common/common.sh
+common/helper.sh
+common/json.sh
+common/zypper.sh
+"
+
+function abort_missing_dep {
+    local executable="$1"
+    local provided_by="$2"
+    if type "$executable" > /dev/null 2>&1 ; then
+        true
+    else
+        >&2 echo "ERROR: $executable not available"
+        >&2 echo "Please install the $provided_by package for your OS, and try again."
+        exit 1
+    fi
+}
+
+function run_shellcheck_on {
+    local target="$1"
+    shellcheck "$target"
+}
+
+abort_missing_dep shellcheck ShellCheck
+
+if [ -e "./health-ok.sh" ] ; then
+    true
+else
+    >&2 echo "ERROR: not in the qa/ directory"
+    exit 1
+fi
+
+for script in $SCRIPTS_TO_SHELLCHECK ; do
+    run_shellcheck_on "$script"
+done
+


### PR DESCRIPTION
Since cephadm/orchestrator does Day 1 operations asynchronously, when an
Octopus/Pacific cluster is coming up it can take some time for the MDS
metadata to be updated. And, in fact, there is no guarantee that the MDS
metadata will be present before "ceph orch ls --service-type mds" starts
reporting the MDS as "running".

Also, do some general clean up of the qa bash scripting, including further
work to make it ShellCheck-clean and facilitate running ShellCheck on the
code.