### PR TITLE
ses5: stop patching srv/salt/ceph/time/ntp/default.sls

### DIFF
--- a/seslib/templates/salt/deepsea/ses5_pre_stage_0.sh.j2
+++ b/seslib/templates/salt/deepsea/ses5_pre_stage_0.sh.j2
@@ -42,27 +42,8 @@ cat > /root/mds-get-name.patch <<EOF
      return host
 EOF
 
-{% raw %}
-cat > /root/ntp.patch <<EOF
---- srv/salt/ceph/time/ntp/default.sls
-+++ srv/salt/ceph/time/ntp/default.sls
-@@ -26,8 +26,7 @@ sync time:
-     - fire_event: True
-
- start ntp:
--  service.running:
--    - name: ntpd
--    - enable: True
-+  cmd.run:
-+    - name: "systemctl enable ntpd.service && systemctl start ntpd.service"
- {% endif %}
-
-EOF
-{% endraw %}
-
 pushd /
 patch -p0 < /root/mds-get-name.patch
-patch -p0 < /root/ntp.patch
 popd
 
 {% if total_osds < 6 %}


### PR DESCRIPTION
This partially reverts f1fb650b2309e9f91098da02bff795238e6d95a2
which was monkey-patching srv/salt/ceph/time/ntp/default.sls to work
around a bug in the Salt that affects SES5. (That bug was preventing
sesdev from syncing the clocks.) In the meantime the following
commit:

https://github.com/SUSE/DeepSea/pull/1823/commits/d22232629d7d55387b7d6eaee7a510eced848d34

was merged into the SES5 DeepSea branch and started shipping to
customers, so the monkey-patch no longer applies cleanly (and is
no longer needed).

Signed-off-by: Nathan Cutler <ncutler@suse.com>