### PR TITLE
settings: rename straggler version_os_repo_mappings

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -205,6 +205,7 @@ if [ -e "$HOME/.sesdev/config.yaml" ] ; then
 fi
 
 set -x
+touch $HOME/.sesdev/config.yaml
 
 if [ "$SES5" ] ; then
     sesdev --verbose box remove --non-interactive sles-12-sp3
@@ -333,5 +334,7 @@ if [ "$(sesdev list --format json | jq -r '. | length')" != "0" ] ; then
     echo "(One or more deployments created by this script were not destroyed)"
     exit 1
 fi
+
+rm $HOME/.sesdev/config.yaml
 
 final_report

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -366,7 +366,7 @@ class Settings():
         Log.debug("_load_config_file: config_tree: {}".format(config_tree))
         assert isinstance(config_tree, dict), "yaml.load() of config file misbehaved!"
         __fill_in_config_tree('os_repos', Constant.OS_REPOS)
-        __fill_in_config_tree('version_os_repo_mapping', Constant.VERSION_OS_REPO_MAPPING)
+        __fill_in_config_tree('version_devel_repos', Constant.VERSION_DEVEL_REPOS)
         __fill_in_config_tree('image_paths', Constant.IMAGE_PATHS)
         __fill_in_config_tree('version_default_roles', Constant.ROLES_DEFAULT_BY_VERSION)
         return config_tree


### PR DESCRIPTION
A user reported the following Traceback:

```
Traceback (most recent call last):
  File "/run/media/rimarques/data/projects/sesdev/venv/bin/sesdev", line 11, in <module>
    load_entry_point('sesdev', 'console_scripts', 'sesdev')()
  File "/run/media/rimarques/data/projects/sesdev/sesdev/__init__.py", line 38, in sesdev_main
    cli(prog_name='sesdev')
  File "/run/media/rimarques/data/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/run/media/rimarques/data/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/run/media/rimarques/data/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/run/media/rimarques/data/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/run/media/rimarques/data/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/run/media/rimarques/data/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/run/media/rimarques/data/projects/sesdev/sesdev/__init__.py", line 860, in pacific
    _create_command(deployment_id, deploy, settings_dict)
  File "/run/media/rimarques/data/projects/sesdev/sesdev/__init__.py", line 667, in _create_command
    settings = Settings(**settings_dict)
  File "/run/media/rimarques/data/projects/sesdev/seslib/settings.py", line 305, in __init__
    config = self._load_config_file()
  File "/run/media/rimarques/data/projects/sesdev/seslib/settings.py", line 369, in _load_config_file
    __fill_in_config_tree('version_os_repo_mapping', Constant.VERSION_OS_REPO_MAPPING)
AttributeError: type object 'Constant' has no attribute 'VERSION_OS_REPO_MAPPING'
```

The user had a ~/.sesdev/config.yaml in which all the lines had been commented
out. I had not seen this because my regression test suite refuses to run if a
file called ~/.sesdev/config.yaml exists, so it was not triggering this code
path.

Fixes: c5ce08a520a796afad9332aa2ff2fd5f56ddbe19
Signed-off-by: Nathan Cutler <ncutler@suse.com>