### PR TITLE
caasp: set num_disks in same way as for ceph deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,25 +392,30 @@ $ sesdev create caasp4
 
 By default it just creates and configures CaaSP cluster and workers don't have any disks if there is no `--deploy-ses` option.
 
-To create workers with disks and without loadbalancer role:
+To create workers with disks and without a `loadbalancer` role:
 
 ```
 $ sesdev create caasp4 --roles="[master], [worker], [worker]" --disk-size 6 --num-disks 2
 ```
 
-To deploy Rook on that cluster use `--deploy-ses` option, default disk size would be 8G, num of disks per node 2:
+To deploy Rook on that cluster use `--deploy-ses` option, default disk size
+would be 8G, number of worker nodes 2, number of disks per worker node 3:
 
 ```
 $ sesdev create caasp4 --deploy-ses
 ```
 
-To create single node cluster use `--single-node` option, for example this creates 1 node with 2 disks (8G) and deploy Rook:
+To create a single-node cluster use `--single-node` option, for example this
+creates a CaaSP cluster on 1 node with 4 disks (8G) and also deploys SES/Ceph on
+it, using Rook:
 
 ```
 $ sesdev create caasp4 --single-node --deploy-ses
 ```
 
-resulting single node cluster would have `-mini` postfix to the cluster name, so resulting cluster from example above would be `caasp4-mini`.
+Since passing `--single-node` without an explicit deployment name causes the
+name to be set to `DEPLOYMENT_VERSION-mini`, the resulting cluster from the
+example above would be called `caasp4-mini`.
 
 #### On a remote libvirt server via SSH
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -420,6 +420,7 @@ def _gen_settings_dict(
         cpus=None,
         deepsea_branch=None,
         deepsea_repo=None,
+        deploy_ses=None,
         devel=None,
         disk_size=None,
         dry_run=None,
@@ -473,7 +474,7 @@ def _gen_settings_dict(
         elif version in ['ses5']:
             roles_string = Constant.ROLES_SINGLE_NODE['luminous']
         elif version == 'caasp4':
-            roles_string = "[ master ]"
+            roles_string = Constant.ROLES_SINGLE_NODE['caasp4']
         else:
             raise VersionNotKnown(version)
         settings_dict['roles'] = _parse_roles(roles_string)
@@ -643,6 +644,9 @@ def _gen_settings_dict(
 
     if stop_before_run_make_check is not None:
         settings_dict['makecheck_stop_before_run_make_check'] = stop_before_run_make_check
+
+    if deploy_ses:
+        settings_dict['caasp_deploy_ses'] = True
 
     for folder in synced_folder:
         try:
@@ -869,17 +873,13 @@ def pacific(deployment_id, deploy, **kwargs):
 @libvirt_options
 @click.option("--deploy-ses", is_flag=True, default=False,
               help="Deploy SES using rook in CaasP")
-def caasp4(deployment_id, deploy, deploy_ses, **kwargs):
+def caasp4(deployment_id, deploy, **kwargs):
     """
     Creates a CaaSP cluster using SLES 15 SP1
     """
     _prep_kwargs(kwargs)
-    if kwargs['num_disks'] is None:
-        kwargs['num_disks'] = 2 if deploy_ses else 0
     settings_dict = _gen_settings_dict('caasp4', **kwargs)
     deployment_id = _maybe_gen_dep_id('caasp4', deployment_id, settings_dict)
-    if deploy_ses:
-        settings_dict['caasp_deploy_ses'] = True
     _create_command(deployment_id, deploy, settings_dict)
 
 

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -191,6 +191,7 @@ class Constant():
     ]
 
     ROLES_SINGLE_NODE = {
+        "caasp4":  "[ master ]",
         "luminous": "[ master, storage, mon, mgr, mds, igw, rgw, nfs, openattic ]",
         "nautilus": "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
                     "nfs ]",

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -198,6 +198,8 @@ class Deployment():
                 if role_type in node_roles:
                     self.node_counts[role_type] += 1
 
+        single_node = self.settings.single_node or len(self.settings.roles) == 1
+
         if self.settings.version in Constant.CORE_VERSIONS:
             if self.node_counts['master'] == 0:
                 self.settings.roles[0].append('master')
@@ -211,6 +213,12 @@ class Deployment():
                         break
 
         storage_nodes = self.node_counts["storage"]
+        if self.settings.version in ['caasp4'] and self.settings.caasp_deploy_ses:
+            if single_node:
+                storage_nodes = 1
+            else:
+                storage_nodes = self.node_counts["worker"]
+        Log.debug("_generate_nodes: storage_nodes == {}".format(storage_nodes))
         if not self.settings.explicit_num_disks:
             if storage_nodes:
                 if storage_nodes == 1:
@@ -220,7 +228,6 @@ class Deployment():
                 else:
                     # go with the default
                     pass
-        Log.debug("_generate_nodes: storage_nodes == {}".format(storage_nodes))
 
         for node_roles in self.settings.roles:  # loop once for every node in cluster
             if self.settings.version == 'caasp4':
@@ -306,7 +313,7 @@ class Deployment():
                         node.cpus = 2
                     if self.settings.ram < 2:
                         node.ram = 2 * 2**10
-                if 'worker' in node_roles or self.settings.single_node:
+                if 'worker' in node_roles or single_node:
                     for _ in range(self.settings.num_disks):
                         node.storage_disks.append(Disk(self.settings.disk_size))
             else:
@@ -448,6 +455,7 @@ class Deployment():
             'rgw_node_list': ','.join(self.nodes_with_role["rgw"]),
             'storage_nodes': self.node_counts["storage"],
             'storage_node_list': ','.join(self.nodes_with_role["storage"]),
+            'worker_nodes': self.node_counts["worker"],
             'deepsea_need_stage_4': bool(self.node_counts["nfs"] or self.node_counts["igw"]
                                          or self.node_counts["mds"] or self.node_counts["rgw"]
                                          or self.node_counts["openattic"]),
@@ -475,7 +483,6 @@ class Deployment():
             'makecheck_stop_before_install_deps': self.settings.makecheck_stop_before_install_deps,
             'makecheck_stop_before_run_make_check':
                 self.settings.makecheck_stop_before_run_make_check,
-            'single_node': self.settings.single_node,
         }
 
         scripts = {}

--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -4,21 +4,47 @@ zypper --non-interactive install --type pattern SUSE-CaaSP-Management
 {% if node.name == 'master' %}
 
 function wait_for_master_ready {
-    printf "Waiting for master to be ready"
-    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "master\s+Ready") -eq 1 ]]; do
-         sleep 5
-		 printf "."
+    set +ex
+    echo "Waiting for master to be ready"
+    timeout_seconds="900"
+    remaining_seconds="$timeout_seconds"
+    interval_seconds="10"
+    while true ; do
+        set -x
+        ACTUAL_NUMBER_OF_MASTERS="$(kubectl get nodes 2>/dev/null | egrep -c "master\s+Ready")"
+        set +x
+        echo "masters in cluster (actual/expected): $ACTUAL_NUMBER_OF_MASTERS/1 (${remaining_seconds} seconds to timeout)"
+        remaining_seconds="$(( remaining_seconds - interval_seconds ))"
+        [ "$ACTUAL_NUMBER_OF_MASTERS" = "1" ] && break
+        if [ "$remaining_seconds" -le "0" ] ; then
+            echo "It seems unlikely that a master will ever appear. Bailing out!"
+            exit 1
+        fi  
+        sleep "$interval_seconds"
     done
