### PR TITLE
makecheck: reasonable defaults for Ceph repo/branch

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -287,11 +287,11 @@ fi
 if [ "$MAKECHECK" ] ; then
     run_cmd sesdev create makecheck --non-interactive --stop-before-run-make-check --ram 4
     run_cmd sesdev destroy --non-interactive makecheck-tumbleweed
-    run_cmd sesdev create makecheck --non-interactive --os sles-12-sp3 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses5 --stop-before-run-make-check --ram 4
+    run_cmd sesdev create makecheck --non-interactive --os sles-12-sp3 --stop-before-run-make-check --ram 4
     run_cmd sesdev destroy --non-interactive makecheck-sles-12-sp3
-    run_cmd sesdev create makecheck --non-interactive --os sles-15-sp1 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses6 --stop-before-run-make-check --ram 4
+    run_cmd sesdev create makecheck --non-interactive --os sles-15-sp1 --stop-before-run-make-check --ram 4
     run_cmd sesdev destroy --non-interactive makecheck-sles-15-sp1
-    run_cmd sesdev create makecheck --non-interactive --os sles-15-sp2 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses7 --stop-before-run-make-check --ram 4
+    run_cmd sesdev create makecheck --non-interactive --os sles-15-sp2 --stop-before-run-make-check --ram 4
     run_cmd sesdev destroy --non-interactive makecheck-sles-15-sp2
 fi
 
@@ -300,6 +300,12 @@ if [ "$CAASP4" ] ; then
     run_cmd sesdev destroy --non-interactive caasp4-default
     run_cmd sesdev create caasp4 --non-interactive --deploy-ses caasp4-with-rook
     run_cmd sesdev destroy --non-interactive caasp4-with-rook
+fi
+
+if [ "$(sesdev list --format json | jq -r '. | length')" != "0" ] ; then
+    echo "ERROR: dangling deployments detected"
+    echo "(One or more deployments created by this script were not destroyed)"
+    exit 1
 fi
 
 final_report

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -858,9 +858,9 @@ def caasp4(deployment_id, deploy, deploy_ses, **kwargs):
 @click.argument('deployment_id', required=False)
 @common_create_options
 @libvirt_options
-@click.option("--ceph-repo", default='https://github.com/ceph/ceph',
+@click.option("--ceph-repo", default=None,
               help='repo from which to clone Ceph source code')
-@click.option("--ceph-branch", default='master',
+@click.option("--ceph-branch", default=None,
               help='ceph branch on which to run "make check"')
 @click.option("--username", default='sesdev',
               help='name of ordinary user that will run make check')
@@ -872,7 +872,10 @@ def caasp4(deployment_id, deploy, deploy_ses, **kwargs):
               help="Stop before running run-make-check.sh")
 def makecheck(deployment_id, deploy, **kwargs):
     """
-    Creates a makecheck cluster
+    Brings up a single VM and clones a Ceph repo/branch which can either be
+    specified explicitly on the command line or, failing that, will default to
+    something reasonable depending on which OS is specified. Inside the Ceph
+    clone, first "install-deps.sh" and then "run-make-check.sh" will be run.
     """
     _prep_kwargs(kwargs)
     settings_dict = _gen_settings_dict('makecheck', **kwargs)

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -633,7 +633,11 @@ def _gen_settings_dict(version,
         settings_dict['image_path'] = image_path
 
     if ceph_repo:
-        settings_dict['makecheck_ceph_repo'] = ceph_repo
+        match = re.search(r'github\.com', ceph_repo)
+        if match:
+            settings_dict['makecheck_ceph_repo'] = ceph_repo
+        else:
+            settings_dict['makecheck_ceph_repo'] = 'https://github.com/{}/ceph'.format(ceph_repo)
 
     if ceph_branch:
         settings_dict['makecheck_ceph_branch'] = ceph_branch

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1590,6 +1590,11 @@ class Deployment():
                 result += "     - cluster_address:  {}\n".format(v.cluster_address)
             result += "     - cpus:             {}\n".format(v.cpus)
             result += "     - ram:              {}G\n".format(int(v.ram / (2 ** 10)))
+            if self.settings.version == 'makecheck':
+                result += ("     - git repo:         {}\n"
+                           .format(self.settings.makecheck_ceph_repo))
+                result += ("     - git branch:       {}\n"
+                           .format(self.settings.makecheck_ceph_branch))
             if v.storage_disks:
                 result += "     - storage_disks:    {}\n".format(len(v.storage_disks))
                 result += ("                         "
@@ -1598,8 +1603,9 @@ class Deployment():
                     "Yes" if self.settings.encrypted_osds else "No")
                 result += "     - OSD objectstore:  {}\n".format(
                     "FileStore" if self.settings.filestore_osds else "BlueStore")
-            result += "     - repo_priority:    {}\n".format(self.settings.repo_priority)
-            result += "     - qa_test:          {}\n".format(self.settings.qa_test)
+            if self.settings.version in GlobalSettings.CORE_VERSIONS:
+                result += "     - repo_priority:    {}\n".format(self.settings.repo_priority)
+                result += "     - qa_test:          {}\n".format(self.settings.qa_test)
             if self.settings.version in ['octopus', 'ses7', 'pacific']:
                 result += "     - image_path:       {}\n".format(self.settings.image_path)
             for synced_folder in self.settings.synced_folder:

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -328,6 +328,32 @@ VERSION_OS_REPO_MAPPING = {
     },
 }
 
+MAKECHECK_DEFAULT_REPO_BRANCH = {
+    'sles-12-sp3': {
+        'repo': 'https://github.com/SUSE/ceph',
+        'branch': 'ses5',
+    },
+    'sles-15-sp1': {
+        'repo': 'https://github.com/SUSE/ceph',
+        'branch': 'ses6-downstream-commits',
+    },
+    'leap-15.1': {
+        'repo': 'https://github.com/ceph/ceph',
+        'branch': 'nautilus',
+    },
+    'sles-15-sp2': {
+        'repo': 'https://github.com/SUSE/ceph',
+        'branch': 'ses7',
+    },
+    'leap-15.2': {
+        'repo': 'https://github.com/ceph/ceph',
+        'branch': 'octopus',
+    },
+    'tumbleweed': {
+        'repo': 'https://github.com/ceph/ceph',
+        'branch': 'master',
+    },
+}
 
 SETTINGS = {
     # RESERVED KEY, DO NOT USE: 'strict'
@@ -991,6 +1017,16 @@ class Deployment():
             if not self.settings.explicit_ram:
                 self.settings.override('ram', GlobalSettings.MAKECHECK_DEFAULT_RAM)
                 self.settings.override('explicit_ram', True)
+            if not self.settings.makecheck_ceph_repo:
+                self.settings.override(
+                    'makecheck_ceph_repo',
+                    MAKECHECK_DEFAULT_REPO_BRANCH[self.settings.os]['repo']
+                    )
+            if not self.settings.makecheck_ceph_branch:
+                self.settings.override(
+                    'makecheck_ceph_branch',
+                    MAKECHECK_DEFAULT_REPO_BRANCH[self.settings.os]['branch']
+                    )
 
         self._generate_nodes()
 


### PR DESCRIPTION
Before this patch, one had to explicitly give "--ceph-repo" and
"--ceph-branch" options on the "sesdev create makecheck" command line if
one wanted to run make check on anything other than the upstream branch.

We can do better than that.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

- [x] display a status message like we do for the other `sesdev create` targets