### PR TITLE
ceph_salt_deployment: do not deploy MDS if no mds roles present

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -118,6 +118,8 @@ echo "{\"service_type\": \"osd\", \"placement\": {\"host_pattern\": \"{{ node.na
 {% endif %}
 {% endfor %}
 
+{% if mds_nodes > 0 %}
 ceph fs volume create myfs "$MDS_NODES_COMMA_SEPARATED_LIST"
+{% endif %}
 
 {% include "qa_test.sh.j2" %}


### PR DESCRIPTION
ed870ab4f7838200729dabc93bce108ba9464aa3 got rid of
"ceph_salt_deploy_mdss" but we still need to check that there are some "mds"
roles present and, if not, refrain from issuing the command

    ceph fs volume create myfs ...

Fixes: ed870ab4f7838200729dabc93bce108ba9464aa3
Signed-off-by: Nathan Cutler <ncutler@suse.com>