### PR TITLE
qa: do not wait for non-existent daemons to start

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -201,6 +201,8 @@ fi
 
 if [ "$SES5" ] ; then
     sesdev box remove --non-interactive sles-12-sp3
+    run_cmd sesdev create ses5 --non-interactive --roles "[master,storage,mon,mgr]" --qa-test ses5-mini
+    run_cmd sesdev destroy --non-interactive ses5-mini
     # deploy ses5 without igw, so as not to hit https://github.com/SUSE/sesdev/issues/239
     run_cmd sesdev create ses5 --product --non-interactive --roles "[master,storage,mon,mgr,mds,rgw,nfs]" --qa-test ses5-1node
     run_cmd sesdev add-repo --update ses5-1node
@@ -228,6 +230,8 @@ fi
 
 if [ "$SES6" ] ; then
     sesdev box remove --non-interactive sles-15-sp1
+    run_cmd sesdev create ses6 --non-interactive --roles "[master,storage,mon,mgr]" --qa-test ses6-mini
+    run_cmd sesdev destroy --non-interactive ses6-mini
     run_cmd sesdev create ses6 --product --non-interactive --single-node --qa-test ses6-1node
     run_cmd sesdev add-repo --update ses6-1node
     run_cmd sesdev destroy --non-interactive ses6-1node
@@ -254,6 +258,8 @@ fi
 
 if [ "$SES7" ] ; then
     sesdev box remove --non-interactive sles-15-sp2
