### PR TITLE
provision.sh: enable autorefresh on all repos

### DIFF
--- a/seslib/templates/caasp/loadbalancer.sh.j2
+++ b/seslib/templates/caasp/loadbalancer.sh.j2
@@ -1,4 +1,5 @@
-zypper -n install nginx
+
+zypper --non-interactive install nginx
 
 cat > /etc/nginx/nginx.conf << EOF
 user  nginx;

--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -1,5 +1,5 @@
 
-zypper -n in -t pattern SUSE-CaaSP-Management
+zypper --non-interactive install --type pattern SUSE-CaaSP-Management
 
 {% if node.name == 'master1' %}
 
@@ -21,7 +21,7 @@ function wait_for_workers_ready {
     printf "\n"
 }
 
-zypper -n in skuba skuba-update
+zypper --non-interactive install skuba skuba-update
 
 touch /tmp/ready
 
@@ -146,7 +146,7 @@ rm ${MLBCONFIG}
 
 # deploy and configure rook + Ceph
 
-zypper -n in rook-k8s-yaml
+zypper --non-interactive install rook-k8s-yaml
 cd /usr/share/k8s-yaml/rook/ceph/
 
 {% if node_manager.get_by_role('worker') | length <3 %}

--- a/seslib/templates/caasp/provision.sh.j2
+++ b/seslib/templates/caasp/provision.sh.j2
@@ -9,10 +9,9 @@ echo "sles ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/sles
 cp -r /root/.ssh/ /home/sles/
 chown -R sles:users /home/sles/.ssh/
 
-zypper -n install cri-o-kubeadm-criconfig kubernetes-kubeadm kubernetes-kubelet \
-          kubernetes-client podman SUSEConnect nfs-client
+zypper --non-interactive install cri-o-kubeadm-criconfig kubernetes-kubeadm kubernetes-kubelet kubernetes-client podman SUSEConnect nfs-client
 
-zypper -n install -t pattern SUSE-CaaSP-Node
+zypper --non-interactive install --type pattern SUSE-CaaSP-Node
 
 {% if node.has_role('master') %}
 {% include "caasp/master.sh.j2" %}

--- a/seslib/templates/caasp/storage.sh.j2
+++ b/seslib/templates/caasp/storage.sh.j2
@@ -1,4 +1,5 @@
-zypper -n in nfs-kernel-server
+
+zypper --non-interactive install nfs-kernel-server
 
 mkdir /nfs
 echo '/nfs     *.{{ domain }}(rw,no_root_squash)' >/etc/exports

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -6,7 +6,7 @@ set -ex
 cd /root
 git clone {{ ceph_salt_git_repo }}
 cd ceph-salt
-zypper -n in autoconf gcc python3-devel python3-pip python3-curses
+zypper --non-interactive install autoconf gcc python3-devel python3-pip python3-curses
 
 {% if ceph_salt_fetch_github_pr_heads %}
 # fetch the available PRs (HEAD) from github. With that, "ceph_salt_git_branch" can be something like "origin/pr/127" to checkout a github PR
@@ -25,7 +25,7 @@ cp -r ceph-salt-formula/salt/* /srv/salt/
 chown -R salt:salt /srv
 {% else %}
 # ceph-salt-formula is installed automatically as a dependency of ceph-salt
-zypper -n in ceph-salt
+zypper --non-interactive install ceph-salt
 {% endif %}
 
 systemctl restart salt-master
@@ -86,7 +86,7 @@ ceph-salt config ls
 ceph-salt export --pretty
 ceph-salt status
 
-zypper lr -upEP
+zypper repos -upEP
 zypper info cephadm | grep -E '(^Repo|^Version)'
 ceph-salt --version
 

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -6,9 +6,9 @@ git checkout {{ deepsea_git_branch }}
 make install
 {% else %}
 {% if version == 'ses5' %}
-zypper -n install deepsea
+zypper --non-interactive install deepsea
 {% else %}
-zypper -n install deepsea deepsea-cli
+zypper --non-interactive install deepsea deepsea-cli
 {% endif %}
 {% endif %}
 deepsea --version

--- a/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
+++ b/seslib/templates/deepsea/ses5_pre_stage_0.sh.j2
@@ -6,7 +6,7 @@ if [ ! -e /etc/fstab ]; then
     echo "$uuid $partial" > /etc/fstab
 fi
 
-zypper -n install SuSEfirewall2
+zypper --non-interactive install SuSEfirewall2
 SuSEfirewall2 off
 
 sed -i 's/#worker_threads: 5/worker_threads: 10/g' /etc/salt/master

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -13,17 +13,18 @@ echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/host
 {% endif %}
 {% endfor %}
 
+# do not exclude documentation files when installing RPM packages
 sed -i 's/^rpm\.install\.excludedocs.*$/# rpm.install.excludedocs = no/' /etc/zypp/zypp.conf
 
 # enable autorefresh on all zypper repos
 find /etc/zypp/repos.d -type f -exec sed -i -e 's/^autorefresh=.*/autorefresh=1/' {} \;
 
 # remove "which" RPM because testing environments typically don't have it installed
