### PR TITLE
contrib/standalone.sh: omit larger ses5 single-node deployment test

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -204,12 +204,17 @@ set -x
 if [ "$SES5" ] ; then
     sesdev box remove --non-interactive sles-12-sp3
     run_cmd sesdev create ses5 --dry-run
-    run_cmd sesdev create ses5 --non-interactive --roles "[master,storage,mon,mgr]" --qa-test ses5-mini
+    run_cmd sesdev create ses5 --non-interactive --product --roles "[master,storage,mon,mgr]" --qa-test ses5-mini
+    run_cmd sesdev add-repo --update ses5-mini
     run_cmd sesdev destroy --non-interactive ses5-mini
-    # deploy ses5 without igw, so as not to hit https://github.com/SUSE/sesdev/issues/239
-    run_cmd sesdev create ses5 --product --non-interactive --roles "[master,storage,mon,mgr,mds,rgw,nfs]" --qa-test ses5-1node
-    run_cmd sesdev add-repo --update ses5-1node
-    run_cmd sesdev destroy --non-interactive ses5-1node
+    # ---------------------------------------------------------------------------
+    # comment out larger single-node deployment due to prometheus-node_exporter
+    # related failure in Stage 2 that started appearing in July 2020
+    # ---------------------------------------------------------------------------
+    ## deploy ses5 without igw, so as not to hit https://github.com/SUSE/sesdev/issues/239
+    # run_cmd sesdev create ses5 --product --non-interactive --roles "[master,storage,mon,mgr,mds,rgw,nfs]" --qa-test ses5-1node
+    # run_cmd sesdev destroy --non-interactive ses5-1node
+    # ---------------------------------------------------------------------------
     run_cmd sesdev create ses5 --non-interactive --roles "[master,client,openattic],[storage,mon,mgr,rgw],[storage,mon,mgr,mds,nfs],[storage,mon,mgr,mds,rgw,nfs]" ses5-4node
     run_cmd sesdev qa-test ses5-4node
     run_cmd sesdev supportconfig ses5-4node node1


### PR DESCRIPTION
We are deploying ses5 single-node twice, once with a minimal complement
of roles and a second time with a larger complement:

    --roles "[master,storage,mon,mgr,mds,rgw,nfs]"

In the first half of July 2020 we started seeing a reproducible failure
in Stage 2 on the "larger complement of roles" single node test:

    master: [14/15] Executing state ceph.monitoring.prometheus.exporters.node_exporter...
    master:          |_  master.ses5-1node.test: install node exporter package(golang-github-prometheus-node_exporter) ok
    master:          master.ses5-1node.test...
    master: fail
    master: [15/15] Executing runner advise.osds...
    master:
    master:          |_  osd.report(human=False)...
    master:                in master.ses5-1node.test... ok
    master: [15/15] Executing runner advise.osds... ok
    master: Finished stage ceph.stage.2: succeeded=14/15 failed=1/15
    master:
    master: Failures summary:
    master: ceph.monitoring.prometheus.exporters.node_exporter:
    master:   master.ses5-1node.test:
    master:     start node exporter: Service prometheus-node_exporter has been enabled, and is dead

Since this "larger complement of roles" single-node test is not essential (and
is indeed an unsupported configuration of the product), comment it out to avoid
the failure.

Signed-off-by: Nathan Cutler <ncutler@suse.com>