### PR TITLE
Fix "replace-mgr-modules" when no containers are running on node

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -2046,7 +2046,8 @@ class Deployment():
                 ssh_cmd = self._ssh_cmd(node)
                 ssh_cmd.append('podman ps --format "{}" -f name=mgr.{}'.format("{{.ID}}", node))
                 containers = tools.run_sync(ssh_cmd)
-                containers = containers.strip().split('\n')
+                containers = containers.strip()
+                containers = containers.split('\n') if containers else []
 
                 print("Copying to node {}".format(node))
                 ssh_cmd = self._ssh_cmd(node)


### PR DESCRIPTION
If there's no containers running on a node, then `replace-mgr-modules` is failing because:

```
>>> 'a\nb\n'.strip().split('\n')
['a', 'b']

>>> '\n'.strip().split('\n')
['']
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>