### PR TITLE
cleanup: nodes_with_role

### DIFF
--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -21,7 +21,23 @@ function _copy_file_from_minion_to_master {
 
 function _first_x_node {
     local ROLE=$1
-    salt --static --out json -G "ceph-salt:roles:$ROLE" test.true 2>/dev/null | jq -r 'keys[0]'
+    if [ "$ROLE" = "igw" ] ; then
+        echo "${IGW_NODE_LIST%%,*}"
+    elif [ "$ROLE" = "mds" ] ; then
+        echo "${MDS_NODE_LIST%%,*}"
+    elif [ "$ROLE" = "mgr" ] ; then
+        echo "${MGR_NODE_LIST%%,*}"
+    elif [ "$ROLE" = "mon" ] ; then
+        echo "${MON_NODE_LIST%%,*}"
+    elif [ "$ROLE" = "nfs" ] ; then
+        echo "${NFS_NODE_LIST%%,*}"
+    elif [ "$ROLE" = "osd" ] ; then
+        echo "${OSD_NODE_LIST%%,*}"
+    elif [ "$ROLE" = "rgw" ] ; then
+        echo "${RGW_NODE_LIST%%,*}"
+    else
+        echo ""
+    fi
 }
 
 function _grace_period {

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -44,6 +44,12 @@ function usage {
     echo "    --mon-nodes          expected number of nodes with MON"
     echo "    --nfs-nodes          expected number of nodes with NFS"
     echo "    --osd-nodes          expected number of nodes with OSD"
+    echo "    --igw-node-list      comma-separated list of nodes with iSCSI Gateway"
+    echo "    --mds-node-list      comma-separated list of nodes with MDS"
+    echo "    --mgr-node-list      comma-separated list of nodes with MGR"
+    echo "    --mon-node-list      comma-separated list of nodes with MON"
+    echo "    --nfs-node-list      comma-separated list of nodes with NFS"
+    echo "    --osd-node-list      comma-separated list of nodes with OSD"
     echo "    --osds               expected total number of OSDs in cluster"
     echo "    --strict-versions    Insist that daemon versions match \"ceph --version\""
     echo "    --rgw-nodes          expected number of nodes with RGW"
@@ -62,28 +68,42 @@ eval set -- "$TEMP"
 ADMIN_KEYRING="/etc/ceph/ceph.client.admin.keyring"
 CEPH_CONF="/etc/ceph/ceph.conf"
 IGW_NODES=""
+IGW_NODE_LIST=""
 MDS_NODES=""
+MDS_NODE_LIST=""
 MGR_NODES=""
+MGR_NODE_LIST=""
 MON_NODES=""
+MON_NODE_LIST=""
 NFS_NODES=""
+NFS_NODE_LIST=""
 OSD_NODES=""
+OSD_NODE_LIST=""
+RGW_NODES=""
+RGW_NODE_LIST=""
 OSDS=""
 STRICT_VERSIONS=""
-RGW_NODES=""
 TOTAL_NODES=""
 
 # process command-line options
 while true ; do
     case "$1" in
         --igw-nodes) shift ; IGW_NODES="$1" ; shift ;;
+        --igw-node-list) shift ; IGW_NODE_LIST="$1" ; shift ;;
         --mds-nodes) shift ; MDS_NODES="$1" ; shift ;;
+        --mds-node-list) shift ; MDS_NODE_LIST="$1" ; shift ;;
         --mgr-nodes) shift ; MGR_NODES="$1" ; shift ;;
+        --mgr-node-list) shift ; MGR_NODE_LIST="$1" ; shift ;;
         --mon-nodes) shift ; MON_NODES="$1" ; shift ;;
+        --mon-node-list) shift ; MON_NODE_LIST="$1" ; shift ;;
         --nfs-nodes) shift ; NFS_NODES="$1" ; shift ;;
+        --nfs-node-list) shift ; NFS_NODE_LIST="$1" ; shift ;;
         --osd-nodes) shift ; OSD_NODES="$1" ; shift ;;
+        --osd-node-list) shift ; OSD_NODE_LIST="$1" ; shift ;;
+        --rgw-nodes) shift ; RGW_NODES="$1" ; shift ;;
+        --rgw-node-list) shift ; RGW_NODE_LIST="$1" ; shift ;;
         --osds) shift ; OSDS="$1" ; shift ;;
         --strict-versions) STRICT_VERSIONS="$1"; shift ;;
