### PR TITLE
seslib: revamp custom_repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,17 @@ sesdev create octopus
 
 ##### octopus from filesystems:ceph:octopus&#8203;:upstream
 
-Add the following to your `config.yaml`:
+Run `sesdev create octopus` with the following options:
+
+```
+sesdev create octopus \
+    --repo-priority \
+    --repo https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/openSUSE_Leap_15.2 \
+    --image-path registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph
+```
+
+Alternatively, add the following to your `config.yaml` to always use these
+options when deploying `octopus` clusters:
 
 ```
 version_os_repo_mapping:
@@ -534,13 +544,10 @@ image_paths:
     octopus: 'registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph'
 ```
 
-(The elevated priority on the `filesystems:ceph:octopus&#8203;:upstream` repo is
-needed to ensure that the ceph package from that project gets installed even if
-RPM evaluates its version number to be lower than that of the ceph packages in 
-the openSUSE Leap 15.2 base and `filesystems:ceph:octopus` repos.)
-
-The `sesdev create` command line is the same as the one shown in
-[octopus from filesystems:ceph:octopus](#octopus-from-filesystemscephoctopus).
+Note: The elevated priority on the `filesystems:ceph:octopus:upstream`
+repo is needed to ensure that the ceph package from that project gets installed
+even if RPM evaluates its version number to be lower than that of the ceph
+packages in the openSUSE Leap 15.2 base and `filesystems:ceph:octopus` repos.
 
 ##### ses7 from Devel:Storage:7.0
 
@@ -556,12 +563,19 @@ installation media repo, not the "SLE_15_SP2" repo.
 
 ##### ses7 from Devel:Storage:7.0:CR
 
-Since `Devel:Storage:7.0:CR/ceph` has the same version as
-`filesystems:ceph:master:upstream/ceph`, this is an unadulterated upstream
-build which requires special zypper priority to get it to install correctly in
-SLE-15-SP2.
+The ceph package in `Devel:Storage:7.0:CR` has the same version as
+the one in `filesystems:ceph:master:upstream`, so the procedure for
+using it is similar:
 
-config.yaml:
+```
+sesdev create ses7 \
+    --repo-priority \
+    --repo http://download.suse.de/ibs/Devel:/Storage:/7.0:/CR/SLE_15_SP2/ \
+    --image-path registry.suse.de/devel/storage/7.0/cr/containers/ses/7/ceph/ceph
+```
+
+Alternatively, add the following to your `config.yaml` to always use
+these options when deploying `ses7` clusters:
 
 ```
 version_os_repo_mapping:
@@ -574,13 +588,10 @@ image_paths:
     ses7: 'registry.suse.de/devel/storage/7.0/cr/containers/ses/7/ceph/ceph'
 ```
 
-(The elevated priority on the `Devel:Storage:7.0:CR` repo is needed to ensure
-that the ceph package from that project gets installed even if RPM evaluates its
-version number to be lower than that of the ceph packages in the SES7 Product
-and `Devel:Storage:7.0` repos.)
-
-The `sesdev create` command line is the same as the one shown in
-[ses7 from Devel:Storage:7.0](#ses7-from-develstorage70).
+Note: The elevated priority on the `Devel:Storage:7.0:CR` repo is needed to
+ensure that the ceph package from that project gets installed even if RPM
+evaluates its version number to be lower than that of the ceph packages in the
+SES7 Product and `Devel:Storage:7.0` repos.
 
 ### List existing deployments
 

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -309,6 +309,8 @@ class Constant():
         'makecheck': 'tumbleweed',
     }
 
+    ZYPPER_PRIO_ELEVATED = 50
+
     @classmethod
     def init_path_to_qa(cls, full_path_to_sesdev_executable):
         if full_path_to_sesdev_executable.startswith('/usr'):

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -2,6 +2,13 @@ class SesDevException(Exception):
     pass
 
 
+class AddRepoNoUpdateWithExplicitRepo(SesDevException):
+    def __init__(self):
+        super(AddRepoNoUpdateWithExplicitRepo, self).__init__(
+            "The --update option does not work with an explicit custom repo."
+            )
+
+
 class BadMakeCheckRolesNodes(SesDevException):
     def __init__(self):
         super(BadMakeCheckRolesNodes, self).__init__(
@@ -143,6 +150,14 @@ class OptionValueError(SesDevException):
         super(OptionValueError, self).__init__(
             "Wrong value for option '{}'. {}. Actual value: '{}'"
             .format(option, message, value))
+
+
+class ProductOptionOnlyOnSES(SesDevException):
+    def __init__(self, version):
+        super(ProductOptionOnlyOnSES, self).__init__(
+            "You asked to create a {} cluster with the --product option, "
+            "but this option only works with versions starting with \"ses\""
+            .format(version))
 
 
 class RoleNotKnown(SesDevException):

--- a/seslib/node.py
+++ b/seslib/node.py
@@ -6,17 +6,17 @@ from .log import Log
 class Node():
     _repo_lowest_prio = 94
 
-    def __init__(self,
-                 name,
-                 fqdn,
-                 roles,
-                 networks,
-                 public_address=None,
-                 cluster_address=None,
-                 storage_disks=None,
-                 ram=None,
-                 cpus=None,
-                 repo_priority=None):
+    def __init__(
+            self,
+            name,
+            fqdn,
+            roles,
+            networks,
+            public_address=None,
+            cluster_address=None,
+            storage_disks=None,
+            ram=None,
+            cpus=None):
         self.name = name
         self.fqdn = fqdn
         self.roles = roles
@@ -29,8 +29,7 @@ class Node():
         self.ram = ram
         self.cpus = cpus
         self.status = None
-        self.repos = []
-        self.repo_priority = repo_priority
+        self.custom_repos = []
 
     def has_role(self, role):
         if role not in Constant.KNOWN_ROLES:
@@ -48,13 +47,11 @@ class Node():
             raise RoleNotKnown(role)
         return self.roles == [role]
 
-    def add_repo(self, repo):
-        if self.repo_priority:
-            if repo.priority is None:
-                repo.priority = self._repo_lowest_prio - len(self.repos)
-        else:
-            repo.priority = None
-        self.repos.append(repo)
+    def add_custom_repo(self, zypper_repo):
+        """
+        Takes a ZypperRepo object
+        """
+        self.custom_repos.append(zypper_repo)
 
 
 class NodeManager:

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -35,6 +35,11 @@ SETTINGS = {
         'help': 'Number of virtual CPUs in each node',
         'default': 2,
     },
+    'custom_repos': {
+        'type': list,
+        'help': 'Optional custom zypper repos to apply to all nodes',
+        'default': [],
+    },
     'deepsea_git_repo': {
         'type': str,
         'help': 'If set, it will install DeepSea from this git repo',
@@ -52,7 +57,7 @@ SETTINGS = {
     },
     'devel_repo': {
         'type': bool,
-        'help': 'Include devel repo, if applicable',
+        'help': 'Include "devel" zypper repo, if applicable',
         'default': True,
     },
     'disk_size': {
@@ -200,15 +205,15 @@ SETTINGS = {
         'help': 'RAM size in gigabytes for each node',
         'default': 4,
     },
-    'repos': {
-        'type': list,
-        'help': 'Custom repos dictionary to apply to all nodes',
-        'default': [],
-    },
     'repo_priority': {
         'type': bool,
-        'help': 'Automatically set priority on custom zypper repos',
+        'help': 'One or more zypper repos will have elevated priority',
         'default': True,
+    },
+    'repos': {
+        'type': list,
+        'help': 'DEPRECATED: use custom_repos instead',
+        'default': [],
     },
     'roles': {
         'type': list,

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -78,7 +78,7 @@ ceph-salt config ls
 ceph-salt export --pretty
 ceph-salt status
 
-zypper repos -upEP
+zypper repos --details
 zypper info cephadm | grep -E '(^Repo|^Version)'
 ceph-salt --version
 

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -29,26 +29,23 @@ zypper --non-interactive removerepo repo-debug-update-non-oss || true
 zypper --non-interactive removerepo repo-source-non-oss || true
 {% endif %}
 
+# base repos
 {% for os_repo_name, os_repo_url in os_base_repos %}
 zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}
 
+# devel repos
 {% set devel_repo_script = "/home/vagrant/add-devel-repo.sh" %}
 cat > {{ devel_repo_script }} << 'EOF'
 #!/bin/bash
 [[ "$*" =~ "--update" ]] && UPDATE="yes"
-set -ex
+set -x
+{% set devel_repo_count = version_repos_prio|length %}
 {% for _repo in version_repos_prio %}
-{% if loop.index == 1 %}
-{% set devel_repo_name = "devel-repo" %}
-{% else %}
-{% set devel_repo_name = "devel-repo" ~ loop.index %}
-{% endif %}
+{% set devel_repo_name = "devel-repo-" ~ loop.index %}
 zypper addrepo --refresh
 {%- if _repo.priority %}
  --priority {{ _repo.priority }}
-{%- elif repo_priority %}
- --priority 98
 {%- endif %}
  {{ _repo.url }} {{ devel_repo_name }}
 {% endfor %}
@@ -57,14 +54,18 @@ if [ "$UPDATE" ] ; then
     zypper dist-upgrade \
         --allow-vendor-change \
         --auto-agree-with-licenses \
-        --no-confirm \
-        --from=devel-repo
+{% for r in range(1, devel_repo_count + 1) %}
+{% set devel_repo_name = "devel-repo-" ~ r %}
+        --from={{ devel_repo_name }} \
+{% endfor %}
+        --no-confirm
 fi
 EOF
 chmod 755 {{ devel_repo_script }}
+cat {{ devel_repo_script }}
 
 {% if devel_repo or not core_version %}
-if {{ devel_repo_script }} ; then
+if bash -e "{{ devel_repo_script }}" ; then
     true
 else
     echo "{{ devel_repo_script }} failed! Bailing out."
@@ -72,6 +73,16 @@ else
 fi
 {% endif %}
 
+# custom repos
+{% for _repo in node.custom_repos %}
+zypper addrepo --no-gpgcheck --refresh
+{%- if _repo.priority %}
+ --priority={{ _repo.priority }}
+{%- endif %}
+ {{ _repo.url }} {{ _repo.name }}
+{% endfor %}
+
+# SUSE:CA repo on SLE
 {% if os.startswith("sle") %}
 zypper addrepo --refresh
 {%- if os == 'sles-15-sp2' %}
@@ -82,13 +93,6 @@ zypper addrepo --refresh
  http://download.suse.de/ibs/SUSE:/CA/SLE_12_SP3/SUSE:CA.repo
 {% endif %}
 {% endif %}
-
-{% for repo in node.repos %}
-zypper addrepo --refresh {{ repo.url }} {{ repo.name }}
-{% if repo_priority and repo.priority %}
-zypper modifyrepo --priority {{ repo.priority }} {{ repo.name }}
-{% endif %}
-{% endfor %}
 
 zypper --gpg-auto-import-keys refresh
 zypper repos --details

--- a/seslib/tools.py
+++ b/seslib/tools.py
@@ -1,6 +1,8 @@
 import fcntl
 import logging
 import os
+import random
+import string
 import subprocess
 import sys
 import time
@@ -57,3 +59,9 @@ def run_interactive(command, cwd=None):
     if ret != 0:
         logger.warning("SSH interactive session finished with ret=%s", ret)
     return ret
+
+
+def gen_random_string(length):
+    letters = string.ascii_letters
+    result_str = ''.join(random.choice(letters) for i in range(length))
+    return result_str.lower()

--- a/seslib/zypper.py
+++ b/seslib/zypper.py
@@ -1,0 +1,5 @@
+class ZypperRepo():
+    def __init__(self, **kwargs):
+        self.name = kwargs.get('name', '')
+        self.url = kwargs.get('url', '')
+        self.priority = kwargs.get('priority', None)


### PR DESCRIPTION
The way we were handling the "custom repo" (repo specified by the
user on the command line) was suboptimal.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

- [x] passes manual testing: `sesdev create --repo REPO_URL`
- [x] passes manual testing: `sesdev create --repo REPO_URL --repo-priority`
- [x] passes manual testing: multiple custom repos `sesdev create --repo REPO_URL --repo SECOND_REPO_URL`
- [x] passes manual testing: multiple custom repos `sesdev create --repo REPO_URL --repo SECOND_REPO_URL --repo-priority`
- [x] ~passes manual testing: `sesdev create --product --repo REPO_URL`~ (SKIPPED)
- [x] passes manual testing: `sesdev create --product --repo REPO_URL --repo-priority`
- [x] passes manual testing: multiple custom repos `sesdev create --product --repo REPO_URL --repo SECOND_REPO_URL`
- [x] ~passes manual testing: multiple custom repos `sesdev create --product --repo REPO_URL --repo SECOND_REPO_URL --repo-priority`~ (SKIPPED)
- [x] passes manual testing: multiple devel repos (set `filesystems:ceph:octopus:upstream` in config.yaml and deploy, then check `/home/vagrant/add-devel-repo.sh`)
- [x] passes manual testing: bare `sesdev add-repo` after `sesdev create --product`
- [x] passes manual testing: bare `sesdev add-repo` after `sesdev create --devel` (ERROR)
- [ ] passes manual testing: bare `sesdev add-repo --repo-priority` after `sesdev create --product`
- [ ] passes manual testing: bare `sesdev add-repo --repo-priority` after `sesdev create --devel` (ERROR)
- [ ] passes manual testing: bare `sesdev add-repo --update` after `sesdev create --product`
- [x] passes manual testing: bare `sesdev add-repo --update` after `sesdev create --devel` (ERROR)
- [ ] passes manual testing: bare `sesdev add-repo --repo-priority --update` after `sesdev create --product`
- [ ] passes manual testing: bare `sesdev add-repo --repo-priority --update` after `sesdev create --devel` (ERROR)
- [x] passes manual testing: `sesdev add-repo REPO_URL` after `sesdev create --product`
- [x] passes manual testing: `sesdev add-repo REPO_URL` after `sesdev create --devel`
- [x] passes manual testing: `sesdev add-repo --repo-priority REPO_URL` after `sesdev create --product`
- [x] passes manual testing: `sesdev add-repo --repo-priority REPO_URL` after `sesdev create --devel`
- [x] passes manual testing: `sesdev add-repo --update REPO_URL` after `sesdev create --product` (ERROR)
- [x] passes manual testing: `sesdev add-repo --update REPO_URL` after `sesdev create --devel` (ERROR)
- [x] passes manual testing: `sesdev add-repo --repo-priority --update REPO_URL` after `sesdev create --product` (ERROR)
- [x] passes manual testing: `sesdev add-repo --repo-priority --update REPO_URL` after `sesdev create --devel` (ERROR)
- [x] passes `contrib/standalone.sh --full`
- [x] passes `contrib/standalone.sh --full` again