### PR TITLE
ceph_salt_deployment: extend OSD deployment timeout

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -400,6 +400,10 @@ class Deployment():
                      )
             ceph_salt_fetch_github_pr_merges = True
 
+        cephadm_bootstrap_node = None
+        if self.nodes_with_role["bootstrap"]:
+            cephadm_bootstrap_node = self.nodes[self.nodes_with_role["bootstrap"][0]]
+
         context = {
             'ssh_key_name': Constant.SSH_KEY_NAME,
             'sesdev_path_to_qa': Constant.PATH_TO_QA,
@@ -434,6 +438,7 @@ class Deployment():
             'core_version': self.settings.version in Constant.CORE_VERSIONS,
             'qa_test': self.settings.qa_test,
             'node_list': self.node_list,
+            'cephadm_bootstrap_node': cephadm_bootstrap_node,
             'nfs_nodes': self.node_counts["nfs"],
             'nfs_node_list': ','.join(self.nodes_with_role["nfs"]),
             'igw_nodes': self.node_counts["igw"],

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -53,10 +53,8 @@ ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/cephadm add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
 {% endif %}
-{% if node.has_role('bootstrap') %}
-ceph-salt config /ceph_cluster/roles/bootstrap set {{ node.fqdn }}
-{% endif %}
 {% endfor %}
+ceph-salt config /ceph_cluster/roles/bootstrap set {{ cephadm_bootstrap_node.fqdn }}
 
 ceph-salt config /system_update/packages disable
 ceph-salt config /system_update/reboot disable
@@ -104,6 +102,38 @@ echo "Stopping the deployment now because --stop-before-ceph-orch-apply option w
 set -x
 exit 0
 {% endif %} {# stop_before_ceph_orch_apply #}
+
+# Wait for the bootstrap MON+MGR to appear
+
+function number_of_foos_in_bootstrap_cephadm_ls {
+    local foo="$1"
+    set -x
+    ssh {{ cephadm_bootstrap_node.fqdn }} cephadm ls | jq "[ .[].name | select(startswith(\"$foo\")) ] | length"
+    set +x
+}
+
+set +x
+timeout_seconds="3600"
+remaining_seconds="$timeout_seconds"
+interval_seconds="30"
+while true ; do
+    ACTUAL_NUMBER_OF_MONS="$(number_of_foos_in_bootstrap_cephadm_ls mon)"
+    ACTUAL_NUMBER_OF_MGRS="$(number_of_foos_in_bootstrap_cephadm_ls mgr)"
+    echo "MONs in cluster (actual/expected): $ACTUAL_NUMBER_OF_MONS/1 (${remaining_seconds} seconds to timeout)"
+    echo "MGRs in cluster (actual/expected): $ACTUAL_NUMBER_OF_MGRS/1 (${remaining_seconds} seconds to timeout)"
+    remaining_seconds="$(( remaining_seconds - interval_seconds ))"
+    [ "$ACTUAL_NUMBER_OF_MONS" = "1" ] && [ "$ACTUAL_NUMBER_OF_MGRS" = "1" ] && break
+    if [ "$remaining_seconds" -le "0" ] ; then
+        set -x
+        ceph status
+        set +x
+        echo "It seems unlikely that the bootstrap MON and MGR will ever appear. Bailing out!"
+        exit 1
+    fi  
+    echo "..."
+    sleep "$interval_seconds"
+done
+set -x
 
 {% set service_spec_core = "/root/service_spec_core.yml" %}
 rm -f {{ service_spec_core }}

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -199,6 +199,10 @@ ceph orch device ls --refresh
 {% endif %} {# storage_nodes > 0 #}
 
 {% if ceph_orch_apply_needed %}
+set +x
+echo "Allowing one-minute grace period to expire before initiating \"ceph orch apply\"."
+sleep 60
+set -x
 cat {{ service_spec_core }}
 ceph orch apply -i {{ service_spec_core }}
 {% endif %} {# ceph_orch_apply_needed #}

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -135,6 +135,8 @@ while true ; do
 done
 set -x
 
+ceph status
+
 {% set service_spec_core = "/root/service_spec_core.yml" %}
 rm -f {{ service_spec_core }}
 touch {{ service_spec_core }}

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -183,9 +183,9 @@ function number_of_osds_in_ceph_osd_tree {
 EXPECTED_NUMBER_OF_OSDS="{{ total_osds }}"
 
 set +x
-timeout_seconds="900"
+timeout_seconds="3600"
 remaining_seconds="$timeout_seconds"
-interval_seconds="10"
+interval_seconds="30"
 while true ; do
     ACTUAL_NUMBER_OF_OSDS="$(number_of_osds_in_ceph_osd_tree)"
     echo "OSDs in cluster (actual/expected): $ACTUAL_NUMBER_OF_OSDS/$EXPECTED_NUMBER_OF_OSDS (${remaining_seconds} seconds to timeout)"


### PR DESCRIPTION
If we hit https://tracker.ceph.com/issues/46990, mgr/cephadm enters
a 600 second timeout before it resets the SSH connection, and in
that case 900 seconds is not enough for cephadm to finish deploying
the OSDs.

Signed-off-by: Nathan Cutler <ncutler@suse.com>