-        --rgw-nodes) shift ; RGW_NODES="$1" ; shift ;;
         --total-nodes) shift ; TOTAL_NODES="$1" ; shift ;;
         -h|--help) usage ;;    # does not return
         --) shift ; break ;;
@@ -101,9 +121,16 @@ test "$MGR_NODES"
 test "$MON_NODES"
 test "$NFS_NODES"
 test "$OSD_NODES"
+test "$RGW_NODES"
+test "$IGW_NODE_LIST"
+test "$MDS_NODE_LIST"
+test "$MGR_NODE_LIST"
+test "$MON_NODE_LIST"
+test "$NFS_NODE_LIST"
+test "$OSD_NODE_LIST"
+test "$RGW_NODE_LIST"
 test "$OSDS"
 test "$STRICT_VERSIONS"
-test "$RGW_NODES"
 test "$TOTAL_NODES"
 set -e
 

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -927,8 +927,10 @@ class Deployment():
         self.existing = existing  # True: we are loading, False: we are creating
         self.nodes = {}
         self.node_counts = {}
+        self.nodes_with_role = {}
         for role in KNOWN_ROLES:
             self.node_counts[role] = 0
+            self.nodes_with_role[role] = []
         _log_debug("Deployment ctor: node_counts: {}".format(self.node_counts))
         self.master = None
         self.suma = None
@@ -1129,6 +1131,9 @@ class Deployment():
                         cpus=self.settings.cpus,
                         repo_priority=self.settings.repo_priority)
 
+            for role in node_roles:
+                self.nodes_with_role[role].append(name)
+
             if 'master' in node_roles:
                 self.master = node
 
@@ -1258,12 +1263,19 @@ class Deployment():
             'repo_priority': self.settings.repo_priority,
             'qa_test': self.settings.qa_test,
             'nfs_nodes': self.node_counts["nfs"],
+            'nfs_node_list': ','.join(self.nodes_with_role["nfs"]),
             'igw_nodes': self.node_counts["igw"],
+            'igw_node_list': ','.join(self.nodes_with_role["igw"]),
             'mds_nodes': self.node_counts["mds"],
+            'mds_node_list': ','.join(self.nodes_with_role["mds"]),
             'mgr_nodes': self.node_counts["mgr"],
+            'mgr_node_list': ','.join(self.nodes_with_role["mgr"]),
             'mon_nodes': self.node_counts["mon"],
+            'mon_node_list': ','.join(self.nodes_with_role["mon"]),
             'rgw_nodes': self.node_counts["rgw"],
+            'rgw_node_list': ','.join(self.nodes_with_role["rgw"]),
             'storage_nodes': self.node_counts["storage"],
+            'storage_node_list': ','.join(self.nodes_with_role["storage"]),
             'deepsea_need_stage_4': bool(self.node_counts["nfs"] or self.node_counts["igw"]
                                          or self.node_counts["mds"] or self.node_counts["rgw"]
                                          or self.node_counts["openattic"]),

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -119,13 +119,13 @@ ceph fs volume create myfs "{{ mds_node_list }}"
 radosgw-admin realm create --rgw-realm=default --default
 radosgw-admin zonegroup create --rgw-zonegroup=default> --master --default
 radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=default --master --default
-ceph orch apply rgw default default --placement="{{ rgw_nodes }} {{ rgw_node_list }}"
+ceph orch apply rgw default default --placement="{{ rgw_node_list }}"
 {% endif %}
 
 {% if nfs_nodes > 0 %}
 ceph osd pool create rbd
 ceph osd pool application enable rbd nfs
-ceph orch apply nfs default rbd nfs --placement="{{ nfs_nodes }} {{ nfs_node_list }}"
+ceph orch apply nfs default rbd nfs --placement="{{ nfs_node_list }}"
 {% endif %}
 
 {% include "qa_test.sh.j2" %}

--- a/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/ceph-salt/ceph_salt_deployment.sh.j2
@@ -44,11 +44,6 @@ exit 0
 echo "PATH is $PATH"
 type ceph-salt
 
