### PR TITLE
qa: implement superficial test for presence of dashboard branding

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -928,3 +928,29 @@ function osd_objectstore_test {
         false
     fi
 }
+
+function dashboard_branding_not_completely_absent_test {
+    echo "WWWW: dashboard_branding_not_completely_absent_test"
+    if [ "$VERSION_ID" = "15.1" ] ; then
+        local success
+        local dashboard_url
+        set -x
+        dashboard_url="$(ceph mgr services | jq -r .dashboard)"
+        if curl --silent --insecure "$dashboard_url" | grep -i suse ; then
+            success="yes"
+        fi
+        set +x
+        if [ "$success" ] ; then
+            echo "WWWW: dashboard_branding_not_completely_absent_test: OK"
+            echo
+        else
+            echo "CRITICAL RED DANGER: dashboard branding appears to be completely absent!"
+            echo "WWWW: dashboard_branding_not_completely_absent_test: FAIL"
+            echo
+            false
+        fi
+    else
+        echo "WWWW: dashboard_branding_not_completely_absent_test: SKIPPED"
+        echo
+    fi
+}

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -171,5 +171,7 @@ number_of_daemons_expected_vs_actual
 cluster_json_test
 systemctl_list_units_test
 
+# extremely superficial test for presence of dashboard branding
+dashboard_branding_not_completely_absent_test
 # check that the RGWs are serving requests on the expected nodes/ports
 maybe_rgw_smoke_test


### PR DESCRIPTION
Only for VERSION_ID="15.1" for the time being. VERSION_ID="15.2" support
is blocked by https://bugzilla.suse.com/show_bug.cgi?id=1170498 and
the test for VERSION_ID="12.3" would need different semantics
(openATTIC).

References: https://github.com/SUSE/sesdev/issues/292
Signed-off-by: Nathan Cutler <ncutler@suse.com>