### PR TITLE
ceph_salt_deployment: fix off-by-one error in OSDs wait loop

### DIFF
--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -177,7 +177,7 @@ while true ; do
     ACTUAL_NUMBER_OF_OSDS="$(number_of_osds_in_ceph_osd_tree)"
     echo "OSDs in cluster (actual/expected): $ACTUAL_NUMBER_OF_OSDS/$EXPECTED_NUMBER_OF_OSDS (try $count of ${max_count_we_can_tolerate})"
     [ "$ACTUAL_NUMBER_OF_OSDS" = "$EXPECTED_NUMBER_OF_OSDS" ] && break
-    if [ "$count" -gt "$max_count_we_can_tolerate" ] ; then
+    if [ "$count" -ge "$max_count_we_can_tolerate" ] ; then
         echo "It seems unlikely that this cluster will ever reach the expected number of OSDs. Bailing out!"
         exit 1
     fi  


### PR DESCRIPTION
    master: OSDs in cluster (actual/expected): 0/4 (try 49 of 50)
    master: OSDs in cluster (actual/expected): 0/4 (try 50 of 50)
    master: OSDs in cluster (actual/expected): 0/4 (try 51 of 50)

Oops!

Signed-off-by: Nathan Cutler <ncutler@suse.com>