### PR TITLE
replace-mgr-modules: refrain from introducing Python 2

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -1269,7 +1269,7 @@ deployment might not be completely destroyed.
             ssh_cmd = self._ssh_cmd(master_node)
             ssh_cmd.append(
                 "cd ~/ && \
-                zypper -n in python2-pip python3-pip && \
+                zypper -n in python3-pip && \
                 pip install nodeenv && \
                 nodeenv env --node={} --force && \
                 . ~/env/bin/activate && \


### PR DESCRIPTION
We are already ensuring that Python 2 will not be present in the system,
so installing "python2-pip" here will actually pull in the entire Python
2 stack. Also, Python 2 is only available in SLE-15-SP2 via the "Python
Legacy" module which sesdev does not add to the deployment.

Fixes: https://github.com/SUSE/sesdev/issues/430
Signed-off-by: Nathan Cutler <ncutler@suse.com>