### PR TITLE
qa: compare systemctl with expected state on each node

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -106,23 +106,24 @@ function support_cop_out_test {
     local supported
     supported="sesdev-qa supports this OS"
     local not_supported
-    not_supported="ERROR: sesdev-qa does not currently support this OS"
+    not_supported="sesdev-qa does not currently support this OS"
     echo
     echo "WWWW: support_cop_out_test"
     echo "Detected operating system $NAME $VERSION_ID"
     case "$ID" in
         opensuse*|suse|sles)
             case "$VERSION_ID" in
-                15*)
-                    echo "$supported"
-                    ;;
-                *)
-                    echo "$not_supported"
+                12.3) echo "$supported" ;;
+                15.1) echo "$supported" ;;
+                15.2) echo "$supported" ;;
+                *) 
+                    echo "WARNING: $not_supported"
+                    echo "But we'll let it slide this time ;-)"
                     ;;
             esac
             ;;
         *)
-            echo "$not_supported"
+            echo "ERROR: $not_supported"
             false
             ;;
     esac

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -73,3 +73,12 @@ function _extract_ceph_version {
     # shellcheck disable=SC2003
     expr match "$full_version_string" '\(ceph version [^[:space:]]\+\)'
 }
+
+function _fsid {
+    if [ "$VERSION_ID" = "15.2" ] ; then
+        ceph status --format=json | jq -r '.fsid'
+    else
+        echo "ERROR: _fsid needs Octopus or newer"
+        false
+    fi
+}

--- a/qa/common/rgw.sh
+++ b/qa/common/rgw.sh
@@ -14,11 +14,11 @@ function rgw_curl_test {
     local protocol
     local curl_opts
     local rgwxmlout
-    curl_opts="--silent --show-error"
+    curl_opts=( --silent --show-error )
     # 
     # We are not currently testing RGW-over-HTTPS
     # test "$RGW_SSL" && protocol="https" || protocol="http"
-    # test "$RGW_SSL" && curl_opts+=" --insecure"
+    # test "$RGW_SSL" && curl_opts+=( --insecure )
     protocol="http"
     #
     # If rgw_dns_name is configured, we must use it. Currently this is a problem
@@ -31,7 +31,7 @@ function rgw_curl_test {
     # valid XML containing the word "anonymous"
     #
     # shellcheck disable=SC2086
-    curl $curl_opts "${protocol}://${rgw_dns_name}" | tee $rgwxmlout
+    curl "${curl_opts[@]}" "${protocol}://${rgw_dns_name}" | tee $rgwxmlout
     test -f $rgwxmlout
     xmllint $rgwxmlout
     grep anonymous $rgwxmlout

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -45,6 +45,7 @@ function usage {
     echo "    --nfs-nodes          expected number of nodes with NFS"
     echo "    --osd-nodes          expected number of nodes with OSD"
     echo "    --rgw-nodes          expected number of nodes with RGW"
+    echo "    --node-list          comma-separate list of all nodes in cluster"
     echo "    --igw-node-list      comma-separated list of nodes with iSCSI Gateway"
     echo "    --mds-node-list      comma-separated list of nodes with MDS"
     echo "    --mgr-node-list      comma-separated list of nodes with MGR"
@@ -61,7 +62,7 @@ function usage {
 assert_enhanced_getopt
 
 TEMP=$(getopt -o h \
---long "help,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,rgw-nodes:,rgw-node-list:,osds:,strict-versions,total-nodes:" \
+--long "help,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,rgw-nodes:,rgw-node-list:,osds:,strict-versions,total-nodes:,node-list:" \
 -n 'health-ok.sh' -- "$@") || ( echo "Terminating..." >&2 ; exit 1 )
 eval set -- "$TEMP"
 
@@ -85,6 +86,7 @@ RGW_NODE_LIST=""
 OSDS=""
 STRICT_VERSIONS=""
 TOTAL_NODES=""
+NODE_LIST=""
 
 # process command-line options
 while true ; do
@@ -106,6 +108,7 @@ while true ; do
         --osds) shift ; OSDS="$1" ; shift ;;
         --strict-versions) STRICT_VERSIONS="$1"; shift ;;
         --total-nodes) shift ; TOTAL_NODES="$1" ; shift ;;
+        --node-list) shift ; NODE_LIST="$1" ; shift ;;
         -h|--help) usage ;;    # does not return
         --) shift ; break ;;
         *) echo "Internal error" ; exit 1 ;;
@@ -133,6 +136,7 @@ test "$RGW_NODE_LIST"
 test "$OSDS"
 test "$STRICT_VERSIONS"
 test "$TOTAL_NODES"
+test "$NODE_LIST"
 set -e
 
 # run tests
@@ -153,3 +157,5 @@ number_of_services_expected_vs_orch_ps_test
 number_of_daemons_expected_vs_actual
 ceph_health_test
 maybe_rgw_smoke_test
+cluster_json_test
+systemctl_list_units_test

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -928,6 +928,7 @@ class Deployment():
         self.nodes = {}
         self.node_counts = {}
         self.nodes_with_role = {}
+        self.roles_of_nodes = {}
         for role in KNOWN_ROLES:
             self.node_counts[role] = 0
             self.nodes_with_role[role] = []
@@ -1134,6 +1135,8 @@ class Deployment():
             for role in node_roles:
                 self.nodes_with_role[role].append(name)
 
