### PR TITLE
Add "detail" subcommand

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -702,7 +702,7 @@ def _create_command(deployment_id, deploy, settings_dict):
     click.echo("=== Creating deployment \"{}\" with the following configuration ==="
                .format(deployment_id)
                )
-    click.echo(dep.status())
+    click.echo(dep.configuration_report())
     if deploy:
         really_want_to = True
         if interactive:
@@ -1058,6 +1058,18 @@ def add_repo(update, deployment_id, custom_repo):
     dep = Deployment.load(deployment_id)
     dep.add_repo_subcommand(custom_repo, update, _print_log)
 
+
+@cli.command()
+@click.argument('deployment_id')
+def detail(deployment_id):
+    """
+    Display detailed configuration of a running deployment - this is the same
+    information that is displayed by the "create" command before asking the user
+    whether they are really sure they want to create the cluster).
+    """
+    dep = Deployment.load(deployment_id)
+    click.echo(dep.configuration_report())
+    
 
 @cli.command()
 @click.argument('deployment_id')

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -673,10 +673,11 @@ class Deployment():
                     elif line_arr[1].strip().startswith("paused"):
                         self.nodes[line_arr[0]].status = "suspended"
 
-    def status(self):
+    def configuration_report(self):
         result = "\n"
-        result += "Global deployment parameters (applicable to all VMs):\n"
+        result += "Deployment-wide parameters (applicable to all VMs in deployment):\n"
         result += "\n"
+        result += "- deployment ID:    {}\n".format(self.dep_id)
         result += "- version:          {}\n".format(self.settings.version)
         result += "- OS:               {}\n".format(self.settings.os)
         if self.settings.vagrant_box:


### PR DESCRIPTION
This new subcommand provides a way to re-display the detailed
configuration report that is provided by "sesdev create".

Signed-off-by: Nathan Cutler <ncutler@suse.com>