### PR TITLE
ses7,octopus,pacific: deploy NFS-Ganesha

### DIFF
--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -118,6 +118,9 @@ mgr_is_available_test
 maybe_wait_for_osd_nodes_test "$OSD_NODES"  # it might take a long time for OSD nodes to show up
 maybe_wait_for_mdss_test "$MDS_NODES"  # it might take a long time for MDSs to be ready
 maybe_wait_for_rgws_test "$RGW_NODES"  # it might take a long time for RGWs to be ready
+maybe_wait_for_nfss_test "$NFS_NODES"  # it might take a long time for NFSs to be ready
 number_of_daemons_expected_vs_metadata_test
-number_of_nodes_actual_vs_expected_test
+number_of_services_expected_vs_orch_ls_test
+number_of_services_expected_vs_orch_ps_test
+number_of_daemons_expected_vs_actual
 ceph_health_test

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -48,6 +48,7 @@ MON_NODES_COMMA_SEPARATED_LIST=""
 MGR_NODES_COMMA_SEPARATED_LIST=""
 MDS_NODES_COMMA_SEPARATED_LIST=""
 RGW_NODES_SPACE_SEPARATED_LIST=""
+NFS_NODES_SPACE_SEPARATED_LIST=""
 {% for node in nodes %}
 {% if node.has_roles() and not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
@@ -69,11 +70,15 @@ MDS_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
 {% if node.has_role('rgw') %}
 RGW_NODES_SPACE_SEPARATED_LIST+="{{ node.name }} "
 {% endif %}
+{% if node.has_role('nfs') %}
+NFS_NODES_SPACE_SEPARATED_LIST+="{{ node.name }} "
+{% endif %}
 {% endfor %}
 MON_NODES_COMMA_SEPARATED_LIST="${MON_NODES_COMMA_SEPARATED_LIST%,*}"
 MGR_NODES_COMMA_SEPARATED_LIST="${MGR_NODES_COMMA_SEPARATED_LIST%,*}"
 MDS_NODES_COMMA_SEPARATED_LIST="${MDS_NODES_COMMA_SEPARATED_LIST%,*}"
 RGW_NODES_SPACE_SEPARATED_LIST="${RGW_NODES_SPACE_SEPARATED_LIST%"${RGW_NODES_SPACE_SEPARATED_LIST##*[![:space:]]}"}"
+NFS_NODES_SPACE_SEPARATED_LIST="${NFS_NODES_SPACE_SEPARATED_LIST%"${NFS_NODES_SPACE_SEPARATED_LIST##*[![:space:]]}"}"
 
 ceph-salt config /system_update/packages disable
 ceph-salt config /system_update/reboot disable
@@ -140,6 +145,12 @@ radosgw-admin realm create --rgw-realm=default --default
 radosgw-admin zonegroup create --rgw-zonegroup=default> --master --default
 radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=default --master --default
 ceph orch apply rgw default default --placement="{{ rgw_nodes }} $RGW_NODES_SPACE_SEPARATED_LIST"
+{% endif %}
+
+{% if nfs_nodes > 0 %}
+ceph osd pool create rbd
+ceph osd pool application enable rbd nfs
+ceph orch apply nfs default rbd nfs --placement="{{ nfs_nodes }} $NFS_NODES_SPACE_SEPARATED_LIST"
 {% endif %}
 
 {% include "qa_test.sh.j2" %}


### PR DESCRIPTION
Until now, we were ignoring the "nfs" (Ganesha) role. With this
commit, we at least start the NFS daemon using the documented
procedure and, in qa-test, assert (with "ceph orch ls") that it is
running.

Fixes: https://github.com/SUSE/sesdev/issues/256
Signed-off-by: Nathan Cutler <ncutler@suse.com>