### PR TITLE
provision.sh: remove curl RPM from the environment

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -19,8 +19,13 @@ sed -i 's/^rpm\.install\.excludedocs.*$/# rpm.install.excludedocs = no/' /etc/zy
 # enable autorefresh on all zypper repos
 find /etc/zypp/repos.d -type f -exec sed -i -e 's/^autorefresh=.*/autorefresh=1/' {} \;
 
-# remove "which" RPM because testing environments typically don't have it installed
+# remove RPMs that are often silently assumed to be present
+# removing such RPMs is desirable because these "implied" dependencies become
+# known, allowing them to be explicitly declared
 zypper --non-interactive remove which || true
+{% if version != 'ses5' %}
+zypper --non-interactive remove curl || true
+{% endif %}
 
 # remove Python 2 so it doesn't pollute the environment
 {% if os != 'sles-12-sp3' %}


### PR DESCRIPTION
Like "which", "curl" is an RPM that is often silently assumed to be
present, leading to bugs like:

https://tracker.ceph.com/issues/44498

Signed-off-by: Nathan Cutler <ncutler@suse.com>