-	printf "\n"
+    set -ex
 }
 
 function wait_for_workers_ready {
-    printf "Waiting for workers to be ready"
-    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "worker[0-9]\s+Ready") -eq {{node_manager.get_by_role('worker') | length}} ]]; do
-         sleep 5
-         printf "."
+    set +ex
+    echo "Waiting for {{ worker_nodes }} workers to be ready"
+    timeout_seconds="900"
+    remaining_seconds="$timeout_seconds"
+    interval_seconds="10"
+    while true ; do
+        set -x
+        ACTUAL_NUMBER_OF_WORKERS="$(kubectl get nodes 2>/dev/null | egrep -c "worker[0-9]\s+Ready")"
+        set +x
+        echo "workers in cluster (actual/expected): $ACTUAL_NUMBER_OF_WORKERS/{{ worker_nodes }} (${remaining_seconds} seconds to timeout)"
+        remaining_seconds="$(( remaining_seconds - interval_seconds ))"
+        [ "$ACTUAL_NUMBER_OF_WORKERS" = "{{ worker_nodes }}" ] && break
+        if [ "$remaining_seconds" -le "0" ] ; then
+            echo "It seems unlikely that {{ worker_nodes }} workers will ever appear. Bailing out!"
+            exit 1
+        fi  
+        sleep "$interval_seconds"
     done
-    printf "\n"
+    set -ex
 }
 
 zypper --non-interactive install skuba skuba-update
@@ -78,7 +104,7 @@ wait_for_workers_ready
 skuba -v ${SKUBA_VERBOSITY} cluster status
 kubectl get nodes -o wide
 
-{% if single_node %}
+{% if nodes|length == 1 %}
 
 kubectl taint nodes --all node-role.kubernetes.io/master-
 
@@ -165,13 +191,13 @@ rm ${MLBCONFIG}
 zypper --non-interactive install rook-k8s-yaml
 cd /usr/share/k8s-yaml/rook/ceph/
 
-{% if node_manager.get_by_role('worker') | length <3 %}
+{% if node_manager.get_by_role('worker') | length < 3 %}
 
 sed -i 's/allowMultiplePerNode: false/allowMultiplePerNode: true/' /usr/share/k8s-yaml/rook/ceph/cluster.yaml
 
-{% endif %}
+{% endif %} {# node_manager.get_by_role('worker') | length < 3 #}
 
-{% if single_node %}
+{% if nodes|length == 1 %}
 
 sed -i 's/count: .*/count: 1/' /usr/share/k8s-yaml/rook/ceph/cluster.yaml
 
@@ -182,7 +208,7 @@ sleep 15
 kubectl apply -f cluster.yaml -f toolbox.yaml
 echo "Verify the installation by running 'kubectl get pods -n rook-ceph'"
 
-{% endif %}
+{% endif %} {# caasp_deploy_ses #}
 
 {% else %}
 


### PR DESCRIPTION
Before this commit, we were setting num_disks default for

    sesdev create caasp4 --deploy-ses

in a different way than for standard Ceph deployments. As a result, we
were only getting 2 disks even on a single-node caasp4 deployment.

Signed-off-by: Nathan Cutler <ncutler@suse.com>