+    run_cmd sesdev create ses7 --non-interactive --roles "[master,storage,mon,mgr]" --qa-test ses7-mini
+    run_cmd sesdev destroy --non-interactive ses7-mini
     run_cmd sesdev create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --qa-test ses7-1node
     run_cmd sesdev destroy --non-interactive ses7-1node
     run_cmd sesdev create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" ses7-4node

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -252,7 +252,7 @@ function maybe_wait_for_osd_nodes_test {
     local expected_osd_nodes="$1"
     echo
     echo "WWWW: maybe_wait_for_osd_nodes_test"
-    if [ "$expected_osd_nodes" ] ; then
+    if [ "$expected_osd_nodes" -gt "0" ] ; then
         local actual_osd_nodes
         local minutes_to_wait
         minutes_to_wait="5"
@@ -294,7 +294,7 @@ function maybe_wait_for_mdss_test {
     local expected_mdss="$1"
     echo
     echo "WWWW: maybe_wait_for_mdss_test"
-    if [ "$expected_mdss" ] ; then
+    if [ "$expected_mdss" -gt "0" ] ; then
         local actual_mdss
         local minutes_to_wait
         minutes_to_wait="5"
@@ -338,7 +338,7 @@ function maybe_wait_for_rgws_test {
     local expected_rgws="$1"
     echo
     echo "WWWW: maybe_wait_for_rgws_test"
-    if [ "$expected_rgws" ] ; then
+    if [ "$expected_rgws" -gt "0" ] ; then
         local actual_rgws
         local minutes_to_wait
         minutes_to_wait="5"
@@ -383,7 +383,7 @@ function maybe_wait_for_nfss_test {
         local expected_nfss="$1"
         echo
         echo "WWWW: maybe_wait_for_nfss_test"
-        if [ "$expected_nfss" ] ; then
+        if [ "$expected_nfss" -gt "0" ] ; then
             local orch_ps_nfss
             local orch_ls_nfss
             local minutes_to_wait
@@ -520,36 +520,24 @@ function number_of_services_expected_vs_orch_ls_test {
         [ "$OSDS" ]      && expected_osds="$OSDS"
         [ "$RGW_NODES" ] && expected_rgws="$RGW_NODES"
         [ "$NFS_NODES" ] && expected_nfss="$NFS_NODES"
-        if [ "$expected_mgrs" ] ; then
-            echo "MGR services (orch ls/expected): $orch_ls_mgrs/$expected_mgrs"
-            if [ "$orch_ls_mgrs" = "$expected_mgrs" ] ; then
-                true  # normal success case
-            elif [ "$expected_mgrs" -gt "1" ] && [ "$orch_ls_mgrs" = "$((expected_mgrs + 1))" ] ; then
-                true  # workaround for https://tracker.ceph.com/issues/45093
-            else
-                success=""
-            fi
+        echo "MGR services (orch ls/expected): $orch_ls_mgrs/$expected_mgrs"
+        if [ "$orch_ls_mgrs" = "$expected_mgrs" ] ; then
+            true  # normal success case
+        elif [ "$expected_mgrs" -gt "1" ] && [ "$orch_ls_mgrs" = "$((expected_mgrs + 1))" ] ; then
+            true  # workaround for https://tracker.ceph.com/issues/45093
+        else
+            success=""
         fi
-        if [ "$expected_mons" ] ; then
-            echo "MON services (orch ls/expected): $orch_ls_mons/$expected_mons"
-            [ "$orch_ls_mons" = "$expected_mons" ] || success=""
-        fi
-        if [ "$expected_mdss" ] ; then
-            echo "MDS services (orch ls/expected): $orch_ls_mdss/$expected_mdss"
-            [ "$orch_ls_mdss" = "$expected_mdss" ] || success=""
-        fi
-        # if [ "$expected_osds" ] ; then
-        #     echo "OSDs orch ls/expected: $orch_ls_osds/$expected_osds"
-        #     [ "$orch_ls_osds" = "$expected_osds" ] || success=""
-        # fi
-        if [ "$expected_rgws" ] ; then
-            echo "RGW services (orch ls/expected): $orch_ls_rgws/$expected_rgws"
-            [ "$orch_ls_rgws" = "$expected_rgws" ] || success=""
-        fi
-        if [ "$expected_nfss" ] ; then
-            echo "NFS services (orch ls/expected): $orch_ls_nfss/$expected_nfss"
-            [ "$orch_ls_nfss" = "$expected_nfss" ] || success=""
-        fi
+        echo "MON services (orch ls/expected): $orch_ls_mons/$expected_mons"
+        [ "$orch_ls_mons" = "$expected_mons" ] || success=""
+        echo "MDS services (orch ls/expected): $orch_ls_mdss/$expected_mdss"
+        [ "$orch_ls_mdss" = "$expected_mdss" ] || success=""
+        # echo "OSDs orch ls/expected: $orch_ls_osds/$expected_osds"
+        # [ "$orch_ls_osds" = "$expected_osds" ] || success=""
+        echo "RGW services (orch ls/expected): $orch_ls_rgws/$expected_rgws"
+        [ "$orch_ls_rgws" = "$expected_rgws" ] || success=""
+        echo "NFS services (orch ls/expected): $orch_ls_nfss/$expected_nfss"
+        [ "$orch_ls_nfss" = "$expected_nfss" ] || success=""
         if [ "$success" ] ; then
             echo "WWWW: number_of_services_expected_vs_orch_ls_test: OK"
             echo
@@ -595,36 +583,24 @@ function _orch_ps_test {
     [ "$OSDS" ]      && expected_osds="$OSDS"
     [ "$RGW_NODES" ] && expected_rgws="$RGW_NODES"
     [ "$NFS_NODES" ] && expected_nfss="$NFS_NODES"
-    if [ "$expected_mgrs" ] ; then
-        echo "MGR daemons (orch ps/expected): $orch_ps_mgrs/$expected_mgrs"
-        if [ "$orch_ps_mgrs" = "$expected_mgrs" ] ; then
-            true  # normal success case
-        elif [ "$expected_mgrs" -gt "1" ] && [ "$orch_ps_mgrs" = "$((expected_mgrs + 1))" ] ; then
-            true  # workaround for https://tracker.ceph.com/issues/45093
-        else
-            success=""
-        fi
+    echo "MGR daemons (orch ps/expected): $orch_ps_mgrs/$expected_mgrs"
+    if [ "$orch_ps_mgrs" = "$expected_mgrs" ] ; then
+        true  # normal success case
+    elif [ "$expected_mgrs" -gt "1" ] && [ "$orch_ps_mgrs" = "$((expected_mgrs + 1))" ] ; then
+        true  # workaround for https://tracker.ceph.com/issues/45093
+    else
+        success=""
     fi
-    if [ "$expected_mons" ] ; then
-        echo "MON daemons (orch ps/expected): $orch_ps_mons/$expected_mons"
-        [ "$orch_ps_mons" = "$expected_mons" ] || success=""
-    fi
-    if [ "$expected_mdss" ] ; then
-        echo "MDS daemons (orch ps/expected): $orch_ps_mdss/$expected_mdss"
-        [ "$orch_ps_mdss" = "$expected_mdss" ] || success=""
-    fi
-    # if [ "$expected_osds" ] ; then
-    #     echo "OSDs orch ps/expected: $orch_ps_osds/$expected_osds"
-    #     [ "$orch_ps_osds" = "$expected_osds" ] || success=""
-    # fi
-    if [ "$expected_rgws" ] ; then
-        echo "RGW daemons (orch ps/expected): $orch_ps_rgws/$expected_rgws"
-        [ "$orch_ps_rgws" = "$expected_rgws" ] || success=""
-    fi
-    if [ "$expected_nfss" ] ; then
-        echo "NFS daemons (orch ps/expected): $orch_ps_nfss/$expected_nfss"
-        [ "$orch_ps_nfss" = "$expected_nfss" ] || success=""
-    fi
+    echo "MON daemons (orch ps/expected): $orch_ps_mons/$expected_mons"
+    [ "$orch_ps_mons" = "$expected_mons" ] || success=""
+    echo "MDS daemons (orch ps/expected): $orch_ps_mdss/$expected_mdss"
+    [ "$orch_ps_mdss" = "$expected_mdss" ] || success=""
+    # echo "OSDs orch ps/expected: $orch_ps_osds/$expected_osds"
+    # [ "$orch_ps_osds" = "$expected_osds" ] || success=""
+    echo "RGW daemons (orch ps/expected): $orch_ps_rgws/$expected_rgws"
+    [ "$orch_ps_rgws" = "$expected_rgws" ] || success=""
+    echo "NFS daemons (orch ps/expected): $orch_ps_nfss/$expected_nfss"
+    [ "$orch_ps_nfss" = "$expected_nfss" ] || success=""
     if [ "$success" ] ; then
         return 0
     else

--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -13,12 +13,12 @@ function json_ses7_orch_ls {
         local ceph_orch_ls
         local running
         ceph_orch_ls="$(ceph orch ls --service-type "$service_type" --format json)"
-        running="$(echo "$ceph_orch_ls" | jq -r '.[] | .running')"
-        if [ "$running" = "null" ] ; then
-            # we have fallen victim to ongoing Orchestrator refactoring
+        if echo "$ceph_orch_ls" | jq -r >/dev/null 2>&1 ; then
             running="$(echo "$ceph_orch_ls" | jq -r '.[] | .status.running')"
+            echo "$running"
+        else
+            echo "0"
         fi
-        echo "$running"
     else
         echo "ERROR"
     fi
@@ -28,10 +28,15 @@ function json_ses7_orch_ps {
     # returns number of running daemons of a given type, according to "ceph orch ps"
     if [ "$VERSION_ID" = "15.2" ] ; then  # SES7
         local daemon_type="$1"
-        local retval
-        retval=$(ceph orch ps -f json-pretty | jq "[.[] | select(.daemon_type==\"$daemon_type\" and .status_desc==\"running\")] | length")
-        [ "$retval" ] || retval="0"
-        echo "$retval"
+        local ceph_orch_ps
+        local running
+        ceph_orch_ps="$(ceph orch ps --daemon-type "$daemon_type" -f json-pretty)"
+        if echo "$ceph_orch_ps" | jq -r >/dev/null 2>&1 ; then
+            running="$(echo "$ceph_orch_ps" | jq -r '[ .[] | select(.status_desc == "running") ] | length')"
+            echo "$running"
+        else
+            echo "0"
+        fi
     else
         echo "ERROR"
     fi


### PR DESCRIPTION
I tried to deploy a cluster with no "mds" role, and QA test failed:

    master: 0 MDS daemons did not appear even after waiting 5 minutes.
    Giving up.

This is because we were running the test whenever "$expected_mdss" is
non-empty, which is the wrong conditional criterion, since it's always
going to be true (the string "0" is non-empty).

Fixes: https://github.com/SUSE/sesdev/issues/366
Signed-off-by: Nathan Cutler <ncutler@suse.com>