### PR TITLE
Make sure CaaSP nodes are properly prepared

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -111,11 +111,11 @@ hostnamectl set-hostname {{ node.name }}
 
 {% if version == 'caasp4' %}
 {% include "caasp/provision.sh.j2" %}
-{% elif version == 'makecheck' %}
-{% include "makecheck/provision.sh.j2" %}
 {% endif %}
 
-{% if node != suma %}
+{% if version == 'makecheck' %}
+{% include "makecheck/provision.sh.j2" %}
+{% elif not suma %}
 zypper -n install salt-minion
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
 
@@ -129,7 +129,7 @@ systemctl start salt-minion
 {% include "sync_clocks.sh.j2" %}
 {% endif %}
 
-{% endif %} {# node != suma #}
+{% endif %} {# not suma #}
 
 touch /tmp/ready
 

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -113,7 +113,9 @@ hostnamectl set-hostname {{ node.name }}
 {% include "caasp/provision.sh.j2" %}
 {% elif version == 'makecheck' %}
 {% include "makecheck/provision.sh.j2" %}
-{% elif not suma %}
+{% endif %}
+
+{% if node != suma %}
 zypper -n install salt-minion
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
 
@@ -127,7 +129,7 @@ systemctl start salt-minion
 {% include "sync_clocks.sh.j2" %}
 {% endif %}
 
-{% endif %} {# not suma #}
+{% endif %} {# node != suma #}
 
 touch /tmp/ready
 


### PR DESCRIPTION
While attempting to create a CaaSP cluster with a command like the following...

```
sesdev create caasp4 --non-interactive \
	--num-disks 2 --disk-size 32 --ram 6 --cpus 2 --domain caasp4.is \
	--roles="[master], [worker, storage], [worker, storage], [worker, storage]" reykjavik
```

...the whole process fails:

```
[...]
    master: Executing %posttrans script 'python3-salt-2019.2.0-6.24.1.x86_64.rpm' [..
    master: ..done]
    master: ++ sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
    master: ++ systemctl enable salt-master
    master: Created symlink /etc/systemd/system/multi-user.target.wants/salt-master.service → /usr/lib/systemd/system/salt-master.service.
    master: ++ systemctl start salt-master
    master: ++ sleep 5
    master: ++ systemctl restart salt-minion
    master: Failed to restart salt-minion.service: Unit salt-minion.service not found.
Command '['vagrant', 'up']' failed: ret=1 stderr:
==> master: An error occurred. The error will be shown after all tasks complete.
An error occurred while executing multiple actions in parallel.
Any errors that occurred are shown below.

An error occurred while executing the action on the 'master'
machine. Please handle this error then try again:

The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

This is because of a "logic bug" in `seslib/templates/provision.sh.j2`. Specifically, when CaaSP is detected then `salt-minion` is not installed in the master node, nor the minions in workers point to the master. After some slight changes in `seslib/templates/provision.sh.j2`, CaaSP creation goes through and finishes with no issues:

```
[...]
    master: 4 of 4 minions have submitted their keys.
    master: ++ salt-key -Ay
    master: The following keys are going to be accepted:
    master: Unaccepted Keys:
    master: master.caasp4.is
    master: worker1.caasp4.is
    master: worker2.caasp4.is
    master: worker3.caasp4.is
    master: Key for minion master.caasp4.is accepted.
    master: Key for minion worker1.caasp4.is accepted.
    master: Key for minion worker2.caasp4.is accepted.
    master: Key for minion worker3.caasp4.is accepted.
    master: Pinging 4 minions...
    master: ++ set +ex
    master: 0 of 4 minions responded to ping.
    master: ++ sleep 3
    master: Pinging 4 minions...
    master: ++ set +x
    master: 4 of 4 minions responded to ping.
=== Deployment Finished ===

You can login into the cluster with:

  $ sesdev ssh reykjavik

Or, access the Ceph Dashboard with:

  $ sesdev tunnel reykjavik dashboard
```