### PR TITLE
ceph_salt_deployment: fix use_salt=True deployment

### DIFF
--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -31,10 +31,11 @@ zypper --non-interactive install ceph-salt
 systemctl restart salt-master
 {% include "wait_for_minions.sh.j2" %}
 
+{% if use_salt %}
 salt '*' saltutil.pillar_refresh
 salt '*' saltutil.sync_all
-
 sleep 2
+{% endif %}
 
 {% if stop_before_ceph_salt_config %}
 exit 0

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -31,6 +31,11 @@ zypper --non-interactive install ceph-salt
 systemctl restart salt-master
 {% include "wait_for_minions.sh.j2" %}
 
+salt '*' saltutil.pillar_refresh
+salt '*' saltutil.sync_all
+
+sleep 2
+
 {% if stop_before_ceph_salt_config %}
 exit 0
 {% endif %}


### PR DESCRIPTION
Since 73a121a81e28c4d9acefc5cf3bcaf907463d7fda the use_salt=True
(--salt) deployment has been broken.

When using Salt to apply the Salt Formula, one must sync the Salt
modules (i.e. copy the modules to all the minions) manually, first.
When using "ceph-salt apply", this step is automated.

Fixes: 73a121a81e28c4d9acefc5cf3bcaf907463d7fda
Fixes: https://github.com/ceph/ceph-salt/issues/198
