### PR TITLE
deepsea: "openattic" role needs Stage 4

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1260,7 +1260,8 @@ class Deployment():
             'rgw_nodes': self.node_counts["rgw"],
             'storage_nodes': self.node_counts["storage"],
             'deepsea_need_stage_4': bool(self.node_counts["nfs"] or self.node_counts["igw"]
-                                         or self.node_counts["mds"] or self.node_counts["rgw"]),
+                                         or self.node_counts["mds"] or self.node_counts["rgw"]
+                                         or self.node_counts["openattic"]),
             'total_osds': self.settings.num_disks * self.node_counts["storage"],
             'encrypted_osds': self.settings.encrypted_osds,
             'scc_username': self.settings.scc_username,


### PR DESCRIPTION
Before this fix, we might skip Stage 4 even though the "openattic" role
is given. In such a case, openATTIC would not get deployed, which is
a bug.

Signed-off-by: Nathan Cutler <ncutler@suse.com>