### PR TITLE
ceph_salt: deploy and smoke-test Prometheus

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -260,8 +260,8 @@ function maybe_wait_for_osd_nodes_test {
         local i
         local success
         echo "Waiting up to $minutes_to_wait minutes for all $expected_osd_nodes OSD node(s) to show up..."
-        for minute in $(seq 1 "$minutes_to_wait") ; do
-            for i in $(seq 1 4) ; do
+        for (( minute=1; minute<=minutes_to_wait; minute++ )) ; do
+            for (( i=1; i<=4; i++ )) ; do
                 set -x
                 actual_osd_nodes="$(json_osd_nodes)"
                 set +x
@@ -269,7 +269,7 @@ function maybe_wait_for_osd_nodes_test {
                     success="not_empty"
                     break 2
                 else
-                    _grace_period 15 "$i"
+                    _grace_period 15 "($i of 4)"
                 fi
             done
             echo "Minutes left to wait: $((minutes_to_wait - minute))"
@@ -303,8 +303,8 @@ function maybe_wait_for_mdss_test {
         local i
         local success
         echo "Waiting up to $minutes_to_wait minutes for all $expected_mdss MDS daemon(s) to show up..."
-        for minute in $(seq 1 "$minutes_to_wait") ; do
-            for i in $(seq 1 4) ; do
+        for (( minute=1; minute<=minutes_to_wait; minute++ )) ; do
+            for (( i=1; i<=4; i++ )) ; do
                 set -x
                 metadata_mdss="$(json_metadata_mdss)"
                 actual_mdss="$(json_total_mdss)"
@@ -346,8 +346,8 @@ function maybe_wait_for_rgws_test {
         local i
         local success
         echo "Waiting up to $minutes_to_wait minutes for all $expected_rgws RGW daemon(s) to show up..."
-        for minute in $(seq 1 "$minutes_to_wait") ; do
-            for i in $(seq 1 4) ; do
+        for (( minute=1; minute<=minutes_to_wait; minute++ )) ; do
+            for (( i=1; i<=4; i++ )) ; do
                 set -x
                 actual_rgws="$(json_total_rgws)"
                 set +x
@@ -390,8 +390,8 @@ function _wait_for {
         local i
         local success
         echo "Waiting up to $minutes_to_wait minutes for all $expected $what daemon(s) to show up..."
-        for minute in $(seq 1 "$minutes_to_wait") ; do
-            for i in $(seq 1 4) ; do
+        for (( minute=1; minute<=minutes_to_wait; minute++ )) ; do
+            for (( i=1; i<=4; i++ )) ; do
                 set -x
                 orch_ls="$(json_ses7_orch_ls "$what")"
                 orch_ps="$(json_ses7_orch_ps "$what")"
@@ -656,8 +656,8 @@ function number_of_services_expected_vs_orch_ps_test {
         local i
         local success
         echo "Waiting up to $minutes_to_wait minutes for \"ceph orch ps\" to list all expected daemons"
-        for minute in $(seq 1 "$minutes_to_wait") ; do
-            for i in $(seq 1 4) ; do
+        for (( minute=1; minute<=minutes_to_wait; minute++ )) ; do
+            for (( i=1; i<=4; i++ )) ; do
                 if _orch_ps_test ; then
                     success="not_empty"
                     break 2
@@ -768,8 +768,8 @@ function ceph_health_test {
     local cluster_status
     local minute
     local i
-    for minute in $(seq 1 "$minutes_to_wait") ; do
-        for i in $(seq 1 4) ; do
+    for (( minute=1; minute<=minutes_to_wait; minute++ )) ; do
+        for (( i=1; i<=4; i++ )) ; do
             set -x
             ceph status
             cluster_status="$(ceph health detail --format json | jq -r .status)"
@@ -806,7 +806,7 @@ function maybe_rgw_smoke_test {
         local IFS
         IFS=","
         read -r -a rgw_nodes_arr <<<"$RGW_NODE_LIST"
-        for (( n=0; n < ${#rgw_nodes_arr[*]}; n++ )) ; do
+        for (( n=0; n<${#rgw_nodes_arr[*]}; n++ )) ; do
             rgw_node_under_test="${rgw_nodes_arr[n]}"
             rgw_node_under_test="${rgw_node_under_test//[$'\t\r\n']}"
             set -x
@@ -839,7 +839,7 @@ function cluster_json_test {
     local IFS
     IFS=","
     read -r -a nodes_arr <<<"$NODE_LIST"
-    for (( n=0; n < ${#nodes_arr[*]}; n++ )) ; do
+    for (( n=0; n<${#nodes_arr[*]}; n++ )) ; do
         node_under_test="${nodes_arr[n]}"
         node_under_test="${node_under_test//[$'\t\r\n']}"
         set -x
@@ -873,7 +873,7 @@ function systemctl_list_units_test {
     local IFS
     IFS=","
     read -r -a nodes_arr <<<"$NODE_LIST"
-    for (( n=0; n < ${#nodes_arr[*]}; n++ )) ; do
+    for (( n=0; n<${#nodes_arr[*]}; n++ )) ; do
         node_under_test="${nodes_arr[n]}"
         node_under_test="${node_under_test//[$'\t\r\n']}"
         set -x
@@ -1109,13 +1109,13 @@ function _prometheus_wait_for {
     echo -en "ss -ntulw | grep '\*\:9095'\n" >> /tmp/wfp.sh
     scp "/tmp/wfp.sh" "$node:/home/vagrant/is_prometheus_listening.sh"
     echo "Waiting up to $minutes_to_wait minutes for Prometheus on $node to start listening on its port"
-    for minute in $(seq 1 "$minutes_to_wait") ; do
-        for i in $(seq 1 60) ; do
-            echo "Pinging prometheus on $node... ($i)"
+    for (( minute=1; minute<=minutes_to_wait; minute++ )) ; do
+        for (( i=1; i<=12; i++ )) ; do
+            echo "Pinging prometheus on $node... ($i of 12)"
             if ssh "$node" "bash" "/home/vagrant/is_prometheus_listening.sh" ; then
                 break 2
             fi
-            sleep 1
+            sleep 5
         done
         echo "Trying for another minute!"
     done
@@ -1139,7 +1139,7 @@ function prometheus_smoke_test {
         local curl_exit_status
         IFS=","
         read -r -a prometheus_nodes_arr <<<"$PROMETHEUS_NODE_LIST"
-        for (( n=0; n < ${#prometheus_nodes_arr[*]}; n++ )) ; do
+        for (( n=0; n<${#prometheus_nodes_arr[*]}; n++ )) ; do
             prometheus_node_under_test="${prometheus_nodes_arr[n]}"
             prometheus_node_under_test="${prometheus_node_under_test//[$'\t\r\n']}"
             _prometheus_wait_for "$prometheus_node_under_test"

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -533,6 +533,8 @@ function number_of_services_expected_vs_orch_ls_test {
         orch_ls_nfss="$(json_ses7_orch_ls nfs)"
         local orch_ls_igws
         orch_ls_igws="$(json_ses7_orch_ls iscsi)"
+        local orch_ls_prometheuses
+        orch_ls_prometheuses="$(json_ses7_orch_ls prometheus)"
         local success
         success="yes"
         local expected_mgrs
@@ -542,6 +544,7 @@ function number_of_services_expected_vs_orch_ls_test {
         local expected_rgws
         local expected_nfss
         local expected_igws
+        local expected_prometheuses
         [ "$MGR_NODES" ] && expected_mgrs="$MGR_NODES"
         [ "$MON_NODES" ] && expected_mons="$MON_NODES"
         [ "$MDS_NODES" ] && expected_mdss="$MDS_NODES"
@@ -549,6 +552,7 @@ function number_of_services_expected_vs_orch_ls_test {
         [ "$RGW_NODES" ] && expected_rgws="$RGW_NODES"
         [ "$NFS_NODES" ] && expected_nfss="$NFS_NODES"
         [ "$IGW_NODES" ] && expected_igws="$IGW_NODES"
+        [ "$PROMETHEUS_NODES" ] && expected_prometheuses="$PROMETHEUS_NODES"
         echo "MGR services (orch ls/expected): $orch_ls_mgrs/$expected_mgrs"
         if [ "$orch_ls_mgrs" = "$expected_mgrs" ] ; then
             true  # normal success case
@@ -569,6 +573,8 @@ function number_of_services_expected_vs_orch_ls_test {
         [ "$orch_ls_nfss" = "$expected_nfss" ] || success=""
         echo "IGW services (orch ls/expected): $orch_ls_igws/$expected_igws"
         [ "$orch_ls_igws" = "$expected_igws" ] || success=""
+        echo "Prometheus services (orch ls/expected): $orch_ls_prometheuses/$expected_prometheuses"
+        [ "$orch_ls_prometheuses" = "$expected_prometheuses" ] || success=""
         if [ "$success" ] ; then
             echo "WWWW: number_of_services_expected_vs_orch_ls_test: OK"
             echo
@@ -599,6 +605,8 @@ function _orch_ps_test {
     orch_ps_nfss="$(json_ses7_orch_ps nfs)"
     local orch_ps_igws
     orch_ps_igws="$(json_ses7_orch_ps iscsi)"
+    local orch_ps_prometheuses
+    orch_ps_prometheuses="$(json_ses7_orch_ps prometheus)"
     ## commented-out osds pending resolution of
     ## - https://bugzilla.suse.com/show_bug.cgi?id=1172791
     ## - https://github.com/SUSE/sesdev/pull/203
@@ -611,6 +619,7 @@ function _orch_ps_test {
     local expected_rgws
     local expected_nfss
     local expected_igws
+    local expected_prometheuses
     [ "$MGR_NODES" ] && expected_mgrs="$MGR_NODES"
     [ "$MON_NODES" ] && expected_mons="$MON_NODES"
     [ "$MDS_NODES" ] && expected_mdss="$MDS_NODES"
@@ -618,6 +627,7 @@ function _orch_ps_test {
     [ "$RGW_NODES" ] && expected_rgws="$RGW_NODES"
     [ "$NFS_NODES" ] && expected_nfss="$NFS_NODES"
     [ "$IGW_NODES" ] && expected_igws="$IGW_NODES"
+    [ "$PROMETHEUS_NODES" ] && expected_prometheuses="$PROMETHEUS_NODES"
     echo "MGR daemons (orch ps/expected): $orch_ps_mgrs/$expected_mgrs"
     if [ "$orch_ps_mgrs" = "$expected_mgrs" ] ; then
         true  # normal success case
@@ -638,6 +648,8 @@ function _orch_ps_test {
     [ "$orch_ps_nfss" = "$expected_nfss" ] || success=""
     echo "IGW daemons (orch ps/expected): $orch_ps_igws/$expected_igws"
     [ "$orch_ps_igws" = "$expected_igws" ] || success=""
+    echo "Prometheus daemons (orch ps/expected): $orch_ps_prometheuses/$expected_prometheuses"
+    [ "$orch_ps_prometheuses" = "$expected_prometheuses" ] || success=""
     if [ "$success" ] ; then
         return 0
     else

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -35,33 +35,35 @@ function usage {
     echo "  $SCRIPTNAME [-h,--help] [options as shown below]"
     echo
     echo "Options:"
-    echo "    --help               Display this usage message"
-    echo "    --igw-nodes          expected number of nodes with iSCSI Gateway"
-    echo "    --mds-nodes          expected number of nodes with MDS"
-    echo "    --mgr-nodes          expected number of nodes with MGR"
-    echo "    --mon-nodes          expected number of nodes with MON"
-    echo "    --nfs-nodes          expected number of nodes with NFS"
-    echo "    --osd-nodes          expected number of nodes with OSD"
-    echo "    --rgw-nodes          expected number of nodes with RGW"
-    echo "    --node-list          comma-separate list of all nodes in cluster"
-    echo "    --igw-node-list      comma-separated list of nodes with iSCSI Gateway"
-    echo "    --mds-node-list      comma-separated list of nodes with MDS"
-    echo "    --mgr-node-list      comma-separated list of nodes with MGR"
-    echo "    --mon-node-list      comma-separated list of nodes with MON"
-    echo "    --nfs-node-list      comma-separated list of nodes with NFS"
-    echo "    --osd-node-list      comma-separated list of nodes with OSD"
-    echo "    --rgw-node-list      comma-separated list of nodes with RGW"
-    echo "    --osds               expected total number of OSDs in cluster"
-    echo "    --filestore-osds     whether there are FileStore OSDs in cluster"
-    echo "    --strict-versions    Insist that daemon versions match \"ceph --version\""
-    echo "    --total-nodes        expected total number of nodes in cluster"
+    echo "    --help                 Display this usage message"
+    echo "    --igw-nodes            expected number of nodes with iSCSI Gateway"
+    echo "    --mds-nodes            expected number of nodes with MDS"
+    echo "    --mgr-nodes            expected number of nodes with MGR"
+    echo "    --mon-nodes            expected number of nodes with MON"
+    echo "    --nfs-nodes            expected number of nodes with NFS"
+    echo "    --osd-nodes            expected number of nodes with OSD"
+    echo "    --prometheus-nodes     expected number of nodes with Prometheus"
+    echo "    --rgw-nodes            expected number of nodes with RGW"
+    echo "    --node-list            comma-separate list of all nodes in cluster"
+    echo "    --igw-node-list        comma-separated list of nodes with iSCSI Gateway"
+    echo "    --mds-node-list        comma-separated list of nodes with MDS"
+    echo "    --mgr-node-list        comma-separated list of nodes with MGR"
+    echo "    --mon-node-list        comma-separated list of nodes with MON"
+    echo "    --nfs-node-list        comma-separated list of nodes with NFS"
+    echo "    --osd-node-list        comma-separated list of nodes with OSD"
+    echo "    --prometheus-node-list comma-separated list of nodes with OSD"
+    echo "    --rgw-node-list        comma-separated list of nodes with RGW"
+    echo "    --osds                 expected total number of OSDs in cluster"
+    echo "    --filestore-osds       whether there are FileStore OSDs in cluster"
+    echo "    --strict-versions      Insist that daemon versions match \"ceph --version\""
+    echo "    --total-nodes          expected total number of nodes in cluster"
     exit 1
 }
 
 assert_enhanced_getopt
 
 TEMP=$(getopt -o h \
---long "help,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,rgw-nodes:,rgw-node-list:,osds:,filestore-osds,strict-versions,total-nodes:,node-list:" \
+--long "help,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,prometheus-nodes:,prometheus-node-list:,rgw-nodes:,rgw-node-list:,osds:,filestore-osds,strict-versions,total-nodes:,node-list:" \
 -n 'health-ok.sh' -- "$@") || ( echo "Terminating..." >&2 ; exit 1 )
 eval set -- "$TEMP"
 
@@ -80,6 +82,8 @@ NFS_NODES=""
 NFS_NODE_LIST=""
 OSD_NODES=""
 OSD_NODE_LIST=""
+PROMETHEUS_NODES=""
+PROMETHEUS_NODE_LIST=""
 RGW_NODES=""
 RGW_NODE_LIST=""
 OSDS=""
@@ -103,6 +107,8 @@ while true ; do
         --nfs-node-list) shift ; NFS_NODE_LIST="$1" ; shift ;;
         --osd-nodes) shift ; OSD_NODES="$1" ; shift ;;
         --osd-node-list) shift ; OSD_NODE_LIST="$1" ; shift ;;
+        --prometheus-nodes) shift ; PROMETHEUS_NODES="$1" ; shift ;;
+        --prometheus-node-list) shift ; PROMETHEUS_NODE_LIST="$1" ; shift ;;
         --rgw-nodes) shift ; RGW_NODES="$1" ; shift ;;
         --rgw-node-list) shift ; RGW_NODE_LIST="$1" ; shift ;;
         --osds) shift ; OSDS="$1" ; shift ;;
@@ -126,6 +132,7 @@ test "$MGR_NODES"
 test "$MON_NODES"
 test "$NFS_NODES"
 test "$OSD_NODES"
+test "$PROMETHEUS_NODES"
 test "$RGW_NODES"
 test "$IGW_NODE_LIST"
 test "$MDS_NODE_LIST"
@@ -133,6 +140,7 @@ test "$MGR_NODE_LIST"
 test "$MON_NODE_LIST"
 test "$NFS_NODE_LIST"
 test "$OSD_NODE_LIST"
+test "$PROMETHEUS_NODE_LIST"
 test "$RGW_NODE_LIST"
 test "$OSDS"
 test "$FILESTORE_OSDS"
@@ -177,3 +185,5 @@ maybe_rgw_smoke_test
 nfs_maybe_list_objects_in_recovery_pool_test
 nfs_maybe_create_export
 nfs_maybe_mount_export_and_touch_file
+# prometheus smoke test
+prometheus_smoke_test

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -1181,8 +1181,12 @@ deployment might not be completely destroyed.
                 service_url = 'https://{}:{}'.format(local_address, local_port)
             elif service == 'prometheus':
                 node = self._find_service_node(service)
-                remote_port = 9090
-                local_port = 9090
+                if self.settings.version in ['octopus', 'ses6', 'pacific']:
+                    remote_port = 9095
+                    local_port = 9095
+                else:
+                    remote_port = 9090
+                    local_port = 9090
                 service_url = 'http://{}:{}'.format(local_address, local_port)
             elif service == 'alertmanager':
                 node = self._find_service_node(service)

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -464,6 +464,8 @@ class Deployment():
             'qa_test': self.settings.qa_test,
             'node_list': self.node_list,
             'cephadm_bootstrap_node': cephadm_bootstrap_node,
+            'prometheus_nodes': self.node_counts["prometheus"],
+            'prometheus_node_list': ','.join(self.nodes_with_role["prometheus"]),
             'nfs_nodes': self.node_counts["nfs"],
             'nfs_node_list': ','.join(self.nodes_with_role["nfs"]),
             'igw_nodes': self.node_counts["igw"],

--- a/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
@@ -187,7 +187,15 @@ ceph nfs cluster ls
 
 {% endif %} {# mds_nodes > 0 #}
 
-{% if rgw_nodes > 0 or igw_nodes > 0 %}
+{% set deploy_monitoring = False %}
+{% if prometheus_nodes > 0 %}
+{% set deploy_monitoring = True %}
+# manually enabling prometheus module will no longer be required once
+# https://tracker.ceph.com/issues/46606 is fixed
+ceph mgr module enable prometheus
+{% endif %} {# prometheus_nodes > 0 #}
+
+{% if rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring %}
 
 {% set service_spec_gw = "/root/service_spec_gw.yml" %}
 rm -f {{ service_spec_gw }}
@@ -245,9 +253,24 @@ spec:
 EOF
 {% endif %} {# igw_nodes > 0 #}
 
+{% if prometheus_nodes > 0 %}
+cat >> {{ service_spec_gw }} << 'EOF'
+---
+service_type: prometheus
+service_id: prometheus
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('prometheus') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+{% endif %} {# prometheus_nodes > 0 #}
+
 cat {{ service_spec_gw }}
 ceph orch apply -i {{ service_spec_gw }}
 
-{% endif %} {# rgw_nodes > 0 or igw_nodes > 0 #}
+{% endif %} {# rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring #}
 
 {% endif %} {# storage_nodes > 0 #}

--- a/seslib/templates/salt/cluster_json.j2
+++ b/seslib/templates/salt/cluster_json.j2
@@ -27,7 +27,7 @@ SUCCESS="yes"
 for role in $ROLES_OF_THIS_NODE ; do
     REGEX=""
     [ "$role" = "storage" ] && role="osd"
-    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ]; then
+    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ] || [ "$role" = "prometheus" ]; then
         if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] ; then
             if [ "$VERSION_ID" = "15.2" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
@@ -51,6 +51,14 @@ for role in $ROLES_OF_THIS_NODE ; do
                 REGEX="^ceph-$FSID@iscsi.+loaded active running"
             elif [ "$OS" = "leap-15.1" ] || [ "$OS" = "sles-15-sp1" ] ; then
                 REGEX="^rbd-target-api\.service.+loaded active running"
+            else
+                REGEX=""
+            fi
+        elif [ "$role" = "prometheus" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
+                REGEX="^ceph-$FSID@prometheus.+loaded active running"
+            elif [ "$VERSION_ID" = "15.1" ] ; then
+                REGEX="^prometheus\.service.+loaded active running"
             else
                 REGEX=""
             fi

--- a/seslib/templates/salt/cluster_json.j2
+++ b/seslib/templates/salt/cluster_json.j2
@@ -15,10 +15,12 @@ cat > {{ systemctl_test_script }} << 'EOF'
 FSID="$1"
 source /etc/os-release
 echo "Running $0 on $NAME $VERSION ($PRETTY_NAME)"
-if [ "$VERSION_ID" = "15.2" ] && [ -z "$FSID" ] ; then
-    echo "You must provide a Ceph Cluster FSID as an option to this script."
-    echo "Bailing out!"
-    false
+if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
+    if [ -z "$FSID" ] ; then
+        echo "You must provide a Ceph Cluster FSID as an option to this script."
+        echo "Bailing out!"
+        false
+    fi
 fi
 NUM_DISKS="$(cat /home/vagrant/cluster.json | jq -r '.num_disks')"
 ROLES_OF_NODES="$(cat /home/vagrant/cluster.json | jq -r '.roles_of_nodes')"
@@ -29,27 +31,27 @@ for role in $ROLES_OF_THIS_NODE ; do
     [ "$role" = "storage" ] && role="osd"
     if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ] || [ "$role" = "prometheus" ]; then
         if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] ; then
-            if [ "$VERSION_ID" = "15.2" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
             else
                 REGEX="^ceph-$role@.+loaded active running"
             fi
         elif [ "$role" = "rgw" ] ; then
-            if [ "$VERSION_ID" = "15.2" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
             else
                 REGEX="^ceph-radosgw@.+loaded active running"
             fi
         elif [ "$role" = "nfs" ] ; then
-            if [ "$VERSION_ID" = "15.2" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
             else
                 REGEX="^nfs-ganesha\.service.+loaded active running"
             fi
         elif [ "$role" = "igw" ] ; then
-            if [ "$OS" = "leap-15.2" ] || [ "$OS" = "sles-15-sp2" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
                 REGEX="^ceph-$FSID@iscsi.+loaded active running"
-            elif [ "$OS" = "leap-15.1" ] || [ "$OS" = "sles-15-sp1" ] ; then
+            elif [ "$VERSION_ID" = "15.1" ] ; then
                 REGEX="^rbd-target-api\.service.+loaded active running"
             else
                 REGEX=""

--- a/seslib/templates/salt/qa_test.j2
+++ b/seslib/templates/salt/qa_test.j2
@@ -12,6 +12,7 @@ set -x
     ~ " --mgr-nodes=" ~ mgr_nodes
     ~ " --mon-nodes=" ~ mon_nodes
     ~ " --osd-nodes=" ~ storage_nodes
+    ~ " --prometheus-nodes=" ~ prometheus_nodes
     ~ " --rgw-nodes=" ~ rgw_nodes
     ~ " --node-list=" ~ node_list
     ~ " --nfs-node-list=" ~ nfs_node_list
@@ -20,6 +21,7 @@ set -x
     ~ " --mgr-node-list=" ~ mgr_node_list
     ~ " --mon-node-list=" ~ mon_node_list
     ~ " --osd-node-list=" ~ storage_node_list
+    ~ " --prometheus-node-list=" ~ prometheus_node_list
     ~ " --rgw-node-list=" ~ rgw_node_list
     ~ " --osds=" ~ total_osds
 -%}

--- a/seslib/templates/sync_clocks.j2
+++ b/seslib/templates/sync_clocks.j2
@@ -23,7 +23,7 @@ function try_wait {
     local cmd="$1"
     local tries="$2"
     local sleep_secs="$3"
-    for i in $(seq 1 "$tries") ; do
+    for (( i="1"; i<="$tries"; i++ )) ; do
         set -x
         $cmd
         set +x
@@ -88,7 +88,7 @@ function try_wait {
     local cmd="$*"
     local success=""
     set +x
-    for i in $(seq 1 "$tries") ; do
+    for (( i="1"; i<="$tries"; i++ )) ; do
         set -x
         $cmd
         SAVED_STATUS="$?"


### PR DESCRIPTION
With this PR, nodes that have the "prometheus" role will get
a "prometheus" service deployed.

References: https://github.com/SUSE/sesdev/issues/354
Fixes: https://github.com/SUSE/sesdev/issues/417
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

- [x] #416 merged and this PR rebased