### PR TITLE
Rename --deepsea-cli and --ceph-salt-deploy options to --salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ the VMs and run the deployment scripts.
 * [Usage](#usage)
    * [Create/deploy a Ceph cluster](#createdeploy-a-ceph-cluster)
       * [On a remote libvirt server via SSH](#on-a-remote-libvirt-server-via-ssh)
+      * [Using salt instead of DeepSea/ceph-salt CLI](#using-salt-instead-of-deepseaceph-salt-cli)
       * [With an additional custom zypper repo](#with-an-additional-custom-zypper-repo)
       * [With a set of custom zypper repos completely replacing the default repos](#with-a-set-of-custom-zypper-repos-completely-replacing-the-default-repos)
       * [With custom image paths](#with-custom-image-paths)
@@ -357,6 +358,15 @@ libvirt_host: <hostname|ip address>
 
 Note that passwordless SSH access to this user@host combination needs to be
 configured and enabled.
+
+#### Using salt instead of DeepSea/ceph-salt CLI
+
+By default, sesdev will use the DeepSea CLI to run the DeepSea Stages (ses5,
+nautilus, ses6) or the "ceph-salt" command to apply the ceph-salt Salt Formula
+(ses7, octopus, pacific).
+
+If you would rather use Salt directly, give the `--salt` option on the `sesdev
+create` command line.
 
 #### With an additional custom zypper repo
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -54,8 +54,8 @@ def libvirt_options(func):
 
 def deepsea_options(func):
     click_options = [
-        click.option('--deepsea-cli/--salt-run', default=True,
-                     help="Use deepsea-cli or salt-run to execute DeepSea stages"),
+        click.option('--salt/--deepsea-cli', default=False,
+                     help='Use "salt-run" (instead of DeepSea CLI) to execute DeepSea stages'),
         click.option('--stop-before-deepsea-stage', type=int, default=None,
                      help='Allows to stop deployment before running the specified DeepSea stage'),
         click.option('--deepsea-repo', type=str, default=None, help='DeepSea Git repo URL'),
@@ -83,8 +83,8 @@ def ceph_salt_options(func):
         click.option('--deploy-mgrs/--no-deploy-mgrs', default=True, help='Deploy Ceph MGRs'),
         click.option('--deploy-osds/--no-deploy-osds', default=True, help='Deploy Ceph OSDs'),
         click.option('--deploy-mdss/--no-deploy-mdss', default=True, help='Deploy Ceph MDSs'),
-        click.option('--ceph-salt-deploy/--no-ceph-salt-deploy', default=True,
-                     help='Use `ceph-salt deploy` command to run ceph-salt formula'),
+        click.option('--salt/--ceph-salt', default=False,
+                     help='Use "salt" (instead of "ceph-salt") to run ceph-salt formula'),
     ]
     return _decorator_composer(click_options, func)
 
@@ -465,7 +465,7 @@ def _gen_settings_dict(version,
                        force,
                        synced_folder,
                        encrypted_osds,
-                       deepsea_cli=None,
+                       salt=None,
                        stop_before_deepsea_stage=None,
                        deepsea_repo=None,
                        deepsea_branch=None,
@@ -475,7 +475,6 @@ def _gen_settings_dict(version,
                        stop_before_ceph_salt_deploy=False,
                        image_path=None,
                        cephadm_bootstrap=None,
-                       ceph_salt_deploy=None,
                        deploy_mons=None,
                        deploy_mgrs=None,
                        deploy_osds=None,
@@ -548,16 +547,16 @@ def _gen_settings_dict(version,
     if libvirt_networks:
         settings_dict['libvirt_networks'] = libvirt_networks
 
-    if deepsea_cli is not None:
-        settings_dict['use_deepsea_cli'] = deepsea_cli
+    if salt is not None:
+        settings_dict['use_salt'] = salt
 
     if stop_before_deepsea_stage is not None:
         settings_dict['stop_before_stage'] = stop_before_deepsea_stage
 
-    if deepsea_repo:
+    if deepsea_repo is not None:
         settings_dict['deepsea_git_repo'] = deepsea_repo
 
-    if deepsea_branch:
+    if deepsea_branch is not None:
         settings_dict['deepsea_git_branch'] = deepsea_branch
 
     if version is not None:
@@ -612,10 +611,10 @@ def _gen_settings_dict(version,
     if ceph_salt_branch:
         settings_dict['ceph_salt_git_branch'] = ceph_salt_branch
 
-    if stop_before_ceph_salt_config:
+    if stop_before_ceph_salt_config is not None:
         settings_dict['stop_before_ceph_salt_config'] = stop_before_ceph_salt_config
 
-    if stop_before_ceph_salt_deploy:
+    if stop_before_ceph_salt_deploy is not None:
         settings_dict['stop_before_ceph_salt_deploy'] = stop_before_ceph_salt_deploy
 
     if image_path:
@@ -630,42 +629,34 @@ def _gen_settings_dict(version,
     if username:
         settings_dict['makecheck_username'] = username
 
-    if stop_before_git_clone:
+    if stop_before_git_clone is not None:
         settings_dict['makecheck_stop_before_git_clone'] = stop_before_git_clone
 
-    if stop_before_install_deps:
+    if stop_before_install_deps is not None:
         settings_dict['makecheck_stop_before_install_deps'] = stop_before_install_deps
 
-    if stop_before_run_make_check:
+    if stop_before_run_make_check is not None:
         settings_dict['makecheck_stop_before_run_make_check'] = stop_before_run_make_check
 
-    if cephadm_bootstrap:
-        settings_dict['ceph_salt_cephadm_bootstrap'] = True
-        settings_dict['ceph_salt_deploy_mons'] = True
-        settings_dict['ceph_salt_deploy_mgrs'] = True
-        settings_dict['ceph_salt_deploy_osds'] = True
-        settings_dict['ceph_salt_deploy_mdss'] = True
-    else:
-        settings_dict['ceph_salt_cephadm_bootstrap'] = False
-        settings_dict['ceph_salt_deploy_mons'] = False
-        settings_dict['ceph_salt_deploy_mgrs'] = False
-        settings_dict['ceph_salt_deploy_osds'] = False
-        settings_dict['ceph_salt_deploy_mdss'] = False
+    if deploy_mons is not None:
+        settings_dict['ceph_salt_deploy_mons'] = deploy_mons
 
-    if not deploy_mons:
-        settings_dict['ceph_salt_deploy_mons'] = False
+    if deploy_mgrs is not None:
+        settings_dict['ceph_salt_deploy_mgrs'] = deploy_mgrs
 
-    if not deploy_mgrs:
-        settings_dict['ceph_salt_deploy_mgrs'] = False
+    if deploy_osds is not None:
+        settings_dict['ceph_salt_deploy_osds'] = deploy_osds
 
-    if not deploy_osds:
-        settings_dict['ceph_salt_deploy_osds'] = False
+    if deploy_mdss is not None:
+        settings_dict['ceph_salt_deploy_mdss'] = deploy_mdss
 
-    if not deploy_mdss:
-        settings_dict['ceph_salt_deploy_mdss'] = False
-
-    if not ceph_salt_deploy:
-        settings_dict['ceph_salt_deploy'] = False
+    if cephadm_bootstrap is not None:
+        settings_dict['ceph_salt_cephadm_bootstrap'] = cephadm_bootstrap
+        if cephadm_bootstrap is False:
+            settings_dict['ceph_salt_deploy_mons'] = False
+            settings_dict['ceph_salt_deploy_mgrs'] = False
+            settings_dict['ceph_salt_deploy_osds'] = False
+            settings_dict['ceph_salt_deploy_mdss'] = False
 
     for folder in synced_folder:
         try:

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -461,11 +461,6 @@ SETTINGS = {
         'help': 'Git branch to use',
         'default': 'master',
     },
-    'use_deepsea_cli': {
-        'type': bool,
-        'help': 'Use deepsea-cli to run deepsea stages',
-        'default': True,
-    },
     'stop_before_stage': {
         'type': int,
         'help': 'Stop deployment before running the specified DeepSea stage',
@@ -576,10 +571,10 @@ SETTINGS = {
         'help': 'Tell ceph-salt to deploy Ceph MDSs',
         'default': True,
     },
-    'ceph_salt_deploy': {
+    'use_salt': {
         'type': bool,
-        'help': 'Use "ceph-salt deploy" instead of applying the ceph-salt highstate directly',
-        'default': True,
+        'help': 'Use "salt" (or "salt-run") to apply Salt Formula (or execute DeepSea Stages)',
+        'default': False,
     },
     'caasp_deploy_ses': {
         'type': bool,
@@ -1245,7 +1240,6 @@ class Deployment():
             'deepsea_git_repo': self.settings.deepsea_git_repo,
             'deepsea_git_branch': self.settings.deepsea_git_branch,
             'version': self.settings.version,
-            'use_deepsea_cli': self.settings.use_deepsea_cli,
             'stop_before_stage': self.settings.stop_before_stage,
             'deployment_tool': self.settings.deployment_tool,
             'version_repos_prio': version_repos_prio,
@@ -1278,7 +1272,7 @@ class Deployment():
             'ceph_salt_deploy_mgrs': self.settings.ceph_salt_deploy_mgrs,
             'ceph_salt_deploy_osds': self.settings.ceph_salt_deploy_osds,
             'ceph_salt_deploy_mdss': self.settings.ceph_salt_deploy_mdss,
-            'ceph_salt_deploy': self.settings.ceph_salt_deploy,
+            'use_salt': self.settings.use_salt,
             'node_manager': NodeManager(list(self.nodes.values())),
             'caasp_deploy_ses': self.settings.caasp_deploy_ses,
             'synced_folders': self.settings.synced_folder,

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -97,10 +97,10 @@ ceph-salt --version
 exit 0
 {% endif %}
 
-{% if ceph_salt_deploy %}
-stdbuf -o0 ceph-salt -ldebug deploy --non-interactive
-{% else %}
+{% if use_salt %}
 salt -G 'ceph-salt:member' state.apply ceph-salt
+{% else %}
+stdbuf -o0 ceph-salt -ldebug deploy --non-interactive
 {% endif %}
 
 {% if ceph_salt_deploy_mons %}

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -37,17 +37,19 @@ sleep 5
 exit 0
 {% endif %}
 
-{% if use_deepsea_cli %}
 echo "PATH is $PATH"
+{% if use_salt %}
+type salt-run
+{% else %}
 type deepsea
 {% endif %}
 
 echo ""
 echo "***** RUNNING stage.0 *******"
-{% if use_deepsea_cli %}
-deepsea stage run --simple-output ceph.stage.0
-{% else %}
+{% if use_salt %}
 salt-run state.orch ceph.stage.0
+{% else %}
+deepsea stage run --simple-output ceph.stage.0
 {% endif %}
 sleep 5
 
@@ -59,10 +61,10 @@ exit 0
 
 echo ""
 echo "***** RUNNING stage.1 *******"
-{% if use_deepsea_cli %}
-deepsea stage run --simple-output ceph.stage.1
-{% else %}
+{% if use_salt %}
 salt-run state.orch ceph.stage.1
+{% else %}
+deepsea stage run --simple-output ceph.stage.1
 {% endif %}
 sleep 5
 
@@ -74,10 +76,10 @@ exit 0
 
 echo ""
 echo "***** RUNNING stage.2 *******"
-{% if use_deepsea_cli %}
-deepsea stage run --simple-output ceph.stage.2
-{% else %}
+{% if use_salt %}
 salt-run state.orch ceph.stage.2
+{% else %}
+deepsea stage run --simple-output ceph.stage.2
 {% endif %}
 sleep 5
 
@@ -100,10 +102,10 @@ cat /srv/salt/ceph/configuration/files/drive_groups.yml
 
 echo ""
 echo "***** RUNNING stage.3 *******"
-{% if use_deepsea_cli %}
-DEV_ENV=true deepsea stage run --simple-output ceph.stage.3
-{% else %}
+{% if use_salt %}
 DEV_ENV=true salt-run state.orch ceph.stage.3
+{% else %}
+DEV_ENV=true deepsea stage run --simple-output ceph.stage.3
 {% endif %}
 sleep 5
 
@@ -131,10 +133,10 @@ exit 0
 {% if deepsea_need_stage_4 %}
 echo ""
 echo "***** RUNNING stage.4 *******"
-{% if use_deepsea_cli %}
-deepsea stage run --simple-output ceph.stage.4
-{% else %}
+{% if use_salt %}
 salt-run state.orch ceph.stage.4
+{% else %}
+deepsea stage run --simple-output ceph.stage.4
 {% endif %}
 sleep 5
 {% endif %} {# deepsea_need_stage_4 #}


### PR DESCRIPTION
With this patch, when we want "salt ... state.apply" (SES7) or "salt-run
state.orch ..." (SES6, SES5), we simply give the option --salt. This is
much more straightforward (and easier to remember) than the previous
method.

Note: this patch does *not* change the default behavior, which is to use
"ceph-salt deploy --non-interactive" (SES7) or "deepsea stage run ..."
(SES6, SES5). The patch only renames the options used to trigger the
non-default behavior.