### PR TITLE
[DNM] Instantiate monitoring roles on {octopus,ses7,pacific}

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -22,6 +22,7 @@ from .exceptions import \
                         MultipleRolesPerMachineNotAllowedInCaaSP, \
                         NodeDoesNotExist, \
                         NodeMustBeAdminAsWell, \
+                        NoAlertManagerOrNodeExporterIn, \
                         NoGaneshaRolePostNautilus, \
                         NoPrometheusGrafanaInSES5, \
                         NoSourcePortForPortForwarding, \
@@ -464,6 +465,14 @@ class Deployment():
             'qa_test': self.settings.qa_test,
             'node_list': self.node_list,
             'cephadm_bootstrap_node': cephadm_bootstrap_node,
+            'prometheus_nodes': self.node_counts["prometheus"],
+            'prometheus_node_list': ','.join(self.nodes_with_role["prometheus"]),
+            'grafana_nodes': self.node_counts["grafana"],
+            'grafana_node_list': ','.join(self.nodes_with_role["grafana"]),
+            'alertmanager_nodes': self.node_counts["alertmanager"],
+            'alertmanager_node_list': ','.join(self.nodes_with_role["alertmanager"]),
+            'node_exporter_nodes': self.node_counts["node-exporter"],
+            'node_exporter_node_list': ','.join(self.nodes_with_role["node-exporter"]),
             'nfs_nodes': self.node_counts["nfs"],
             'nfs_node_list': ','.join(self.nodes_with_role["nfs"]),
             'igw_nodes': self.node_counts["igw"],
@@ -871,6 +880,10 @@ deployment might not be completely destroyed.
         if self.settings.version == 'ses5':
             if self.node_counts['prometheus'] > 0 or self.node_counts['grafana'] > 0:
                 raise NoPrometheusGrafanaInSES5()
+        # alertmanager and node-exporter roles are only valid in octopus+
+        if self.settings.version not in ["octopus", "ses7", "pacific"]:
+            if self.node_counts['alertmanager'] > 0 or self.node_counts['node-exporter'] > 0:
+                raise NoAlertManagerOrNodeExporterIn(self.settings.version)
         # suma role only in octopus and not together with master
         if self.suma:
             if self.settings.version not in 'octopus':

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -139,6 +139,13 @@ class NoGaneshaRolePostNautilus(SesDevException):
         )
 
 
+class NoAlertManagerOrNodeExporterIn(SesDevException):
+    def __init__(self, version):
+        super().__init__(
+            "The \"alertmanager\" and \"node-exporter\" roles require Octopus "
+            "or above (your version: {})".format(version))
+
+
 class NoExplicitRolesWithSingleNode(SesDevException):
     def __init__(self):
         super().__init__(

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -162,10 +162,9 @@ echo "\"ceph status\" exit code: $?"
 rm -f {{ service_spec_core }}
 touch {{ service_spec_core }}
 
-{% set ceph_orch_apply_needed = False %}
+{% if mon_nodes > 1 or mgr_nodes > 1 or storage_nodes > 0 %}
 
 {% if mon_nodes > 1 %}
-{% set ceph_orch_apply_needed = True %}
 cat >> {{ service_spec_core }} << 'EOF'
 ---
 service_type: mon
@@ -180,7 +179,6 @@ EOF
 {% endif %} {# mon_nodes > 1 #}
 
 {% if mgr_nodes > 1 %}
-{% set ceph_orch_apply_needed = True %}
 cat >> {{ service_spec_core }} << 'EOF'
 ---
 service_type: mgr
@@ -195,7 +193,6 @@ EOF
 {% endif %} {# mgr_nodes > 1 #}
 
 {% if storage_nodes > 0 %}
-{% set ceph_orch_apply_needed = True %}
 cat >> {{ service_spec_core }} << 'EOF'
 ---
 service_type: osd
@@ -218,7 +215,6 @@ objectstore: filestore
 EOF
 {% endif %} {# storage_nodes > 0 #}
 
-{% if ceph_orch_apply_needed %}
 set +x
 echo "Allowing one-minute grace period to expire before initiating \"ceph orch apply\"."
 sleep 60
@@ -226,7 +222,8 @@ set -x
 cat {{ service_spec_core }}
 ceph orch apply -i {{ service_spec_core }} --dry-run
 ceph orch apply -i {{ service_spec_core }}
-{% endif %} {# ceph_orch_apply_needed #}
+
+{% endif %} {# mon_nodes > 1 or mgr_nodes > 1 or storage_nodes > 0 #}
 
 {% if total_osds > 0 %}
 
@@ -346,7 +343,15 @@ ceph nfs cluster ls
 
 {% endif %} {# mds_nodes > 0 #}
 
-{% if rgw_nodes > 0 or igw_nodes > 0 %}
+{% set deploy_monitoring = False %}
+{% if prometheus_nodes > 0 or grafana_nodes > 0 or alertmanager_nodes > 0 or node_exporter_nodes > 0 %}
+{% set deploy_monitoring = True %}
+# manually enabling prometheus module will no longer be required once
+# https://tracker.ceph.com/issues/46606 is fixed
+ceph mgr module enable prometheus
+{% endif %} {# prometheus_nodes > 0 or grafana_nodes > 0 or alertmanager_nodes > 0 or node_exporter_nodes > 0 #}
+
+{% if rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring %}
 
 {% set service_spec_gw = "/root/service_spec_gw.yml" %}
 rm -f {{ service_spec_gw }}
@@ -404,10 +409,70 @@ spec:
 EOF
 {% endif %} {# igw_nodes > 0 #}
 
+{% if prometheus_nodes > 0 %}
+cat >> {{ service_spec_gw }} << 'EOF'
+---
+service_type: prometheus
+service_id: sesdev_monitoring_prometheus
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('prometheus') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+{% endif %} {# prometheus_nodes > 0 #}
+
+{% if grafana_nodes > 0 %}
+cat >> {{ service_spec_gw }} << 'EOF'
+---
+service_type: grafana
+service_id: sesdev_monitoring_grafana
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('grafana') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+{% endif %} {# grafana_nodes > 0 #}
+
+{% if alertmanager_nodes > 0 %}
+cat >> {{ service_spec_gw }} << 'EOF'
+---
+service_type: alertmanager
+service_id: sesdev_monitoring_alertmanager
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('alertmanager') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+{% endif %} {# alertmanager_nodes > 0 #}
+
+{% if node_exporter_nodes > 0 %}
+cat >> {{ service_spec_gw }} << 'EOF'
+---
+service_type: node-exporter
+service_id: sesdev_monitoring_node_exporter
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('node-exporter') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+{% endif %} {# node_exporter_nodes > 0 #}
+
 cat {{ service_spec_gw }}
 ceph orch apply -i {{ service_spec_gw }}
 
-{% endif %} {# rgw_nodes > 0 or igw_nodes > 0 #}
+{% endif %} {# rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring #}
 
 {% endif %} {# storage_nodes > 0 #}
 


### PR DESCRIPTION
The monitoring roles are:

* prometheus
* grafana
* alertmanager
* node-exporter

Fixes: https://github.com/SUSE/sesdev/issues/354
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

Still missing (to be done via follow-on issues/PRs):

- [x] merge #416 and rebase this PR
- [ ] get this to work
- [ ] ability to override monitoring stack container image paths via sesdev config (The container image paths need to be entered into the MON config store using https://github.com/ceph/ceph/pull/35106)
- [ ] smoke test for prometheus - see #418
- [ ] smoke test for grafana
- [ ] smoke test for alertmanager
- [ ] smoke test for node-exporter