### PR TITLE
qa/systemctl_test: better error message when FSID omitted

### DIFF
--- a/seslib/templates/cluster_json.sh.j2
+++ b/seslib/templates/cluster_json.sh.j2
@@ -12,7 +12,14 @@ EOF
 cat > {{ systemctl_test_script }} << 'EOF'
 #!/bin/bash
 FSID="$1"
-OS="{{ os }}"
+source /etc/os-release
+echo "Running $0 on $NAME $VERSION ($PRETTY_NAME)"
+if [ "$VERSION_ID" = "15.2" ] && [ -z "$FSID" ] ; then
+    echo "You must provide a Ceph Cluster FSID as an option to this script."
+    echo "Bailing out!"
+    echo
+    exit 1
+fi
 NUM_DISKS="$(cat /home/vagrant/cluster.json | jq -r '.num_disks')"
 ROLES_OF_NODES="$(cat /home/vagrant/cluster.json | jq -r '.roles_of_nodes')"
 ROLES_OF_THIS_NODE="$(echo "$ROLES_OF_NODES" | jq -r '.{{ node.name }}[]')"
@@ -22,19 +29,19 @@ for role in $ROLES_OF_THIS_NODE ; do
     [ "$role" = "storage" ] && role="osd"
     if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ]; then
         if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] ; then
-            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
             else
                 REGEX="^ceph-$role@.+loaded active running"
             fi
         elif [ "$role" = "rgw" ] ; then
-            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
             else
                 REGEX="^ceph-radosgw@.+loaded active running"
             fi
         elif [ "$role" = "nfs" ] ; then
-            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
             else
                 REGEX="^nfs-ganesha\.service.+loaded active running"


### PR DESCRIPTION
If systemctl_test.sh is run manually, the human running it might forget
that it needs a Ceph Cluster FSID on {octopus,ses6,pacific}. Produce a
helpful error message in that case.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

To Do:

- [x] #372 merged
- [x] this PR rebased