### PR TITLE
seslib: no longer support nautilus deployment in Tumbleweed

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -238,10 +238,6 @@ VERSION_OS_REPO_MAPPING = {
             'https://download.opensuse.org/repositories/filesystems:/ceph:/nautilus/'
             'openSUSE_Leap_15.1/'
         ],
-        'tumbleweed': [
-            'https://download.opensuse.org/repositories/filesystems:/ceph:/nautilus/'
-            'openSUSE_Tumbleweed'
-        ],
     },
     'ses6': {
         'sles-15-sp1': [
@@ -255,7 +251,7 @@ VERSION_OS_REPO_MAPPING = {
             'openSUSE_Leap_15.1'
         ],
         'leap-15.2': [
-            'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/'
+            'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/'
             'openSUSE_Leap_15.2'
         ],
         'tumbleweed': [


### PR DESCRIPTION
Since Tumbleweed is now on Octopus, nautilus is not expected to be built
for Factory/Tumbleweed anymore in filesystems:ceph:nautilus.

Also, the "octopus" deployment target is expected to deploy something
very similar, if not identical, to SES7 on openSUSE Leap 15.2. So use
`filesystems:ceph:octopus` by default, instead of
`filesystems:ceph:octopus:upstream`.

Signed-off-by: Nathan Cutler <ncutler@suse.com>