### PR TITLE
Make use of 'cephadm' role

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -44,6 +44,7 @@ MDS_NODES_COMMA_SEPARATED_LIST=""
 {% for node in nodes %}
 {% if node.has_roles() and not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
+ceph-salt config /ceph_cluster/roles/cephadm add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
 {% endif %}
 {% if node.has_role('bootstrap') %}


### PR DESCRIPTION
Adapts `sesdev` according to https://github.com/ceph/ceph-salt/pull/235

Signed-off-by: Ricardo Marques <rimarques@suse.com>