### PR TITLE
supportconfig: handle /var/log/scc* and /var/log/nts*

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -182,6 +182,7 @@ if [ "$SES5" ] ; then
     run_cmd sesdev destroy --non-interactive ses5-1node
     run_cmd sesdev create ses5 --non-interactive --roles "[master,client,openattic],[storage,mon,mgr,rgw],[storage,mon,mgr,mds,nfs],[storage,mon,mgr,mds,rgw,nfs]" ses5-4node
     run_cmd sesdev qa-test ses5-4node
+    run_cmd sesdev supportconfig ses5-4node node1
     # consider uncommenting after the following bugs are fixed:
     # - https://github.com/SUSE/sesdev/issues/276
     # - https://github.com/SUSE/sesdev/issues/291
@@ -205,6 +206,7 @@ if [ "$SES6" ] ; then
     run_cmd sesdev destroy --non-interactive ses6-1node
     run_cmd sesdev create ses6 --non-interactive ses6-4node
     run_cmd sesdev qa-test ses6-4node
+    run_cmd sesdev supportconfig ses6-4node node1
     # consider uncommenting after the following bugs are fixed:
     # - https://github.com/SUSE/sesdev/issues/276
     # - https://github.com/SUSE/sesdev/issues/291
@@ -228,6 +230,7 @@ if [ "$SES7" ] ; then
     run_cmd sesdev destroy --non-interactive ses7-1node
     run_cmd sesdev create ses7 --non-interactive $CEPH_SALT_FROM_SOURCE ses7-4node
     run_cmd sesdev qa-test ses7-4node
+    run_cmd sesdev supportconfig ses7-4node node1
     # consider uncommenting after the following bugs are fixed:
     # - bsc#1170498
     # - https://github.com/SUSE/sesdev/issues/276

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -21,7 +21,7 @@ from .exceptions import DeploymentDoesNotExists, VersionOSNotSupported, SettingT
                         CmdException, VagrantSshConfigNoHostName, ScpInvalidSourceOrDestination, \
                         UniqueRoleViolation, SettingNotKnown, SupportconfigOnlyOnSLE, \
                         NoPrometheusGrafanaInSES5, BadMakeCheckRolesNodes, \
-                        DuplicateRolesNotSupported
+                        DuplicateRolesNotSupported, NoSupportConfigTarballFound
 
 
 JINJA_ENV = Environment(loader=PackageLoader('seslib', 'templates'), trim_blocks=True)
@@ -1574,7 +1574,7 @@ class Deployment():
         return _cmd
 
     def ssh(self, name, command):
-        tools.run_interactive(self._ssh_cmd(name, command))
+        return tools.run_interactive(self._ssh_cmd(name, command))
 
     def _scp_cmd(self, source, destination, recurse=False):
         host_is_source = False
@@ -1640,9 +1640,20 @@ class Deployment():
             ))
         self.ssh(name, ('supportconfig',))
         log_handler("=> Grabbing the resulting tarball from the cluster node\n")
-        self.scp(str(name) + ':/var/log/nts*', '.')
+        scc_exists = self.ssh(name, ('ls', '/var/log/scc*'))
+        nts_exists = self.ssh(name, ('ls', 'var/log/nts*'))
+        glob_to_get = None
+        if scc_exists == 0:
+            log_handler("Found /var/log/scc* (supportconfig) files on {}\n".format(name))
+            glob_to_get = 'scc*'
+        elif nts_exists == 0:
+            log_handler("Found /var/log/nts* (supportconfig) files on {}\n".format(name))
+            glob_to_get = 'nts*'
+        else:
+            raise NoSupportConfigTarballFound(name)
+        self.scp('{n}:/var/log/{g}'.format(n=name, g=glob_to_get), '.')
         log_handler("=> Deleting the tarball from the cluster node\n")
-        self.ssh(name, ('rm', '/var/log/nts*'))
+        self.ssh(name, ('rm', '/var/log/{}'.format(glob_to_get)))
 
     def qa_test(self, log_handler):
         tools.run_async(

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -176,3 +176,9 @@ class DuplicateRolesNotSupported(SesDevException):
             "A node with more than one \"{r}\" role was detected. "
             "sesdev does not support more than one \"{r}\" role per node.".format(r=role)
             )
+
+
+class NoSupportConfigTarballFound(SesDevException):
+    def __init__(self, node):
+        super(NoSupportConfigTarballFound, self).__init__(
+            "No supportconfig tarball found on node {}".format(node))


### PR DESCRIPTION
Recently, supportconfig started creating tarballs starting with "scc",
whereas before they used to start with "nts". Handle both cases.

Fixes: https://github.com/SUSE/sesdev/issues/322
Signed-off-by: Nathan Cutler <ncutler@suse.com>