### PR TITLE
Implement --filestore option to deploy OSDs with FileStore

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -199,7 +199,7 @@ fi
 
 if [ "$NAUTILUS" ] ; then
     sesdev box remove --non-interactive leap-15.1
-    run_cmd sesdev create nautilus --non-interactive --single-node --qa-test nautilus-1node
+    run_cmd sesdev create nautilus --non-interactive --single-node --filestore --qa-test nautilus-1node
     run_cmd sesdev destroy --non-interactive nautilus-1node
     run_cmd sesdev create nautilus --non-interactive nautilus-4node
     run_cmd sesdev qa-test nautilus-4node

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -879,3 +879,39 @@ function systemctl_list_units_test {
         false
     fi
 }
+
+function osd_objectstore_test {
+    echo "WWWW: osd_objectstore_test"
+    local expected_objectstore
+    [ "$FILESTORE_OSDS" ] && expected_objectstore="filestore" || expected_objectstore="bluestore"
+    local osd_objectstore
+    osd_objectstore=$(_osd_objectstore)
+    local line
+    local success
+    success="yes"
+    local count
+    count="0"
+    for line in $osd_objectstore ; do
+        echo "$line"
+        if [ "$line" = "$expected_objectstore" ] ; then
+            count="$((count + 1))"
+        else
+            echo "ERROR: encountered OSD with unexpected objectstore $line"
+            success=""
+        fi
+    done
+    echo "$expected_objectstore OSDs (found/expected): $count/$OSDS"
+    if [ "$count" = "$OSDS" ] ; then
+        true
+    else
+        success=""
+    fi
+    if [ "$success" ] ; then
+        echo "WWWW: osd_objectstore_test: OK"
+        echo
+    else
+        echo "WWWW: osd_objectstore_test: FAIL"
+        echo
+        false
+    fi
+}

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -82,3 +82,12 @@ function _fsid {
         false
     fi
 }
+
+function _osd_objectstore {
+    # sample output for a cluster with 4 FileStore OSDs:
+    # filestore 
+    # filestore 
+    # filestore 
+    # filestore 
+    ceph osd metadata | jq -r '.[] | .osd_objectstore'
+}

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -54,6 +54,7 @@ function usage {
     echo "    --osd-node-list      comma-separated list of nodes with OSD"
     echo "    --rgw-node-list      comma-separated list of nodes with RGW"
     echo "    --osds               expected total number of OSDs in cluster"
+    echo "    --filestore-osds     whether there are FileStore OSDs in cluster"
     echo "    --strict-versions    Insist that daemon versions match \"ceph --version\""
     echo "    --total-nodes        expected total number of nodes in cluster"
     exit 1
@@ -62,7 +63,7 @@ function usage {
 assert_enhanced_getopt
 
 TEMP=$(getopt -o h \
---long "help,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,rgw-nodes:,rgw-node-list:,osds:,strict-versions,total-nodes:,node-list:" \
+--long "help,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,rgw-nodes:,rgw-node-list:,osds:,filestore-osds,strict-versions,total-nodes:,node-list:" \
 -n 'health-ok.sh' -- "$@") || ( echo "Terminating..." >&2 ; exit 1 )
 eval set -- "$TEMP"
 
@@ -84,6 +85,7 @@ OSD_NODE_LIST=""
 RGW_NODES=""
 RGW_NODE_LIST=""
 OSDS=""
+FILESTORE_OSDS=""
 STRICT_VERSIONS=""
 TOTAL_NODES=""
 NODE_LIST=""
@@ -106,6 +108,7 @@ while true ; do
         --rgw-nodes) shift ; RGW_NODES="$1" ; shift ;;
         --rgw-node-list) shift ; RGW_NODE_LIST="$1" ; shift ;;
         --osds) shift ; OSDS="$1" ; shift ;;
+        --filestore-osds) FILESTORE_OSDS="yes" ; shift ;;
         --strict-versions) STRICT_VERSIONS="$1"; shift ;;
         --total-nodes) shift ; TOTAL_NODES="$1" ; shift ;;
         --node-list) shift ; NODE_LIST="$1" ; shift ;;
@@ -134,6 +137,7 @@ test "$NFS_NODE_LIST"
 test "$OSD_NODE_LIST"
 test "$RGW_NODE_LIST"
 test "$OSDS"
+test "$FILESTORE_OSDS"
 test "$STRICT_VERSIONS"
 test "$TOTAL_NODES"
 test "$NODE_LIST"
@@ -159,3 +163,4 @@ ceph_health_test
 maybe_rgw_smoke_test
 cluster_json_test
 systemctl_list_units_test
+osd_objectstore_test

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -471,6 +471,11 @@ SETTINGS = {
         'help': 'Whether OSDs should be deployed encrypted',
         'default': False,
     },
