### PR TITLE
Drop the --use-deepsea option for {ses7,octopus,pacific}

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -744,9 +744,7 @@ def ses6(deployment_id, deploy, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
-@click.option("--use-deepsea/--use-cephadm", default=False,
-              help="Use deepsea to deploy SES7 instead of cephadm")
-def ses7(deployment_id, deploy, use_deepsea, **kwargs):
+def ses7(deployment_id, deploy, **kwargs):
     """
     Creates a SES7 cluster using SLES-15-SP2 and packages (and container image)
     from the Devel:Storage:7.0 IBS project
@@ -754,8 +752,6 @@ def ses7(deployment_id, deploy, use_deepsea, **kwargs):
     _prep_kwargs(kwargs)
     settings_dict = _gen_settings_dict('ses7', **kwargs)
     deployment_id = _maybe_gen_dep_id('ses7', deployment_id, settings_dict)
-    if use_deepsea:
-        settings_dict['deployment_tool'] = 'deepsea'
     _create_command(deployment_id, deploy, settings_dict)
 
 
@@ -781,9 +777,7 @@ def nautilus(deployment_id, deploy, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
-@click.option("--use-deepsea/--use-cephadm", default=False,
-              help="Use deepsea to deploy Ceph Octopus instead of cephadm")
-def octopus(deployment_id, deploy, use_deepsea, **kwargs):
+def octopus(deployment_id, deploy, **kwargs):
     """
     Creates a Ceph Octopus cluster using openSUSE Leap 15.2 and packages
     (and container image) from filesystems:ceph:octopus:upstream OBS project
@@ -791,8 +785,6 @@ def octopus(deployment_id, deploy, use_deepsea, **kwargs):
     _prep_kwargs(kwargs)
     settings_dict = _gen_settings_dict('octopus', **kwargs)
     deployment_id = _maybe_gen_dep_id('octopus', deployment_id, settings_dict)
-    if use_deepsea:
-        settings_dict['deployment_tool'] = 'deepsea'
     _create_command(deployment_id, deploy, settings_dict)
 
 
@@ -802,9 +794,7 @@ def octopus(deployment_id, deploy, use_deepsea, **kwargs):
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
-@click.option("--use-deepsea/--use-cephadm", default=False,
-              help="Use deepsea to deploy Ceph Master Branch instead of cephadm")
-def pacific(deployment_id, deploy, use_deepsea, **kwargs):
+def pacific(deployment_id, deploy, **kwargs):
     """
     Creates a Ceph Pacific cluster using openSUSE Leap 15.2 and packages
     (and container image) from filesystems:ceph:master:upstream OBS project
@@ -812,8 +802,6 @@ def pacific(deployment_id, deploy, use_deepsea, **kwargs):
     _prep_kwargs(kwargs)
     settings_dict = _gen_settings_dict('pacific', **kwargs)
     deployment_id = _maybe_gen_dep_id('pacific', deployment_id, settings_dict)
-    if use_deepsea:
-        settings_dict['deployment_tool'] = 'deepsea'
     _create_command(deployment_id, deploy, settings_dict)
 
 

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -458,7 +458,7 @@ SETTINGS = {
     },
     'deployment_tool': {
         'type': str,
-        'help': 'Deployment tool to deploy the Ceph cluster. Currently only deepsea is supported',
+        'help': 'Deployment tool (deepsea, cephadm) to deploy the Ceph cluster',
         'default': '',
     },
     'deepsea_git_repo': {
@@ -1489,8 +1489,7 @@ class Deployment():
                 result += "     - encrypted OSDs:   {}\n".format(self.settings.encrypted_osds)
             result += "     - repo_priority:    {}\n".format(self.settings.repo_priority)
             result += "     - qa_test:          {}\n".format(self.settings.qa_test)
-            if self.settings.version in ['octopus', 'ses7', 'master'] \
-                    and self.settings.deployment_tool == 'cephadm':
+            if self.settings.version in ['octopus', 'ses7', 'pacific']:
                 result += "     - image_path:       {}\n".format(self.settings.image_path)
             for synced_folder in self.settings.synced_folder:
                 result += "     - synced_folder:    {}\n".format(' -> '.join(synced_folder))


### PR DESCRIPTION
This option was implemented at a time when it was not certain whether
SES7 would use cephadm or deepsea as its deployment tool.

Signed-off-by: Nathan Cutler <ncutler@suse.com>