### PR TITLE
setup.cfg: fix "options.package_data" file list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,11 +36,13 @@ packages =
 [options.package_data]
 seslib =
     templates/*.j2
-    templates/deepsea/*.j2
     templates/caasp/*.j2
-    templates/ceph-salt/*.j2
-    templates/suma/*.j2
     templates/engine/libvirt/*.j2
+    templates/makecheck/*.j2
+    templates/salt/*.j2
+    templates/salt/ceph-salt/*.j2
+    templates/salt/deepsea/*.j2
+    templates/salt/suma/*.j2
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The "options.package_data" file list in setup.cfg determines which
template files get included in the sesdev Python package and that,
in turn, determines which files and directories get included in the
RPM package.

Commit 53c782290650ba57eff009c5dcc08d4d540a20a1 refactored the template
files but forgot to update setup.cfg accordingly.

Fixes: 53c782290650ba57eff009c5dcc08d4d540a20a1
Signed-off-by: Nathan Cutler <ncutler@suse.com>