### PR TITLE
makecheck: possibly prophylactically downgrade libncurses6

### DIFF
--- a/seslib/templates/makecheck/provision.sh.j2
+++ b/seslib/templates/makecheck/provision.sh.j2
@@ -13,6 +13,7 @@ set -ex
 # problem in the past:
 #
 zypper --non-interactive install --force libudev1 || true
+zypper --non-interactive install --force libncurses6 || true
 
 useradd -m {{ makecheck_username }}
 echo "{{ makecheck_username }} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Avoid the following zypper conflict:

```
03:20:45 Problem: ncurses-devel-6.1-lp152.7.53.x86_64 requires libncurses6 = 6.1-lp152.7.53, but this requirement cannot be provided
03:20:45   not installable providers: libncurses6-6.1-lp152.7.53.x86_64[oss]
03:20:45  Solution 1: Following actions will be done:
03:20:45   do not install ncurses-devel-6.1-lp152.7.53.x86_64
03:20:45   do not install cunit-devel-2.1.3-lp152.3.5.x86_64
03:20:45   do not install libxml2-devel-2.9.7-lp152.7.7.x86_64
03:20:45   do not install xmlsec1-devel-1.2.28-lp152.1.2.x86_64
03:20:45   do not install xmlsec1-openssl-devel-1.2.28-lp152.1.2.x86_64
03:20:45  Solution 2: downgrade of libncurses6-6.1-lp152.7.57.x86_64 to libncurses6-6.1-lp152.7.53.x86_64
03:20:45  Solution 3: break ncurses-devel-6.1-lp152.7.53.x86_64 by ignoring some of its dependencies
03:20:45
03:20:45 Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
```

Signed-off-by: Nathan Cutler <ncutler@suse.com>