### PR TITLE
ceph_salt_deployment: "ceph -s" when OSDs fail to come up

### DIFF
--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -178,6 +178,7 @@ while true ; do
     echo "OSDs in cluster (actual/expected): $ACTUAL_NUMBER_OF_OSDS/$EXPECTED_NUMBER_OF_OSDS (try $count of ${max_count_we_can_tolerate})"
     [ "$ACTUAL_NUMBER_OF_OSDS" = "$EXPECTED_NUMBER_OF_OSDS" ] && break
     if [ "$count" -ge "$max_count_we_can_tolerate" ] ; then
+        ceph status
         echo "It seems unlikely that this cluster will ever reach the expected number of OSDs. Bailing out!"
         exit 1
     fi  


### PR DESCRIPTION
We might see clusters fail to deploy because OSDs fail to
come up:

    ...
    master: OSDs in cluster (actual/expected): 0/4 (try 47 of 50)
    master: OSDs in cluster (actual/expected): 0/4 (try 48 of 50)
    master: OSDs in cluster (actual/expected): 0/4 (try 49 of 50)
    master: OSDs in cluster (actual/expected): 0/4 (try 50 of 50)
    master: It seems unlikely that this cluster will ever reach the expected number of OSDs. Bailing out!

In that case, issue a "ceph status" command so the log shows the high-level
state of the cluster when this happens.

Signed-off-by: Nathan Cutler <ncutler@suse.com>