### PR TITLE
Unify role-related constants

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -466,11 +466,11 @@ def _gen_settings_dict(
     elif single_node:
         roles_string = ""
         if version in ['ses7', 'octopus', 'pacific']:
-            roles_string = Constant.ROLES_SINGLE_NODE_OCTOPUS
+            roles_string = Constant.ROLES_SINGLE_NODE['octopus']
         elif version in ['ses6', 'nautilus']:
-            roles_string = Constant.ROLES_SINGLE_NODE_NAUTILUS
+            roles_string = Constant.ROLES_SINGLE_NODE['nautilus']
         elif version in ['ses5']:
-            roles_string = Constant.ROLES_SINGLE_NODE_LUMINOUS
+            roles_string = Constant.ROLES_SINGLE_NODE['luminous']
         else:
             raise VersionNotKnown(version)
         settings_dict['roles'] = _parse_roles(roles_string)

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -18,23 +18,6 @@ class Constant():
 
     DEBUG = False
 
-    DEFAULT_ROLES = {
-        "caasp4": [["master"], ["worker"], ["worker"], ["loadbalancer"]],
-        "luminous": [["master", "client", "openattic"],
-                     ["storage", "mon", "mgr", "rgw", "igw"],
-                     ["storage", "mon", "mgr", "mds", "nfs"],
-                     ["storage", "mon", "mgr", "mds", "rgw", "nfs"]],
-        "makecheck": [["makecheck"]],
-        "nautilus": [["master", "client", "prometheus", "grafana"],
-                     ["storage", "mon", "mgr", "rgw", "igw"],
-                     ["storage", "mon", "mgr", "mds", "igw", "nfs"],
-                     ["storage", "mon", "mgr", "mds", "rgw", "nfs"]],
-        "octopus": [["master", "client", "prometheus", "grafana"],
-                    ["bootstrap", "storage", "mon", "mgr", "rgw", "igw"],
-                    ["storage", "mon", "mgr", "mds", "igw", "nfs"],
-                    ["storage", "mon", "mgr", "mds", "rgw", "nfs"]]
-    }
-
     IMAGE_PATHS = {
         'ses7': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
         'octopus': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph',
@@ -42,28 +25,6 @@ class Constant():
     }
 
     JINJA_ENV = Environment(loader=PackageLoader('seslib', 'templates'), trim_blocks=True)
-
-    KNOWN_ROLES = [
-        "admin",
-        "bootstrap",
-        "client",
-        "ganesha",       # deprecated (replaced by "nfs")
-        "grafana",
-        "igw",
-        "loadbalancer",
-        "makecheck",
-        "master",
-        "mds",
-        "mgr",
-        "mon",
-        "nfs",
-        "openattic",
-        "prometheus",
-        "rgw",
-        "storage",
-        "suma",
-        "worker",
-    ]
 
     LOGFILE = None
 
@@ -177,36 +138,71 @@ class Constant():
         },
     }
 
-    ROLES_SINGLE_NODE_LUMINOUS = (
-        "[ master, storage, mon, mgr, mds, igw, rgw, nfs, openattic ]"
-    )
+    ROLES_DEFAULT = {
+        "caasp4": [["master"], ["worker"], ["worker"], ["loadbalancer"]],
+        "luminous": [["master", "client", "openattic"],
+                     ["storage", "mon", "mgr", "rgw", "igw"],
+                     ["storage", "mon", "mgr", "mds", "nfs"],
+                     ["storage", "mon", "mgr", "mds", "rgw", "nfs"]],
+        "makecheck": [["makecheck"]],
+        "nautilus": [["master", "client", "prometheus", "grafana"],
+                     ["storage", "mon", "mgr", "rgw", "igw"],
+                     ["storage", "mon", "mgr", "mds", "igw", "nfs"],
+                     ["storage", "mon", "mgr", "mds", "rgw", "nfs"]],
+        "octopus": [["master", "client", "prometheus", "grafana", "alertmanager", "node-exporter"],
+                    ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
+                    ["storage", "mon", "mgr", "mds", "igw", "nfs", "node-exporter"],
+                    ["storage", "mon", "mgr", "mds", "rgw", "nfs", "node-exporter"]]
+    }
 
-    ROLES_SINGLE_NODE_NAUTILUS = (
-        "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
-        "nfs ]"
-    )
+    ROLES_DEFAULT_BY_VERSION = {
+        'caasp4': ROLES_DEFAULT["caasp4"],
+        'makecheck': ROLES_DEFAULT["makecheck"],
+        'nautilus': ROLES_DEFAULT["nautilus"],
+        'octopus': ROLES_DEFAULT["octopus"],
+        'pacific': ROLES_DEFAULT["octopus"],
+        'ses5': ROLES_DEFAULT["luminous"],
+        'ses6': ROLES_DEFAULT["nautilus"],
+        'ses7': ROLES_DEFAULT["octopus"],
+    }
 