+            self.roles_of_nodes[name] = node_roles
+
             if 'master' in node_roles:
                 self.master = node
 
@@ -1183,6 +1186,7 @@ class Deployment():
                 node.add_repo(ZypperRepo(r_name.format(idx+1), repo_url))
 
             self.nodes[node.name] = node
+        self.node_list = ','.join(self.nodes.keys())
 
     def _generate_vagrantfile(self):
         vagrant_box = self.settings.os
@@ -1247,6 +1251,10 @@ class Deployment():
             'libvirt_storage_pool': self.settings.libvirt_storage_pool,
             'vagrant_box': vagrant_box,
             'nodes': list(self.nodes.values()),
+            'cluster_json': json.dumps({
+                "num_disks": self.settings.num_disks,
+                "roles_of_nodes": self.roles_of_nodes
+                }, sort_keys=True, indent=4),
             'master': self.master,
             'suma': self.suma,
             'domain': self.settings.domain.format(self.dep_id),
@@ -1262,6 +1270,7 @@ class Deployment():
             'os_base_repos': os_base_repos,
             'repo_priority': self.settings.repo_priority,
             'qa_test': self.settings.qa_test,
+            'node_list': self.node_list,
             'nfs_nodes': self.node_counts["nfs"],
             'nfs_node_list': ','.join(self.nodes_with_role["nfs"]),
             'igw_nodes': self.node_counts["igw"],

--- a/seslib/templates/cluster_json.sh.j2
+++ b/seslib/templates/cluster_json.sh.j2
@@ -1,0 +1,63 @@
+
+# files created on all nodes for QA testing purposes:
+# - /home/vagrant/cluster.json
+# - /home/vagrant/systemctl_test.sh
+
+{% set cluster_json_file = "/home/vagrant/cluster.json" %}
+cat > {{ cluster_json_file }} << EOF
+{{ cluster_json }}
+EOF
+
+{% set systemctl_test_script = "/home/vagrant/systemctl_test.sh" %}
+cat > {{ systemctl_test_script }} << 'EOF'
+#!/bin/bash
+FSID="$1"
+OS="{{ os }}"
+NUM_DISKS="$(cat /home/vagrant/cluster.json | jq -r '.num_disks')"
+ROLES_OF_NODES="$(cat /home/vagrant/cluster.json | jq -r '.roles_of_nodes')"
+ROLES_OF_THIS_NODE="$(echo "$ROLES_OF_NODES" | jq -r '.{{ node.name }}[]')"
+SUCCESS="yes"
+for role in $ROLES_OF_THIS_NODE ; do
+    [ "$role" = "storage" ] && role="osd"
+    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] ; then
+        if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] ; then
+            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+                REGEX="^ceph-$FSID@$role.+loaded active running"
+            else
+                REGEX="^ceph-$role@.+loaded active running"
+            fi
+        elif [ "$role" = "rgw" ] ; then
+            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+                REGEX="^ceph-$FSID@$role.+loaded active running"
+            else
+                REGEX="^ceph-radosgw@.+loaded active running"
+            fi
+        elif [ "$role" = "nfs" ] ; then
+            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+                REGEX="^ceph-$FSID@$role.+loaded active running"
+            else
+                REGEX="^nfs-ganesha\.service.+loaded active running"
+            fi
+        fi
+        running_instances="$(systemctl list-units --type=service --state=running | grep -E "$REGEX"  | wc --lines)"
+        if [ "$role" = "osd" ] ; then
+            expected_instances="$NUM_DISKS"
+        else
+            expected_instances="1"
+        fi
+        echo "running instances of $role systemd unit on node {{ node.name }} (systemctl/expected): ${running_instances}/${expected_instances}"
+        if [ "$running_instances" = "$expected_instances" ] ; then
+            true
+        else
+            echo "TEST FAILURE"
+            SUCCESS=""
+        fi
+    fi  
+done
+if [ "$SUCCESS" ] ; then
+    exit 0
+else
+    exit 1
+fi
+EOF
+chmod 755 {{ systemctl_test_script }}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -139,6 +139,8 @@ touch /tmp/ready
 
 {% if deploy_salt or suma %}
 
+{% include "cluster_json.sh.j2" %}
+
 {% if node == master or node == suma %}
 
 {% if node == master %}

--- a/seslib/templates/qa_test.sh.j2
+++ b/seslib/templates/qa_test.sh.j2
@@ -9,6 +9,7 @@
     ~ " --mon-nodes=" ~ mon_nodes
     ~ " --osd-nodes=" ~ storage_nodes
     ~ " --rgw-nodes=" ~ rgw_nodes
+    ~ " --node-list=" ~ node_list
     ~ " --nfs-node-list=" ~ nfs_node_list
     ~ " --igw-node-list=" ~ igw_node_list
     ~ " --mds-node-list=" ~ mds_node_list


### PR DESCRIPTION
Our systemctl test will use ssh to run a script on each node.
The script will need to know (or be able to look up) certain
characteristics of the cluster configuration.

With this commit, a file (/home/vagrant/cluster.json) is created
on each node. The cluster.json file contains a data structure
into which we place all the information needed by tests that
health-ok.sh triggers on an arbitrary node.

Fixes: https://github.com/SUSE/sesdev/issues/342
