### PR TITLE
Change --repo-priority default from "True" to "False"

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,11 @@ version_default_roles:
 
 ##### octopus from filesystems:ceph:octopus
 
-No config.yaml changes are needed, because this is the default configuration.
+This is the default, so no tweaking of config.yaml is necessary. Just:
+
+```
+sesdev create octopus
+```
 
 ##### octopus from filesystems:ceph:octopus&#8203;:upstream
 
@@ -524,31 +528,26 @@ Add the following to your `config.yaml`:
 version_os_repo_mapping:
     octopus:
         leap-15.2:
-            - 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/openSUSE_Leap_15.2'
+            - 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/openSUSE_Leap_15.2'
+            - '96!https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/openSUSE_Leap_15.2'
 image_paths:
     octopus: 'registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph'
 ```
 
-And use a `sesdev` command line like this:
+(The elevated priority on the `filesystems:ceph:octopus&#8203;:upstream` repo is
+needed to ensure that the ceph package from that project gets installed even if
+RPM evaluates its version number to be lower than that of the ceph packages in 
+the openSUSE Leap 15.2 base and `filesystems:ceph:octopus` repos.)
 
-```
-sesdev create octopus \
-    --ceph-salt-repo https://github.com/ceph/ceph-salt.git \
-    --ceph-salt-branch octopus \
-    --qa-test \
-    --single-node
-```
+The `sesdev create` command line is the same as the one shown in
+[octopus from filesystems:ceph:octopus](#octopus-from-filesystemscephoctopus).
 
 ##### ses7 from Devel:Storage:7.0
 
 This is the default, so no tweaking of config.yaml is necessary. Just:
 
 ```
-sesdev create ses7 \
-    --ceph-salt-repo https://github.com/ceph/ceph-salt.git \
-    --ceph-salt-branch master \
-    --qa-test \
-    --single-node
+sesdev create ses7
 ```
 
 Note that this will work even if there is no ceph package visible at
@@ -575,8 +574,13 @@ image_paths:
     ses7: 'registry.suse.de/devel/storage/7.0/cr/containers/ses/7/ceph/ceph'
 ```
 
-Thanks to the `config.yaml` shown above, the sesdev command line is the same as
-in [ses7 from Devel:Storage:7.0](#ses7-from-develstorage70).
+(The elevated priority on the `Devel:Storage:7.0:CR` repo is needed to ensure
+that the ceph package from that project gets installed even if RPM evaluates its
+version number to be lower than that of the ceph packages in the SES7 Product
+and `Devel:Storage:7.0` repos.)
+
+The `sesdev create` command line is the same as the one shown in
+[ses7 from Devel:Storage:7.0](#ses7-from-develstorage70).
 
 ### List existing deployments
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -116,7 +116,7 @@ def common_create_options(func):
                      help='Deploy a single node cluster. Overrides --roles'),
         click.option('--repo', multiple=True, type=str, default=None,
                      help='Custom zypper repo URL. The repo will be added to each node.'),
-        click.option('--repo-priority/--no-repo-priority', default=True,
+        click.option('--repo-priority/--no-repo-priority', default=False,
                      help="Automatically set priority on custom zypper repos"),
         click.option('--devel/--product', default=True,
                      help="Include devel repo, if applicable"),


### PR DESCRIPTION
This means that, by default, no repos will get elevated zypper priority.
If users providing custom repos on the "sesdev create" command line
want those repos to get elevated priority, they will need to explicitly
provide the "--repo-priority" option.

Rationale:

An important use case for custom repos in sesdev is for troubleshooting
version numbering issues on maintenance updates. If we set zypper
priorities on the custom repos by default, the engineer working on the
version numbering issue might be taken by surprise.

Since zypper itself does not *default* to setting an elevated priority,
it seems odd for sesdev to be doing that.

One problem with this approach is that Ceph packages built directly from
upstream repos might get a version number that is _lower_ than the ceph
RPM version in the main distro repo. In that case, the user would need
to explicitly raise the priority on these repos, using the mechanisms sesdev
provides for doing that.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
