### PR TITLE
provision.sh: persist the journal

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -23,6 +23,10 @@ cat /root/.ssh/{{ ssh_key_name }}.pub >> /root/.ssh/authorized_keys
 # set hostname
 hostnamectl set-hostname {{ node.name }}
 
+# persist the journal
+sed -i -e 's/#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf
+systemctl restart systemd-journald
+
 # zypper-related setup (tweak settings, repos, system packages)
 {% include "zypper.j2" %}
 


### PR DESCRIPTION
This ensures that journal (log) messages are not lost unnecessarily.

For a rationale, see https://github.com/ceph/ceph-salt/issues/304

Signed-off-by: Nathan Cutler <ncutler@suse.com>