-MON_NODES_COMMA_SEPARATED_LIST=""
-MGR_NODES_COMMA_SEPARATED_LIST=""
-MDS_NODES_COMMA_SEPARATED_LIST=""
-RGW_NODES_SPACE_SEPARATED_LIST=""
-NFS_NODES_SPACE_SEPARATED_LIST=""
 {% for node in nodes %}
 {% if node.has_roles() and not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
@@ -58,27 +53,7 @@ ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
 {% if node.has_role('bootstrap') %}
 ceph-salt config /ceph_cluster/roles/bootstrap set {{ node.fqdn }}
 {% endif %}
-{% if node.has_role('mon') %}
-MON_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
-{% endif %}
-{% if node.has_role('mgr') %}
-MGR_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
-{% endif %}
-{% if node.has_role('mds') %}
-MDS_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
-{% endif %}
-{% if node.has_role('rgw') %}
-RGW_NODES_SPACE_SEPARATED_LIST+="{{ node.name }} "
-{% endif %}
-{% if node.has_role('nfs') %}
-NFS_NODES_SPACE_SEPARATED_LIST+="{{ node.name }} "
-{% endif %}
 {% endfor %}
-MON_NODES_COMMA_SEPARATED_LIST="${MON_NODES_COMMA_SEPARATED_LIST%,*}"
-MGR_NODES_COMMA_SEPARATED_LIST="${MGR_NODES_COMMA_SEPARATED_LIST%,*}"
-MDS_NODES_COMMA_SEPARATED_LIST="${MDS_NODES_COMMA_SEPARATED_LIST%,*}"
-RGW_NODES_SPACE_SEPARATED_LIST="${RGW_NODES_SPACE_SEPARATED_LIST%"${RGW_NODES_SPACE_SEPARATED_LIST##*[![:space:]]}"}"
-NFS_NODES_SPACE_SEPARATED_LIST="${NFS_NODES_SPACE_SEPARATED_LIST%"${NFS_NODES_SPACE_SEPARATED_LIST##*[![:space:]]}"}"
 
 ceph-salt config /system_update/packages disable
 ceph-salt config /system_update/reboot disable
@@ -122,11 +97,11 @@ exit 0
 {% endif %}
 
 {% if mon_nodes > 1 %}
-ceph orch apply mon "$MON_NODES_COMMA_SEPARATED_LIST"
+ceph orch apply mon "{{ mon_node_list }}"
 {% endif %} {# mon_nodes > 1 #}
 
 {% if mgr_nodes > 1 %}
-ceph orch apply mgr "$MGR_NODES_COMMA_SEPARATED_LIST"
+ceph orch apply mgr "{{ mgr_node_list }}"
 {% endif %} {# mgr_nodes > 1 #}
 
 ceph orch device ls --refresh
@@ -137,20 +112,20 @@ echo "{\"service_type\": \"osd\", \"placement\": {\"host_pattern\": \"{{ node.na
 {% endfor %}
 
 {% if mds_nodes > 0 %}
-ceph fs volume create myfs "$MDS_NODES_COMMA_SEPARATED_LIST"
+ceph fs volume create myfs "{{ mds_node_list }}"
 {% endif %}
 
 {% if rgw_nodes > 0 %}
 radosgw-admin realm create --rgw-realm=default --default
 radosgw-admin zonegroup create --rgw-zonegroup=default> --master --default
 radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=default --master --default
-ceph orch apply rgw default default --placement="{{ rgw_nodes }} $RGW_NODES_SPACE_SEPARATED_LIST"
+ceph orch apply rgw default default --placement="{{ rgw_nodes }} {{ rgw_node_list }}"
 {% endif %}
 
 {% if nfs_nodes > 0 %}
 ceph osd pool create rbd
 ceph osd pool application enable rbd nfs
-ceph orch apply nfs default rbd nfs --placement="{{ nfs_nodes }} $NFS_NODES_SPACE_SEPARATED_LIST"
+ceph orch apply nfs default rbd nfs --placement="{{ nfs_nodes }} {{ nfs_node_list }}"
 {% endif %}
 
 {% include "qa_test.sh.j2" %}


### PR DESCRIPTION
We have some messy code in ceph_salt_deployment.sh which populates some shell variables with the names of nodes that are supposed to have a given role.

This changeset moves this code into `seslib/__init__.py` by populating python arrays with the same information and converting these into comma-separated strings which are sent into ceph_salt_deployment.sh via the Jinja context.

This also lays some groundwork for further PRs expanding the QA tests so they not only vet the expected number of daemons of various types, but also assert that daemons are actually running on the expected nodes.