### PR TITLE
qa: enable dashboard branding test on {octopus,ses7}

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -931,9 +931,21 @@ function osd_objectstore_test {
 
 function dashboard_branding_not_completely_absent_test {
     echo "WWWW: dashboard_branding_not_completely_absent_test"
-    if [ "$VERSION_ID" = "15.1" ] ; then
+    local the_test_is_on
+    if [ "$VERSION_ID" = "15.1" ] || [ "$VERSION_ID" = "15.2" ] ; then
+        if [[ "$(ceph --version)" =~ "ceph version 16" ]] ; then
+            # ceph version 16 (pacific) is not expected to have downstream
+            # branding
+            true
+        else
+            the_test_is_on="yes"
+        fi
+    fi
+    if [ "$the_test_is_on" ] ; then
         local success
         local dashboard_url
+        _zypper_ref_on_master
+        _zypper_install_on_master curl
         set -x
         dashboard_url="$(ceph mgr services | jq -r .dashboard)"
         if curl --silent --insecure "$dashboard_url" | grep -i suse ; then
@@ -944,7 +956,7 @@ function dashboard_branding_not_completely_absent_test {
             echo "WWWW: dashboard_branding_not_completely_absent_test: OK"
             echo
         else
-            echo "CRITICAL RED DANGER: dashboard branding appears to be completely absent!"
+            echo "ERROR: SUSE dashboard branding appears to be completely absent!"
             echo "WWWW: dashboard_branding_not_completely_absent_test: FAIL"
             echo
             false

--- a/seslib/templates/salt/cluster_json.j2
+++ b/seslib/templates/salt/cluster_json.j2
@@ -66,8 +66,11 @@ for role in $ROLES_OF_THIS_NODE ; do
             echo "running instances of $role systemd unit on node {{ node.name }} (systemctl/expected): ${running_instances}/${expected_instances}"
             if [ "$running_instances" = "$expected_instances" ] ; then
                 true
+            elif [ "$role" = "mgr" ] && [ "$running_instances" = "$((expected_instances + 1))" ] ; then
+                # workaround for https://tracker.ceph.com/issues/45093
+                true
             else
-                echo "TEST FAILURE"
+                echo "TEST FAILURE: number of $role instances different than expected"
                 SUCCESS=""
             fi
         fi


### PR DESCRIPTION
Now that https://build.suse.de/request/show/221714 has been accepted,
it should now be possible to test for presence of dashboard branding
in octopus (filesystems:ceph:octopus) and ses7 (but not "pacific").

Signed-off-by: Nathan Cutler <ncutler@suse.com>