-    ROLES_SINGLE_NODE_OCTOPUS = (
-        "[ master, bootstrap, storage, mon, mgr, prometheus, grafana, mds, "
-        "igw, rgw, nfs ]"
-    )
+    ROLES_KNOWN = [
+        "admin",
+        "alertmanager",
+        "bootstrap",
+        "client",
+        "ganesha",       # deprecated (replaced by "nfs")
+        "grafana",
+        "igw",
+        "loadbalancer",
+        "makecheck",
+        "master",
+        "mds",
+        "mgr",
+        "mon",
+        "nfs",
+        "node-exporter",
+        "openattic",
+        "prometheus",
+        "rgw",
+        "storage",
+        "suma",
+        "worker",
+    ]
+
+    ROLES_SINGLE_NODE = {
+        "luminous": "[ master, storage, mon, mgr, mds, igw, rgw, nfs, openattic ]",
+        "nautilus": "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
+                    "nfs ]",
+        "octopus": "[ master, bootstrap, storage, mon, mgr, mds, igw, rgw, nfs, "
+                   "prometheus, grafana, alertmanager, node-exporter ]",
+    }
 
     SSH_KEY_NAME = 'sesdev'  # do NOT use 'id_rsa'
 
     VAGRANT_DEBUG = None
 
     VERBOSE = None
-
-    VERSION_DEFAULT_ROLES = {
-        'caasp4': DEFAULT_ROLES["caasp4"],
-        'makecheck': DEFAULT_ROLES["makecheck"],
-        'nautilus': DEFAULT_ROLES["nautilus"],
-        'octopus': DEFAULT_ROLES["octopus"],
-        'pacific': DEFAULT_ROLES["octopus"],
-        'ses5': DEFAULT_ROLES["luminous"],
-        'ses6': DEFAULT_ROLES["nautilus"],
-        'ses7': DEFAULT_ROLES["octopus"],
-    }
 
     VERSION_DEVEL_REPOS = {
         'ses5': {

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -82,7 +82,7 @@ class Deployment():
         self.node_counts = {}
         self.nodes_with_role = {}
         self.roles_of_nodes = {}
-        for role in Constant.KNOWN_ROLES:
+        for role in Constant.ROLES_KNOWN:
             self.node_counts[role] = 0
             self.nodes_with_role[role] = []
         Log.debug("Deployment ctor: node_counts: {}".format(self.node_counts))
@@ -114,7 +114,7 @@ class Deployment():
 
         if self.settings.version == 'makecheck':
             self.settings.override('single_node', True)
-            self.settings.override('roles', Constant.VERSION_DEFAULT_ROLES['makecheck'])
+            self.settings.override('roles', Constant.ROLES_DEFAULT_BY_VERSION['makecheck'])
             if not self.settings.explicit_num_disks:
                 self.settings.override('num_disks', 0)
                 self.settings.override('explicit_num_disks', True)
@@ -191,9 +191,9 @@ class Deployment():
                   .format(self.settings.roles))
         for node_roles in self.settings.roles:  # loop once for every node in cluster
             for role in node_roles:
-                if role not in Constant.KNOWN_ROLES:
+                if role not in Constant.ROLES_KNOWN:
                     raise RoleNotKnown(role)
-            for role_type in Constant.KNOWN_ROLES:
+            for role_type in Constant.ROLES_KNOWN:
                 if role_type in node_roles:
                     self.node_counts[role_type] += 1
 
@@ -844,7 +844,7 @@ deployment might not be completely destroyed.
                 raise RoleNotSupported('loadbalancer', self.settings.version)
         # no node may have more than one of any role
         for node in self.settings.roles:
-            for role in Constant.KNOWN_ROLES:
+            for role in Constant.ROLES_KNOWN:
                 if node.count(role) > 1:
                     raise DuplicateRolesNotSupported(role)
 

--- a/seslib/node.py
+++ b/seslib/node.py
@@ -32,7 +32,7 @@ class Node():
         self.custom_repos = []
 
     def has_role(self, role):
-        if role not in Constant.KNOWN_ROLES:
+        if role not in Constant.ROLES_KNOWN:
             raise RoleNotKnown(role)
         return role in self.roles
 
@@ -43,7 +43,7 @@ class Node():
     def has_exclusive_role(self, role):
         Log.debug("Node {}: has_exclusive_role: self.roles: {}"
                   .format(self.fqdn, self.roles))
-        if role not in Constant.KNOWN_ROLES:
+        if role not in Constant.ROLES_KNOWN:
             raise RoleNotKnown(role)
         return self.roles == [role]
 

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -278,7 +278,7 @@ SETTINGS = {
     'version_default_roles': {
         'type': dict,
         'help': 'Default roles for each node - one set of default roles per deployment version',
-        'default': Constant.VERSION_DEFAULT_ROLES,
+        'default': Constant.ROLES_DEFAULT_BY_VERSION,
     },
     'version_devel_repos': {
         'type': dict,
@@ -368,7 +368,7 @@ class Settings():
         __fill_in_config_tree('os_repos', Constant.OS_REPOS)
         __fill_in_config_tree('version_os_repo_mapping', Constant.VERSION_OS_REPO_MAPPING)
         __fill_in_config_tree('image_paths', Constant.IMAGE_PATHS)
-        __fill_in_config_tree('version_default_roles', Constant.VERSION_DEFAULT_ROLES)
+        __fill_in_config_tree('version_default_roles', Constant.ROLES_DEFAULT_BY_VERSION)
         return config_tree
 
 


### PR DESCRIPTION
Over time, a diverse range of role-related constants got added to the
code base. This commit unifies them so they all start with ROLES_

Signed-off-by: Nathan Cutler <ncutler@suse.com>