### PR TITLE
caasp: do not install salt

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -1222,6 +1222,9 @@ class Deployment():
             'deepsea_git_repo': self.settings.deepsea_git_repo,
             'deepsea_git_branch': self.settings.deepsea_git_branch,
             'version': self.settings.version,
+            'deploy_salt': bool(self.settings.version != 'makecheck' and
+                                self.settings.version != 'caasp4' and
+                                not self.suma),
             'stop_before_stage': self.settings.stop_before_stage,
             'deployment_tool': self.settings.deployment_tool,
             'version_repos_prio': version_repos_prio,

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -114,13 +114,7 @@ ln -s /root/.ssh/{{ ssh_key_name }}.pub /root/.ssh/id_rsa.pub
 cat /root/.ssh/{{ ssh_key_name }}.pub >> /root/.ssh/authorized_keys
 hostnamectl set-hostname {{ node.name }}
 
-{% if version == 'caasp4' %}
-{% include "caasp/provision.sh.j2" %}
-{% endif %}
-
-{% if version == 'makecheck' %}
-{% include "makecheck/provision.sh.j2" %}
-{% elif not suma %}
+{% if deploy_salt %}
 zypper --non-interactive install salt-minion
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
 
@@ -134,9 +128,11 @@ systemctl start salt-minion
 {% include "sync_clocks.sh.j2" %}
 {% endif %}
 
-{% endif %} {# not suma #}
+{% endif %} {# deploy_salt #}
 
 touch /tmp/ready
+
+{% if deploy_salt or suma %}
 
 {% if node == master or node == suma %}
 
@@ -200,3 +196,11 @@ salt-key -Ay
 {% endif %}
 
 {% endif %} {# node == master or node == suma #}
+
+{% endif %} {# deploy_salt or suma #}
+
+{% if version == 'caasp4' %}
+{% include "caasp/provision.sh.j2" %}
+{% elif version == 'makecheck' %}
+{% include "makecheck/provision.sh.j2" %}
+{% endif %}


### PR DESCRIPTION
As far as I can tell, Salt is not required in a CaaSP deployment.

Signed-off-by: Nathan Cutler <ncutler@suse.com>