### PR TITLE
Deployment: vet deployment ID before creation

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -258,18 +258,20 @@ fi
 
 if [ "$MAKECHECK" ] ; then
     run_cmd sesdev create makecheck --non-interactive --stop-before-run-make-check --ram 4
-    run_cmd sesdev destroy --non-interactive makecheck_tumbleweed
+    run_cmd sesdev destroy --non-interactive makecheck-tumbleweed
     run_cmd sesdev create makecheck --non-interactive --os sles-12-sp3 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses5 --stop-before-run-make-check --ram 4
-    run_cmd sesdev destroy --non-interactive makecheck_sles-12-sp3
+    run_cmd sesdev destroy --non-interactive makecheck-sles-12-sp3
     run_cmd sesdev create makecheck --non-interactive --os sles-15-sp1 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses6 --stop-before-run-make-check --ram 4
-    run_cmd sesdev destroy --non-interactive makecheck_sles-15-sp1
+    run_cmd sesdev destroy --non-interactive makecheck-sles-15-sp1
     run_cmd sesdev create makecheck --non-interactive --os sles-15-sp2 --ceph-repo https://github.com/SUSE/ceph --ceph-branch ses7 --stop-before-run-make-check --ram 4
-    run_cmd sesdev destroy --non-interactive makecheck_sles-15-sp2
+    run_cmd sesdev destroy --non-interactive makecheck-sles-15-sp2
 fi
 
 if [ "$CAASP4" ] ; then
-    run_cmd sesdev create caasp4 --non-interactive caasp4_default
-    run_cmd sesdev destroy --non-interactive caasp4_default
+    run_cmd sesdev create caasp4 --non-interactive caasp4-default
+    run_cmd sesdev destroy --non-interactive caasp4-default
+    run_cmd sesdev create caasp4 --non-interactive --deploy-ses caasp4-with-rook
+    run_cmd sesdev destroy --non-interactive caasp4-with-rook
 fi
 
 final_report

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -180,7 +180,7 @@ def _maybe_gen_dep_id(version, dep_id, settings_dict):
         single_node = settings_dict['single_node'] if 'single_node' in settings_dict else False
         dep_id = version
         if single_node:
-            dep_id += "_mini"
+            dep_id += "-mini"
     return dep_id
 
 
@@ -849,7 +849,7 @@ def makecheck(deployment_id, deploy, **kwargs):
     settings_dict = _gen_settings_dict('makecheck', **kwargs)
     if not deployment_id:
         os = settings_dict['os'] if 'os' in settings_dict else 'tumbleweed'
-        deployment_id = 'makecheck_{}'.format(os)
+        deployment_id = 'makecheck-{}'.format(os)
     _create_command(deployment_id, deploy, settings_dict)
 
 

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -198,3 +198,18 @@ class SubcommandNotSupportedInVersion(SesDevException):
     def __init__(self, subcmd, version):
         super(SubcommandNotSupportedInVersion, self).__init__(
             "Subcommand {} not supported in '{}'".format(subcmd, version))
+
+
+class DepIDWrongLength(SesDevException):
+    def __init__(self, length):
+        super(DepIDWrongLength, self).__init__(
+            "Deployment ID must be from 1 to 63 characters in length "
+            "(yours had {} characters)".format(length))
+
+
+class DepIDIllegalChars(SesDevException):
+    def __init__(self, dep_id):
+        super(DepIDIllegalChars, self).__init__(
+            "dep_id \"{}\" contains illegal characters. Valid characters for hostnames "
+            "are ASCII(7) letters from a to z, the digits from 0 to 9, and the "
+            "hyphen (-).".format(dep_id))

--- a/tests/test_vet_dep_id.py
+++ b/tests/test_vet_dep_id.py
@@ -1,0 +1,25 @@
+import pytest
+
+from seslib import _vet_dep_id
+from seslib.exceptions import DepIDWrongLength, DepIDIllegalChars
+
+def test_vet_dep_id():
+    assert _vet_dep_id("hooholopar") == "hooholopar"
+    assert _vet_dep_id("oron1anio0") == "oron1anio0"
+    assert _vet_dep_id("hyphen-words-separated") == "hyphen-words-separated"
+    with pytest.raises(DepIDWrongLength):
+        _vet_dep_id("")
+    with pytest.raises(DepIDWrongLength):
+        long_string = (
+            "hooholoparhooholoparhooholoparhooholoparhooh"
+            "hooholoparhooholoparhooholoparhooholoparhooh"
+            "hooholoparhooholoparhooholoparhooholoparhooh"
+            "hooholoparhooholoparhooholoparhooholoparhooh"
+            )
+        _vet_dep_id(long_string)
+    with pytest.raises(DepIDIllegalChars):
+        _vet_dep_id("hooholopar;")
+    with pytest.raises(DepIDIllegalChars):
+        _vet_dep_id("master]")
+    with pytest.raises(DepIDIllegalChars):
+        _vet_dep_id("master_id")


### PR DESCRIPTION
It's not a good idea to allow users to specify a deployment ID that
would not be a valid hostname element [1], since the deployment ID
might be used as a hostname element.

[1] from hostname(7) - Linux manual page:

Each element of the hostname must be from 1 to 63 characters long and the
entire hostname, including the dots, can be at most 253 characters long.
Valid characters for hostnames are ASCII(7) letters from a to z, the digits
from 0 to 9, and the hyphen (-).

Signed-off-by: Nathan Cutler <ncutler@suse.com>