### PR TITLE
Allow user to re-install ceph-salt from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The Jenkins CI tests that `sesdev` can be used to deploy a single-node Ceph
       * [Run "make check" on openSUSE Leap 15.2 from upstream "octopus" branch](#run-make-check-on-opensuse-leap-152-from-upstream-octopus-branch)
       * [Run "make check" on SLE-15-SP2 from downstream "ses7" branch](#run-make-check-on-sle-15-sp2-from-downstream-ses7-branch)
       * [Other "make check" scenarios](#other-make-check-scenarios)
+   * [Replace ceph-salt](#replace-ceph-salt)
 * [Common pitfalls](#common-pitfalls)
    * [Domain about to create is already taken](#domain-about-to-create-is-already-taken)
    * [Storage pool not found: no storage pool with matching name 'default'](#storage-pool-not-found-no-storage-pool-with-matching-name-default)
@@ -599,6 +600,19 @@ $ sesdev tunnel <deployment_id> dashboard
 ```
 
 The command will output the URL that you can use to access the dashboard.
+
+### Replace ceph-salt
+
+For deployments that used ceph-salt, it's possible to replace the ceph-salt
+installed by sesdev with a different one:
+
+```
+$ sesdev replace-ceph-salt --local <path> <deployment_id>
+```
+
+Assuming `<path>` points to ceph-salt source code, the command will work
+regardless of whether ceph-salt was originally installed from source or
+from RPM.
 
 ### Temporarily stop a cluster
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -1140,5 +1140,17 @@ def tunnel(deployment_id, service=None, node=None, remote_port=None, local_port=
     dep.start_port_forwarding(service, node, remote_port, local_port, local_address)
 
 
+@cli.command(name='replace-ceph-salt')
+@click.argument('deployment_id')
+@click.option('--local', default=None, type=str, show_default=True,
+              help='The local path for "ceph-salt" source')
+def replace_ceph_salt(deployment_id, local=None):
+    """
+    Install ceph-salt from source
+    """
+    dep = seslib.Deployment.load(deployment_id)
+    dep.replace_ceph_salt(local)
+
+
 if __name__ == '__main__':
     sys.exit(sesdev_main())


### PR DESCRIPTION
This PR adds the `replace-ceph-salt` command that allows the user to re-install ceph-salt from a given source (by using `rsync` to update files):

```
# sesdev replace-ceph-salt octopus --local ~/projects/ceph-salt
```
This PR was inspired by https://github.com/SUSE/sesdev/pull/24, so all different options to fetch code should be consistent between both `replace-ceph-salt` and `replace-mgr-modules` commands.

For now, only `local` code is supported.

Signed-off-by: Ricardo Marques <rimarques@suse.com>