### PR TITLE
Add --devel/--product option and add-repo subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Jenkins CI tests that `sesdev` can be used to deploy a single-node Ceph
    * [Create/deploy a Ceph cluster](#createdeploy-a-ceph-cluster)
       * [On a remote libvirt server via SSH](#on-a-remote-libvirt-server-via-ssh)
       * [Using salt instead of DeepSea/ceph-salt CLI](#using-salt-instead-of-deepseaceph-salt-cli)
+      * [Without the devel repo](#without-the-devel-repo)
       * [With an additional custom zypper repo](#with-an-additional-custom-zypper-repo)
       * [With a set of custom zypper repos completely replacing the default repos](#with-a-set-of-custom-zypper-repos-completely-replacing-the-default-repos)
       * [With custom image paths](#with-custom-image-paths)
@@ -59,6 +60,7 @@ The Jenkins CI tests that `sesdev` can be used to deploy a single-node Ceph
    * [Services port-forwarding](#services-port-forwarding)
    * [Replace ceph-salt](#replace-ceph-salt)
    * [Replace MGR modules](#replacing-mgr-modules)
+   * [Add a repo to a cluster](#add-a-repo-to-a-cluster)
    * [Temporarily stop a cluster](#temporarily-stop-a-cluster)
    * [Destroy a cluster](#destroy-a-cluster)
    * [Run "make check"](#run-make-check)
@@ -396,6 +398,18 @@ nautilus, ses6) or the "ceph-salt" command to apply the ceph-salt Salt Formula
 If you would rather use Salt directly, give the `--salt` option on the `sesdev
 create` command line.
 
+#### Without the devel repo
+
+The "core" deployment targets (ses5, nautilus, ses6, octopus, ses7, pacific)
+all have a concept of a "devel" repo where updates to the Ceph/storage-related
+packages are staged. Since users frequently want to install the "latest,
+greatest" packages, the "devel" repo is added to all nodes by default. However,
+there are times when this is not desired: when using sesdev to simulate
+update/upgrade scenarios, for example.
+
+To deploy a Ceph cluster without the "devel" repo, give the `--product` option
+on the `sesdev create` command line.
+
 #### With an additional custom zypper repo
 
 Each deployment version (e.g. "octopus", "nautilus") is associated with
@@ -626,6 +640,26 @@ This can be helpful to test PRs in a cluster with all services enabled.
 $ sesdev replace-mgr-modules <deployment_id> <pr>
 ```
 
+### Add a repo to a cluster
+
+A custom repo can be added to all nodes of a running cluster using the following
+command:
+
+```
+$ sesdev add-repo <deployment_id> <repo_url>
+```
+
+If the repo URL is omitted, the "devel" repo (as defined for the Ceph version 
+deployed) will be added.
+
+If you want to also update packages on all nodes to the versions in that repo,
+give the `--update` option. For example, one can test an update scenario by
+deploying a cluster with the `--product` option and then updating the cluster to
+the packages staged in the "devel" project:
+
+```
+$ sesdev add-repo --update <deployment_id>
+```
 
 ### Temporarily stop a cluster
 

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -182,7 +182,8 @@ fi
 if [ "$SES5" ] ; then
     sesdev box remove --non-interactive sles-12-sp3
     # deploy ses5 without igw, so as not to hit https://github.com/SUSE/sesdev/issues/239
-    run_cmd sesdev create ses5 --non-interactive --roles "[master,storage,mon,mgr,mds,rgw,nfs]" --qa-test ses5-1node
+    run_cmd sesdev create ses5 --product --non-interactive --roles "[master,storage,mon,mgr,mds,rgw,nfs]" --qa-test ses5-1node
+    run_cmd sesdev add-repo --update ses5-1node
     run_cmd sesdev destroy --non-interactive ses5-1node
     run_cmd sesdev create ses5 --non-interactive --roles "[master,client,openattic],[storage,mon,mgr,rgw],[storage,mon,mgr,mds,nfs],[storage,mon,mgr,mds,rgw,nfs]" ses5-4node
     run_cmd sesdev qa-test ses5-4node
@@ -207,7 +208,8 @@ fi
 
 if [ "$SES6" ] ; then
     sesdev box remove --non-interactive sles-15-sp1
-    run_cmd sesdev create ses6 --non-interactive --single-node --qa-test ses6-1node
+    run_cmd sesdev create ses6 --product --non-interactive --single-node --qa-test ses6-1node
+    run_cmd sesdev add-repo --update ses6-1node
     run_cmd sesdev destroy --non-interactive ses6-1node
     run_cmd sesdev create ses6 --non-interactive ses6-4node
     run_cmd sesdev qa-test ses6-4node

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -74,20 +74,6 @@ class ExplicitAdminRoleNotAllowed(SesDevException):
             "(TL;DR remove the \"admin\" role and try again!)")
 
 
-class OptionFormatError(SesDevException):
-    def __init__(self, option, expected_type, value):
-        super(OptionFormatError, self).__init__(
-            "Wrong format for option '{}': expected format: '{}', actual format: '{}'"
-            .format(option, expected_type, value))
-
-
-class OptionValueError(SesDevException):
-    def __init__(self, option, message, value):
-        super(OptionValueError, self).__init__(
-            "Wrong value for option '{}'. {}. Actual value: '{}'"
-            .format(option, message, value))
-
-
 class NodeDoesNotExist(SesDevException):
     def __init__(self, node):
         super(NodeDoesNotExist, self).__init__(
@@ -130,6 +116,26 @@ class NoSupportConfigTarballFound(SesDevException):
     def __init__(self, node):
         super(NoSupportConfigTarballFound, self).__init__(
             "No supportconfig tarball found on node {}".format(node))
+
+
+class OptionFormatError(SesDevException):
+    def __init__(self, option, expected_type, value):
+        super(OptionFormatError, self).__init__(
+            "Wrong format for option '{}': expected format: '{}', actual format: '{}'"
+            .format(option, expected_type, value))
+
+
+class OptionNotSupportedInVersion(SesDevException):
+    def __init__(self, option, version):
+        super(OptionNotSupportedInVersion, self).__init__(
+            "Option '{}' not supported with version '{}'".format(option, version))
+
+
+class OptionValueError(SesDevException):
+    def __init__(self, option, message, value):
+        super(OptionValueError, self).__init__(
+            "Wrong value for option '{}'. {}. Actual value: '{}'"
+            .format(option, message, value))
 
 
 class RoleNotKnown(SesDevException):

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -9,7 +9,6 @@ Vagrant.configure("2") do |config|
 
 {% include "engine/" + vm_engine + "/vagrant.provider.j2" %}
 
-
 {% for node in nodes %}
   config.vm.define :"{{ node.name }}" do |node|
 
@@ -19,15 +18,15 @@ Vagrant.configure("2") do |config|
                               destination:".ssh/{{ ssh_key_name }}"
     node.vm.provision "file", source: "keys/{{ ssh_key_name }}.pub",
                               destination:".ssh/{{ ssh_key_name }}.pub"
-
 {% if node == master %}
+
     node.vm.provision "file", source: "bin/", destination: "/home/vagrant/"
     node.vm.provision "file", source: "{{ sesdev_path_to_qa }}", destination: "/home/vagrant/sesdev-qa"
 {% endif %}
 
     node.vm.synced_folder ".", "/vagrant", disabled: true
-
 {% if node == master %}
+
 {% for folder_conf in synced_folders %}
     node.vm.synced_folder "{{ folder_conf[0] }}", "{{ folder_conf[1] }}"
 {% endfor %}
@@ -40,6 +39,14 @@ Vagrant.configure("2") do |config|
       s.inline = "/home/vagrant/qa-test.sh"
     end
 {% endif %}
+
+    node.vm.provision "add-devel-repo", type: "shell", run: "never" do |s|
+      s.inline = "/home/vagrant/add-devel-repo.sh"
+    end
+
+    node.vm.provision "add-devel-repo-and-update", type: "shell", run: "never" do |s|
+      s.inline = "/home/vagrant/add-devel-repo.sh --update"
+    end
   end
 {% endfor %}
 

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -45,15 +45,39 @@ zypper --non-interactive removerepo repo-source-non-oss || true
 zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}
 
+{% set devel_repo_script = "/home/vagrant/add-devel-repo.sh" %}
+cat > {{ devel_repo_script }} << 'EOF'
+#!/bin/bash
+[[ "$*" =~ "--update" ]] && UPDATE="yes"
+set -ex
 {% for _repo in version_repos_prio %}
+{% if loop.index == 1 %}
+{% set devel_repo_name = "devel-repo" %}
+{% else %}
+{% set devel_repo_name = "devel-repo{{ loop.index }}" %}
+{% endif %}
 zypper addrepo --refresh
 {%- if _repo.priority %}
  --priority {{ _repo.priority }}
 {%- elif repo_priority %}
  --priority 98
 {%- endif %}
- {{ _repo.url }} {{ version }}-repo{{ loop.index }}
+ {{ _repo.url }} {{ devel_repo_name }}
 {% endfor %}
+zypper --gpg-auto-import-keys refresh
+if [ "$UPDATE" ] ; then
+    zypper dist-upgrade \
+        --allow-vendor-change \
+        --auto-agree-with-licenses \
+        --no-confirm \
+        --from=devel-repo
+fi
+EOF
+chmod 755 {{ devel_repo_script }}
+
+{% if devel_repo or not core_version %}
+{{ devel_repo_script }}
+{% endif %}
 
 {% if os.startswith("sle") %}
 zypper addrepo --refresh


### PR DESCRIPTION
The --devel/--product option (default: --devel) controls whether the
"devel" repo will be added to the nodes prior to deployment.

For SES{5,6,7}, the "devel" repo is Devel:Storage:{5,6,7}.0 Media1.

For {nautilus,octopus,pacific}, the "devel" repo is something like
"filesystems:ceph:...". For other create targets, the "devel" repo is
undefined and this PR is a noop.

This commit also implements an "add-repo" subcommand which can be used
to add either the "devel" repo or an arbitrary, "custom" repo to an
already-running cluster, and optionally update the cluster to newer (or
older) versions of packages contained in that repo at the same time.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

- [x] https://github.com/SUSE/sesdev/pull/203 merged
- [x] this PR rebased
- [x] figure out how to update the packages non-interactively even with the vendor change
- [x] add `--update` option to `add-default-repo` subcommand
- [x] raise exception if `--product` given with `nautilus`, as there is no deepsea in openSUSE:Leap:15.1
- [x] documentation added to README
- [x] `create --product` + `add-repo --update` test cases added to contrib/standalone.sh
- [x] manual testing complete: works as expected
- [x] passed `contrib/standalone.sh --full`