### PR TITLE
deployment: generate static networks on create only

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -112,7 +112,7 @@ class Deployment():
             if not self.settings.image_path:
                 self.settings.image_path = self.settings.image_paths[self.settings.version]
 
-        if not self.settings.libvirt_networks:
+        if not self.settings.libvirt_networks and not existing:
             self._generate_static_networks()
 
         if self.settings.version == 'makecheck':


### PR DESCRIPTION
This fixes a hang that can happen on "sesdev list" and other commands
that list existing deployments.

Signed-off-by: Nathan Cutler <ncutler@suse.com>