### PR TITLE
Default to ".test" instead of ".com" for the cluster TLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+- If not provided explicitly via the "--domain" option, new deployments now
+  default to ".test" instead of ".com" as the cluster TLD.
+
 ## [1.3.0] - 2020-05-25
 
 ### Added

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -116,7 +116,7 @@ def common_create_options(func):
                      help='SCC organization username'),
         click.option('--scc-pass', type=str, default=None,
                      help='SCC organization password'),
-        click.option('--domain', type=str, default='{}.com',
+        click.option('--domain', type=str, default='{}.test',
                      help='Domain name to use'),
         click.option('--non-interactive', '-n', '--force', '-f', is_flag=True, default=False,
                      help='Do not ask the user if they really want to'),

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -445,7 +445,7 @@ SETTINGS = {
     'domain': {
         'type': str,
         'help': 'The domain name for nodes',
-        'default': '{}.com',
+        'default': '{}.test',
     },
     'non_interactive': {
         'type': bool,


### PR DESCRIPTION
If not provided explicitly via the `--domain` option, new deployments now default to `.test` instead of `.com` as the cluster TLD.

Fixes: https://github.com/SUSE/sesdev/issues/348
Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>