### PR TITLE
qa/nfs: run all nfs smoke tests on ses7 as well as octopus

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -1038,10 +1038,7 @@ function nfs_maybe_mount_export_and_touch_file {
     mount_point="/mnt/nfs"
     echo "WWWW: nfs_maybe_mount_export_and_touch_file"
     echo
-    # for the time being can only be run on openSUSE Leap 15.2 because
-    # the official SES7 container image has NFS Ganesha 3.2 (mgr/nfs
-    # requires 3.3 or later)
-    if [ "$VERSION_ID" = "15.2" ] && [[ "$ID" =~ "opensuse" ]] ; then
+    if [ "$VERSION_ID" = "15.2" ] ; then
         if [ "$NFS_NODE_LIST" ] && [ "$MDS_NODE_LIST" ] ; then
             skipped=""
             _zypper_ref_on_master


### PR DESCRIPTION
Now that nfs-ganesha has been updated to 3.3 on SES7 as well
as filesystems:ceph:octopus, we can run the full set of NFS smoke tests
on ses7 as well as octopus.

Signed-off-by: Nathan Cutler <ncutler@suse.com>