### PR TITLE
Change "version_os_repo_mapping" to "version_devel_repos"

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ completely wrong for your use case, you can override them via
 `~/.sesdev/config.yaml`.
 
 To do this, you have to be familiar with two of sesdev's internal dictionaries:
-`OS_REPOS` and `VERSION_OS_REPO_MAPPING`. The former specifies repos that are
+`OS_REPOS` and `VERSION_DEVEL_REPOS`. The former specifies repos that are
 added to all VMs with a given operating system, regardless of the Ceph version
 being deployed, and the latter specifies additional repos that are added to VMs
 depending on the Ceph version being deployed. Refer to `seslib/__init__.py` for
@@ -451,7 +451,7 @@ the current defaults.
 
 To override `OS_REPOS`, add an `os_repos:` stanza to your `~/.sesdev/config.yaml`.
 
-To override `VERSION_OS_REPO_MAPPING`, add a `version_os_repo_mapping:` stanza to your `~/.sesdev/config.yaml`.
+To override `VERSION_DEVEL_REPOS`, add a `version_devel_repos:` stanza to your `~/.sesdev/config.yaml`.
 
 Please note that you need not copy-paste any parts of these internal
 dictionaries from the source code into your config. You can selectively override
@@ -460,18 +460,18 @@ override the default additional repos for "octopus" deployments on "leap-15.2",
 but it will not change the defaults for any of the other deployment versions:
 
 ```
-version_os_repo_mapping:
+version_devel_repos:
     octopus:
         leap-15.2:
             - 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/openSUSE_Leap_15.2'
 ```
 
 If you need a higher priority on one or more of the repos,
-`version_os_repo_mapping` supports a "magic priority prefix" on the repo URL,
+`version_devel_repos` supports a "magic priority prefix" on the repo URL,
 like so:
 
 ```
-version_os_repo_mapping:
+version_devel_repos:
     octopus:
         leap-15.2:
             - '96!https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/openSUSE_Leap_15.2'
@@ -536,7 +536,7 @@ Alternatively, add the following to your `config.yaml` to always use these
 options when deploying `octopus` clusters:
 
 ```
-version_os_repo_mapping:
+version_devel_repos:
     octopus:
         leap-15.2:
             - 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/openSUSE_Leap_15.2'
@@ -579,7 +579,7 @@ Alternatively, add the following to your `config.yaml` to always use
 these options when deploying `ses7` clusters:
 
 ```
-version_os_repo_mapping:
+version_devel_repos:
     ses7:
         sles-15-sp2:
             - 'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/SES7/images/repo/SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/'

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -198,6 +198,12 @@ if [ "$(sesdev list --format json | jq -r '. | length')" != "0" ] ; then
     exit 1
 fi
 
+if [ -e "$HOME/.sesdev/config.yaml" ] ; then
+    echo "ERROR: detected $HOME/.sesdev/config.yaml"
+    echo "(The existence of this file can skew the test results!)"
+    exit 1
+fi
+
 set -x
 
 if [ "$SES5" ] ; then

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -204,7 +204,7 @@ class Constant():
         'ses7': DEFAULT_ROLES["octopus"],
     }
 
-    VERSION_OS_REPO_MAPPING = {
+    VERSION_DEVEL_REPOS = {
         'ses5': {
             'sles-12-sp3': [
                 'http://download.suse.de/ibs/Devel:/Storage:/5.0/images/repo/'

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -355,7 +355,7 @@ class Deployment():
         try:
             version = self.settings.version
             os_setting = self.settings.os
-            version_repos = self.settings.version_os_repo_mapping[version][os_setting]
+            version_repos = self.settings.version_devel_repos[version][os_setting]
         except KeyError:
             raise VersionOSNotSupported(self.settings.version, self.settings.os)
 

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -280,10 +280,15 @@ SETTINGS = {
         'help': 'Default roles for each node - one set of default roles per deployment version',
         'default': Constant.VERSION_DEFAULT_ROLES,
     },
+    'version_devel_repos': {
+        'type': dict,
+        'help': 'the "devel repo", whatever that means on a particular VERSION:OS combination',
+        'default': Constant.VERSION_DEVEL_REPOS,
+    },
     'version_os_repo_mapping': {
         'type': dict,
-        'help': 'additional repos to be added on particular VERSION:OS combinations',
-        'default': Constant.VERSION_OS_REPO_MAPPING,
+        'help': 'DEPRECATED: additional repos to be added on particular VERSION:OS combinations',
+        'default': Constant.VERSION_DEVEL_REPOS,
     },
     'vm_engine': {
         'type': str,


### PR DESCRIPTION
I never liked "version_os_repo_mapping". In our SES team parlance,
these repos are collectively referred to as "devel repos", so
the name will be more descriptive, and less confusing, if we include
the term "devel repos" in it.

Of course, it's a bit of a long-shot to say that the team is used to
referring to, e.g., "filesystems:ceph:nautilus" as the "SES6 devel repo
for OBS", but that's effectively what it is. (The OBS equivalent
of the SES6 product repo is the Leap 15.1 base repo.)

Signed-off-by: Nathan Cutler <ncutler@suse.com>