### PR TITLE
sesdev: raise exception if --roles combined with --single-node

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -12,6 +12,7 @@ from prettytable import PrettyTable
 import seslib
 from seslib.exceptions import \
                               SesDevException, \
+                              NoExplicitRolesWithSingleNode, \
                               OptionFormatError, \
                               OptionNotSupportedInVersion, \
                               OptionValueError, \
@@ -492,6 +493,8 @@ def _gen_settings_dict(version,
         settings_dict['roles'] = _parse_roles("[ makecheck ]")
     elif not single_node and roles:
         settings_dict['roles'] = _parse_roles(roles)
+    elif single_node and roles:
+        raise NoExplicitRolesWithSingleNode()
     elif single_node:
         roles_string = ""
         if version in ['ses7', 'octopus', 'pacific']:

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -80,6 +80,13 @@ class NodeDoesNotExist(SesDevException):
             "Node '{}' does not exist in this deployment".format(node))
 
 
+class NoExplicitRolesWithSingleNode(SesDevException):
+    def __init__(self):
+        super(NoExplicitRolesWithSingleNode, self).__init__(
+            "The --roles and --single-node options are mutually exclusive. "
+            "One may be given, or the other, but not both at the same time.")
+
+
 class NoPrometheusGrafanaInSES5(SesDevException):
     def __init__(self):
         super(NoPrometheusGrafanaInSES5, self).__init__(


### PR DESCRIPTION
Since --single-node silently clobbers --roles, it's not a good
idea to let the user set them both at the same time.

Fixes: https://github.com/SUSE/sesdev/issues/304
Signed-off-by: Nathan Cutler <ncutler@suse.com>