### PR TITLE
ceph_salt_deployment.sh: rip out time sync code

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -103,56 +103,6 @@ stdbuf -o0 ceph-salt -ldebug apply --non-interactive
 
 {% if ceph_salt_deploy_mons %}
 {% if mon_nodes > 1 %}
-TIME_SERVER="$(ceph-salt export | jq -r .time_server.server_host)"
-{% set chrony_script = "chrony_sync_start.sh" %}
-cat > /root/{{ chrony_script }} << 'EOF'
-#!/bin/bash
-
-set -x
-
-function try_wait {
-    local cmd="$1"
-    local tries="$2"
-    local sleep_secs="$3"
-    set +x
-    for i in $(seq 1 "$tries") ; do
-        set -x
-        $cmd
-        set +x
-        SAVED_STATUS="$?"
-        test "$SAVED_STATUS" = "0" && break
-        set -x
-        sleep "$sleep_secs"
-        set +x
-    done
-    set -x
-}
-
-chronyc 'burst 4/4'
-sleep 15
-chronyc makestep
-stdbuf -o0 chronyc waitsync 30 0.04
-try_wait "chronyc -n sources" 10 5
-systemctl status --lines 20 chronyd.service | grep stepped
-chronyc tracking
-EOF
-chmod 755 /root/{{ chrony_script }}
-{% for _node in nodes %}
-{% if _node != master %}
-scp -o StrictHostKeyChecking=no /root/{{ chrony_script }} {{ _node.name }}:
-{% endif %}
-{% endfor %}
-{% for _node in nodes %}
-if [ "{{ _node.fqdn }}" == "$TIME_SERVER" ] ; then
-    ssh -o StrictHostKeyChecking=no {{ _node.name }} ./{{ chrony_script }}
-fi
-{% endfor %}
-{% for _node in nodes %}
-if [ "{{ _node.fqdn }}" != "$TIME_SERVER" ] ; then
-    ssh -o StrictHostKeyChecking=no {{ _node.name }} ./{{ chrony_script }} &
-fi
-{% endfor %}
-wait
 ceph orch apply mon "$MON_NODES_COMMA_SEPARATED_LIST"
 {% endif %} {# mon_nodes > 1 #}
 {% endif %} {# ceph_salt_deploy_mons #}


### PR DESCRIPTION
ceph-salt got the ability to sync the clocks with

https://github.com/ceph/ceph-salt/pull/202

and that rendered this code superfluous.

Signed-off-by: Nathan Cutler <ncutler@suse.com>