+    'filestore_osds': {
+        'type': bool,
+        'help': 'Whether OSDs should be deployed with FileStore instead of BlueStore',
+        'default': False,
+    },
     'deployment_tool': {
         'type': str,
         'help': 'Deployment tool (deepsea, cephadm) to deploy the Ceph cluster',
@@ -1311,6 +1316,7 @@ class Deployment():
                                          or self.node_counts["openattic"]),
             'total_osds': self.settings.num_disks * self.node_counts["storage"],
             'encrypted_osds': self.settings.encrypted_osds,
+            'filestore_osds': self.settings.filestore_osds,
             'scc_username': self.settings.scc_username,
             'scc_password': self.settings.scc_password,
             'ceph_salt_git_repo': self.settings.ceph_salt_git_repo,
@@ -1552,7 +1558,10 @@ class Deployment():
                 result += "     - storage_disks:    {}\n".format(len(v.storage_disks))
                 result += ("                         "
                            "(device names will be assigned by vagrant-libvirt)\n")
-                result += "     - encrypted OSDs:   {}\n".format(self.settings.encrypted_osds)
+                result += "     - OSD encryption:   {}\n".format(
+                    "Yes" if self.settings.encrypted_osds else "No")
+                result += "     - OSD objectstore:  {}\n".format(
+                    "FileStore" if self.settings.filestore_osds else "BlueStore")
             result += "     - repo_priority:    {}\n".format(self.settings.repo_priority)
             result += "     - qa_test:          {}\n".format(self.settings.qa_test)
             if self.settings.version in ['octopus', 'ses7', 'pacific']:

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -117,7 +117,13 @@ placement:
 {% endfor %}
 service_id: generic_osd_deployment
 data_devices:
-    all: True
+    all: true
+{% if encrypted_osds %}
+encrypted: true
+{% endif %}
+{% if filestore_osds %}
+objectstore: filestore
+{% endif %}
 EOF
 cat {{ service_spec_osd }}
 

--- a/seslib/templates/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/deepsea/deepsea_deployment.sh.j2
@@ -90,14 +90,18 @@ exit 0
 {% endif %}
 
 {% if version != 'ses5' %}
-if [ ! -e "/srv/salt/ceph/configuration/files/drive_groups.yml" ] ; then
-    echo "FATAL: /srv/salt/ceph/configuration/files/drive_groups.yml unexpectedly missing!"
+{% set drive_groups_yml = "/srv/salt/ceph/configuration/files/drive_groups.yml" %}
+if [ ! -e "{{ drive_groups_yml }}" ] ; then
+    echo "FATAL: {{ drive_groups_yml }} unexpectedly missing!"
     exit 1
 fi
-{% if encrypted_osds %}
-echo "  encryption: True" >> /srv/salt/ceph/configuration/files/drive_groups.yml
+{% if filestore_osds %}
+echo "  format: filestore" >> {{ drive_groups_yml }}
 {% endif %}
-cat /srv/salt/ceph/configuration/files/drive_groups.yml
+{% if encrypted_osds %}
+echo "  encryption: True" >> {{ drive_groups_yml }}
+{% endif %}
+cat {{ drive_groups_yml }}
 {% endif %}
 
 echo ""

--- a/seslib/templates/qa_test.sh.j2
+++ b/seslib/templates/qa_test.sh.j2
@@ -19,6 +19,9 @@
     ~ " --rgw-node-list=" ~ rgw_node_list
     ~ " --osds=" ~ total_osds
 -%}
+{% if filestore_osds %}
+{% set qa_test_cmd = qa_test_cmd ~ " --filestore-osds" %}
+{% endif %}
 
 cat > {{ qa_test_script }} << EOF
 #!/bin/bash


### PR DESCRIPTION
Though FileStore is not supported in SES7, the ability to deploy
FileStore OSDs is still present in Octopus and Pacific, even though it
is currently broken there.

Implement a --filestore option which adds the appropriate line to the
drive groups file (ses6,nautilus)/service spec file
(ses7,octopus,pacific) before deploying the OSDs.

Also, add a qa test asserting that the OSD metadata reports the expected
objectstore.

Fixes: https://github.com/SUSE/sesdev/issues/340

---

To Do:


- [x] reject `--filestore` option if `version == "ses5"`
- [x] determine minimum size of a filestore OSD in nautilus,ses6 (15 GB might not the minimum, but it's been known to work)
- [x] default to the minimum if `--filestore` given without explicit `--disk-size`
- [x] pass `--filestore/--bluestore` to health-ok.sh and test `ceph osd metadata` against it
- [x] remove DNM
- [x] tested manually: behaves as expected
- [x] #351 merged
- [x] this PR rebased
- [x] passed `contrib/standalone.sh --full`
