### PR TITLE
provision.sh: fix regression

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -54,7 +54,7 @@ set -ex
 {% if loop.index == 1 %}
 {% set devel_repo_name = "devel-repo" %}
 {% else %}
-{% set devel_repo_name = "devel-repo{{ loop.index }}" %}
+{% set devel_repo_name = "devel-repo" ~ loop.index %}
 {% endif %}
 zypper addrepo --refresh
 {%- if _repo.priority %}


### PR DESCRIPTION
A misuse of Jinja syntax crept in.

Fixes: f4ae4a041650f3ca113363d4ad7fd66d6760555c
Signed-off-by: Nathan Cutler <ncutler@suse.com>