### PR TITLE
sesdev: sanitize makecheck deployment IDs

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -878,7 +878,8 @@ def makecheck(deployment_id, deploy, **kwargs):
     settings_dict = _gen_settings_dict('makecheck', **kwargs)
     if not deployment_id:
         os = settings_dict['os'] if 'os' in settings_dict else 'tumbleweed'
-        deployment_id = 'makecheck-{}'.format(os)
+        safe_os = os.replace('_', '-').replace('.', '-')
+        deployment_id = 'makecheck-{}'.format(safe_os)
     _create_command(deployment_id, deploy, settings_dict)
 
 


### PR DESCRIPTION
As a result of cf327719fcc5d76ea0d54db0a99342b6c1dfdfd3 we can no longer
use characters like "_" (underscore) and "." (fullstop) in deployment
IDs. Because "makecheck" generates the deployment ID from the OS ID
which might contain these characters, we sanitize it by converting these
characters to "-" (hyphen).

Fixes: cf327719fcc5d76ea0d54db0a99342b6c1dfdfd3
Signed-off-by: Nathan Cutler <ncutler@suse.com>