-zypper -n rm which || true
+zypper --non-interactive remove which || true
 
 # remove Python 2 so it doesn't pollute the environment
 {% if os != 'sles-12-sp3' %}
-zypper -n rm python-base || true
+zypper --non-interactive remove python-base || true
 {% endif %}
 
 # remove Non-OSS repos in openSUSE
@@ -36,11 +37,11 @@ zypper --non-interactive removerepo repo-source-non-oss || true
 {% endif %}
 
 {% for os_repo_name, os_repo_url in os_base_repos %}
-zypper addrepo {{ os_repo_url }} {{ os_repo_name }}
+zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}
 
 {% for _repo in version_repos_prio %}
-zypper addrepo
+zypper addrepo --refresh
 {%- if _repo.priority %}
  --priority {{ _repo.priority }}
 {%- elif repo_priority %}
@@ -79,9 +80,9 @@ zypper --non-interactive install --from update --force libncurses5 libncurses6
        'command-not-found',
    ] %}
 {% if os == 'sles-12-sp3' %}
-zypper -n install {{ basic_pkgs_to_install | join(' ') }} ntp
+zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} ntp
 {% else %}
-zypper -n install {{ basic_pkgs_to_install | join(' ') }} chrony hostname
+zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} chrony hostname
 {% endif %}
 
 {% if os.startswith("sle") %}
@@ -90,13 +91,13 @@ zypper -n install {{ basic_pkgs_to_install | join(' ') }} chrony hostname
        'supportutils',
        'supportutils-plugin-ses',
    ] %}
-zypper -n install {{ sle_pkgs_to_install | join(' ') }}
+zypper --non-interactive install {{ sle_pkgs_to_install | join(' ') }}
 {% endif %}
 
 {% for repo in node.repos %}
-zypper ar {{ repo.url }} {{ repo.name }}
+zypper addrepo --refresh {{ repo.url }} {{ repo.name }}
 {% if repo_priority and repo.priority %}
-zypper mr -p {{ repo.priority }} {{ repo.name }}
+zypper modifyrepo --priority {{ repo.priority }} {{ repo.name }}
 {% endif %}
 {% endfor %}
 {% if node.repos|length > 0 %}
@@ -117,7 +118,7 @@ hostnamectl set-hostname {{ node.name }}
 {% elif version == 'makecheck' %}
 {% include "makecheck/provision.sh.j2" %}
 {% elif not suma %}
-zypper -n install salt-minion
+zypper --non-interactive install salt-minion
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
 
 # change salt log level to info
@@ -137,7 +138,7 @@ touch /tmp/ready
 {% if node == master or node == suma %}
 
 {% if node == master %}
-zypper -n install salt-master
+zypper --non-interactive install salt-master
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
 systemctl enable salt-master
 systemctl start salt-master

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -15,6 +15,9 @@ echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/host
 
 sed -i 's/^rpm\.install\.excludedocs.*$/# rpm.install.excludedocs = no/' /etc/zypp/zypp.conf
 
+# enable autorefresh on all zypper repos
+find /etc/zypp/repos.d -type f -exec sed -i -e 's/^autorefresh=.*/autorefresh=1/' {} \;
+
 # remove "which" RPM because testing environments typically don't have it installed
 zypper -n rm which || true
 

--- a/seslib/templates/suma/suma_deployment.sh.j2
+++ b/seslib/templates/suma/suma_deployment.sh.j2
@@ -1,8 +1,9 @@
+
 systemctl stop firewalld
 
 sed -i 's/^.*onlyRequires = true$/solver.onlyRequires = false/g' /etc/zypp/zypp.conf
 
-zypper -n in xfsprogs
+zypper --non-interactive install xfsprogs
 
 SW_DEV=`lsblk --nodeps -o name,size | grep ^vd | grep 101G | head -1 | cut -d' ' -f1`
 PG_DEV=`lsblk --nodeps -o name,size | grep ^vd | grep 51G | head -1 | cut -d' ' -f1`
@@ -17,7 +18,7 @@ mkdir -p /var/lib/pgsql
 mount /var/spacewalk
 mount /var/lib/pgsql
 
-zypper -n in -t pattern uyuni_server
+zypper --non-interactive install --type pattern uyuni_server
 
 cat > /root/setup_env.sh <<EOF
 MANAGER_FORCE_INSTALL='0'


### PR DESCRIPTION
We transiently hit the following error when running "zypper install",
even when network connectivity is OK:

    Media source
    'http://download.opensuse.org/distribution/leap/15.2/repo/oss/' does not
    contain the desired medium

This is because the SLE/Leap repos are periodically updated and we race
with these updates. To reduce the probability of hitting the error, we
enable "autorefresh" on all zypper repos.

Fixes: https://github.com/SUSE/sesdev/issues/287
