### PR TITLE
qa: add IGW to existing tests

### DIFF
--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -157,6 +157,7 @@ maybe_wait_for_osd_nodes_test "$OSD_NODES"  # it might take a long time for OSD 
 maybe_wait_for_mdss_test "$MDS_NODES"  # it might take a long time for MDSs to be ready
 maybe_wait_for_rgws_test "$RGW_NODES"  # it might take a long time for RGWs to be ready
 maybe_wait_for_nfss_test "$NFS_NODES"  # it might take a long time for NFSs to be ready
+maybe_wait_for_igws_test "$IGW_NODES"  # it might take a long time for NFSs to be ready
 ceph_health_test
 
 # check that OSDs have the expected objectstore

--- a/seslib/templates/cluster_json.sh.j2
+++ b/seslib/templates/cluster_json.sh.j2
@@ -18,8 +18,9 @@ ROLES_OF_NODES="$(cat /home/vagrant/cluster.json | jq -r '.roles_of_nodes')"
 ROLES_OF_THIS_NODE="$(echo "$ROLES_OF_NODES" | jq -r '.{{ node.name }}[]')"
 SUCCESS="yes"
 for role in $ROLES_OF_THIS_NODE ; do
+    REGEX=""
     [ "$role" = "storage" ] && role="osd"
-    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] ; then
+    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ]; then
         if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] ; then
             if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
@@ -38,19 +39,29 @@ for role in $ROLES_OF_THIS_NODE ; do
             else
                 REGEX="^nfs-ganesha\.service.+loaded active running"
             fi
+        elif [ "$role" = "igw" ] ; then
+            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+                REGEX="^ceph-$FSID@iscsi.+loaded active running"
+            elif [ "$OS" = "leap-15.1" ] || [ "$OS" = "sles-15-sp1" ] ; then
+                REGEX="^rbd-target-api\.service.+loaded active running"
+            else
+                REGEX=""
+            fi
         fi
-        running_instances="$(systemctl list-units --type=service --state=running | grep -E "$REGEX"  | wc --lines)"
-        if [ "$role" = "osd" ] ; then
-            expected_instances="$NUM_DISKS"
-        else
-            expected_instances="1"
-        fi
-        echo "running instances of $role systemd unit on node {{ node.name }} (systemctl/expected): ${running_instances}/${expected_instances}"
-        if [ "$running_instances" = "$expected_instances" ] ; then
-            true
-        else
-            echo "TEST FAILURE"
-            SUCCESS=""
+        if [ "$REGEX" ] ; then
+            running_instances="$(systemctl list-units --type=service --state=running | grep -E "$REGEX"  | wc --lines)"
+            if [ "$role" = "osd" ] ; then
+                expected_instances="$NUM_DISKS"
+            else
+                expected_instances="1"
+            fi
+            echo "running instances of $role systemd unit on node {{ node.name }} (systemctl/expected): ${running_instances}/${expected_instances}"
+            if [ "$running_instances" = "$expected_instances" ] ; then
+                true
+            else
+                echo "TEST FAILURE"
+                SUCCESS=""
+            fi
         fi
     fi  
 done


### PR DESCRIPTION
Until now, we have not been testing whether the desired number of iSCSI
Gateways (IGWs) was actually deployed.

Now that we have IGW deployment in {octopus,ses7,pacific}, it's time to
add this code.

Signed-off-by: Nathan Cutler <ncutler@suse.com>