### PR TITLE
Rename '--stop-before-ceph-salt-deploy' to '--stop-before-ceph-salt-apply'

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -67,9 +67,9 @@ def deepsea_options(func):
 def ceph_salt_options(func):
     click_options = [
         click.option('--stop-before-ceph-salt-config', is_flag=True, default=False,
-                     help='Allows to stop deployment configuring the cluster with ceph-salt'),
-        click.option('--stop-before-ceph-salt-deploy', is_flag=True, default=False,
-                     help='Allows to stop deployment deploying the cluster with ceph-salt'),
+                     help='Allows to stop deployment before creating ceph-salt configuration'),
+        click.option('--stop-before-ceph-salt-apply', is_flag=True, default=False,
+                     help='Allows to stop deployment before applying ceph-salt configuration'),
         click.option('--ceph-salt-repo', type=str, default=None,
                      help='ceph-salt Git repo URL'),
         click.option('--ceph-salt-branch', type=str, default=None,
@@ -469,7 +469,7 @@ def _gen_settings_dict(version,
                        ceph_salt_repo=None,
                        ceph_salt_branch=None,
                        stop_before_ceph_salt_config=False,
-                       stop_before_ceph_salt_deploy=False,
+                       stop_before_ceph_salt_apply=False,
                        image_path=None,
                        deploy_mons=None,
                        deploy_mgrs=None,
@@ -610,8 +610,8 @@ def _gen_settings_dict(version,
     if stop_before_ceph_salt_config is not None:
         settings_dict['stop_before_ceph_salt_config'] = stop_before_ceph_salt_config
 
-    if stop_before_ceph_salt_deploy is not None:
-        settings_dict['stop_before_ceph_salt_deploy'] = stop_before_ceph_salt_deploy
+    if stop_before_ceph_salt_apply is not None:
+        settings_dict['stop_before_ceph_salt_apply'] = stop_before_ceph_salt_apply
 
     if image_path:
         settings_dict['image_path'] = image_path

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -518,9 +518,9 @@ SETTINGS = {
         'help': 'Stops deployment before ceph-salt config',
         'default': False,
     },
-    'stop_before_ceph_salt_deploy': {
+    'stop_before_ceph_salt_apply': {
         'type': bool,
-        'help': 'Stops deployment before ceph-salt deploy',
+        'help': 'Stops deployment before ceph-salt apply',
         'default': False,
     },
     'image_path': {
@@ -1266,7 +1266,7 @@ class Deployment():
             'ceph_salt_fetch_github_pr_heads': ceph_salt_fetch_github_pr_heads,
             'ceph_salt_fetch_github_pr_merges': ceph_salt_fetch_github_pr_merges,
             'stop_before_ceph_salt_config': self.settings.stop_before_ceph_salt_config,
-            'stop_before_ceph_salt_deploy': self.settings.stop_before_ceph_salt_deploy,
+            'stop_before_ceph_salt_apply': self.settings.stop_before_ceph_salt_apply,
             'image_path': self.settings.image_path,
             'ceph_salt_deploy_mons': self.settings.ceph_salt_deploy_mons,
             'ceph_salt_deploy_mgrs': self.settings.ceph_salt_deploy_mgrs,

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -91,7 +91,7 @@ zypper repos -upEP
 zypper info cephadm | grep -E '(^Repo|^Version)'
 ceph-salt --version
 
-{% if stop_before_ceph_salt_deploy %}
+{% if stop_before_ceph_salt_apply %}
 exit 0
 {% endif %}
 


### PR DESCRIPTION
`ceph-salt deploy` command was renamed to `ceph-salt apply`, so we should rename the `--stop-before-ceph-salt-deploy` option accordingly.

Signed-off-by: Ricardo Marques <rimarques@suse.com>