### PR TITLE
sesdev: use Luminous roles for SES5

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -199,7 +199,7 @@ class Constant():
         'nautilus': DEFAULT_ROLES["nautilus"],
         'octopus': DEFAULT_ROLES["octopus"],
         'pacific': DEFAULT_ROLES["octopus"],
-        'ses5': DEFAULT_ROLES["nautilus"],
+        'ses5': DEFAULT_ROLES["luminous"],
         'ses6': DEFAULT_ROLES["nautilus"],
         'ses7': DEFAULT_ROLES["octopus"],
     }


### PR DESCRIPTION
Fix the error `The DeepSea version used in SES5 does not recognize 'prometheus' or 'grafana' as roles in policy.cfg.` when creating a cluster with default roles.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>