### PR TITLE
Add '--stop-before-ceph-orch-apply' option

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -70,16 +70,14 @@ def ceph_salt_options(func):
                      help='Allows to stop deployment before creating ceph-salt configuration'),
         click.option('--stop-before-ceph-salt-apply', is_flag=True, default=False,
                      help='Allows to stop deployment before applying ceph-salt configuration'),
+        click.option('--stop-before-ceph-orch-apply', is_flag=True, default=False,
+                     help='Allows to stop deployment before applying ceph orch service spec'),
         click.option('--ceph-salt-repo', type=str, default=None,
                      help='ceph-salt Git repo URL'),
         click.option('--ceph-salt-branch', type=str, default=None,
                      help='ceph-salt Git branch'),
         click.option('--image-path', type=str, default=None,
                      help='registry path from which to download Ceph container image'),
-        click.option('--deploy-mons/--no-deploy-mons', default=True, help='Deploy Ceph MONs'),
-        click.option('--deploy-mgrs/--no-deploy-mgrs', default=True, help='Deploy Ceph MGRs'),
-        click.option('--deploy-osds/--no-deploy-osds', default=True, help='Deploy Ceph OSDs'),
-        click.option('--deploy-mdss/--no-deploy-mdss', default=True, help='Deploy Ceph MDSs'),
         click.option('--salt/--ceph-salt', default=False,
                      help='Use "salt" (instead of "ceph-salt") to run ceph-salt formula'),
     ]
@@ -470,11 +468,8 @@ def _gen_settings_dict(version,
                        ceph_salt_branch=None,
                        stop_before_ceph_salt_config=False,
                        stop_before_ceph_salt_apply=False,
+                       stop_before_ceph_orch_apply=False,
                        image_path=None,
-                       deploy_mons=None,
-                       deploy_mgrs=None,
-                       deploy_osds=None,
-                       deploy_mdss=None,
                        ceph_repo=None,
                        ceph_branch=None,
                        username=None,
@@ -613,6 +608,9 @@ def _gen_settings_dict(version,
     if stop_before_ceph_salt_apply is not None:
         settings_dict['stop_before_ceph_salt_apply'] = stop_before_ceph_salt_apply
 
+    if stop_before_ceph_orch_apply is not None:
+        settings_dict['stop_before_ceph_orch_apply'] = stop_before_ceph_orch_apply
+
     if image_path:
         settings_dict['image_path'] = image_path
 
@@ -633,18 +631,6 @@ def _gen_settings_dict(version,
 
     if stop_before_run_make_check is not None:
         settings_dict['makecheck_stop_before_run_make_check'] = stop_before_run_make_check
-
-    if deploy_mons is not None:
-        settings_dict['ceph_salt_deploy_mons'] = deploy_mons
-
-    if deploy_mgrs is not None:
-        settings_dict['ceph_salt_deploy_mgrs'] = deploy_mgrs
-
-    if deploy_osds is not None:
-        settings_dict['ceph_salt_deploy_osds'] = deploy_osds
-
-    if deploy_mdss is not None:
-        settings_dict['ceph_salt_deploy_mdss'] = deploy_mdss
 
     for folder in synced_folder:
         try:

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -523,6 +523,11 @@ SETTINGS = {
         'help': 'Stops deployment before ceph-salt apply',
         'default': False,
     },
+    'stop_before_ceph_orch_apply': {
+        'type': bool,
+        'help': 'Stops deployment before ceph orch apply',
+        'default': False,
+    },
     'image_path': {
         'type': str,
         'help': 'Container image path for Ceph daemons',
@@ -557,26 +562,6 @@ SETTINGS = {
         'type': bool,
         'help': 'Stop before running run-make-check.sh (make check)',
         'default': False,
-    },
-    'ceph_salt_deploy_mons': {
-        'type': bool,
-        'help': 'Tell ceph-salt to deploy Ceph MONs',
-        'default': True,
-    },
-    'ceph_salt_deploy_mgrs': {
-        'type': bool,
-        'help': 'Tell ceph-salt to deploy Ceph MGRs',
-        'default': True,
-    },
-    'ceph_salt_deploy_osds': {
-        'type': bool,
-        'help': 'Tell ceph-salt to deploy Ceph OSDs',
-        'default': True,
-    },
-    'ceph_salt_deploy_mdss': {
-        'type': bool,
-        'help': 'Tell ceph-salt to deploy Ceph MDSs',
-        'default': True,
     },
     'use_salt': {
         'type': bool,
@@ -1267,11 +1252,8 @@ class Deployment():
             'ceph_salt_fetch_github_pr_merges': ceph_salt_fetch_github_pr_merges,
             'stop_before_ceph_salt_config': self.settings.stop_before_ceph_salt_config,
             'stop_before_ceph_salt_apply': self.settings.stop_before_ceph_salt_apply,
+            'stop_before_ceph_orch_apply': self.settings.stop_before_ceph_orch_apply,
             'image_path': self.settings.image_path,
-            'ceph_salt_deploy_mons': self.settings.ceph_salt_deploy_mons,
-            'ceph_salt_deploy_mgrs': self.settings.ceph_salt_deploy_mgrs,
-            'ceph_salt_deploy_osds': self.settings.ceph_salt_deploy_osds,
-            'ceph_salt_deploy_mdss': self.settings.ceph_salt_deploy_mdss,
             'use_salt': self.settings.use_salt,
             'node_manager': NodeManager(list(self.nodes.values())),
             'caasp_deploy_ses': self.settings.caasp_deploy_ses,

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -101,29 +101,25 @@ salt -G 'ceph-salt:member' state.apply ceph-salt
 stdbuf -o0 ceph-salt -ldebug apply --non-interactive
 {% endif %}
 
-{% if ceph_salt_deploy_mons %}
+{% if stop_before_ceph_orch_apply %}
+exit 0
+{% endif %}
+
 {% if mon_nodes > 1 %}
 ceph orch apply mon "$MON_NODES_COMMA_SEPARATED_LIST"
 {% endif %} {# mon_nodes > 1 #}
-{% endif %} {# ceph_salt_deploy_mons #}
 
-{% if ceph_salt_deploy_mgrs %}
 {% if mgr_nodes > 1 %}
 ceph orch apply mgr "$MGR_NODES_COMMA_SEPARATED_LIST"
 {% endif %} {# mgr_nodes > 1 #}
-{% endif %} {# ceph_salt_deploy_mgrs #}
 
-{% if ceph_salt_deploy_osds %}
 ceph orch device ls --refresh
 {% for node in nodes %}
 {% if node.has_role('storage') %}
 echo "{\"service_type\": \"osd\", \"placement\": {\"host_pattern\": \"{{ node.name }}*\"}, \"service_id\": \"testing_dg_{{ node.name }}\", \"data_devices\": {\"all\": True}}" | ceph orch apply osd -i -
 {% endif %}
 {% endfor %}
-{% endif %} {# if ceph_salt_deploy_osds #}
 
-{% if ceph_salt_deploy_mdss %}
 ceph fs volume create myfs "$MDS_NODES_COMMA_SEPARATED_LIST"
-{% endif %} {# if ceph_salt_deploy_mdss #}
 
 {% include "qa_test.sh.j2" %}


### PR DESCRIPTION
This PR adds a new `--stop-before-ceph-orch-apply` option that allows to stop the deployment before applying ceph orch service spec (before deploying ODS, MON, MGR, etc..).

This option replacing the old `--deploy-mons`, `--deploy-mgrs`, `--deploy-osds` and `--deploy-mdss` options.

Signed-off-by: Ricardo Marques <rimarques@suse.com>