### PR TITLE
vet_configuration: vet caasp4 roles more carefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,9 @@ To create CaaSP k8s cluster that has loadbalancer, 2 worker nodes and master:
 $ sesdev create caasp4
 ```
 
-By default it just creates and configures CaaSP cluster and workers don't have any disks if there is no `--deploy-ses` option.
+By default it just creates and configures a CaaSP cluster, and workers don't
+have any disks unless the `--deploy-ses` (see below) or `--num-disks` options
+are given.
 
 To create workers with disks and without a `loadbalancer` role:
 
@@ -399,12 +401,18 @@ To create workers with disks and without a `loadbalancer` role:
 $ sesdev create caasp4 --roles="[master], [worker], [worker]" --disk-size 6 --num-disks 2
 ```
 
-To deploy Rook on that cluster use `--deploy-ses` option, default disk size
-would be 8G, number of worker nodes 2, number of disks per worker node 3:
+To have sesdev deploy Rook on the CaaSP cluster, give the `--deploy-ses` option.
+The default disk size is 8G, number of worker nodes 2, number of disks per
+worker node 3:
 
 ```
 $ sesdev create caasp4 --deploy-ses
 ```
+
+Note: sesdev does not support sharing of roles on a single `caasp4` node. Each
+node must have one and only one role. However, it is still possible to deploy
+a single-node cluster. In this case the master node will also function as
+a worker node even though the `worker` role is not explicitly given.
 
 To create a single-node cluster use `--single-node` option, for example this
 creates a CaaSP cluster on 1 node with 4 disks (8G) and also deploys SES/Ceph on

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -314,9 +314,10 @@ class Deployment():
                         node.cpus = 2
                     if self.settings.ram < 2:
                         node.ram = 2 * 2**10
-                if 'worker' in node_roles or single_node:
-                    for _ in range(self.settings.num_disks):
-                        node.storage_disks.append(Disk(self.settings.disk_size))
+                if self.settings.caasp_deploy_ses or self.settings.explicit_num_disks:
+                    if 'worker' in node_roles or single_node:
+                        for _ in range(self.settings.num_disks):
+                            node.storage_disks.append(Disk(self.settings.disk_size))
             else:
                 if 'suma' in node_roles:
                     self.suma = node

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -87,6 +87,15 @@ class ExplicitAdminRoleNotAllowed(SesDevException):
             "(TL;DR remove the \"admin\" role and try again!)")
 
 
+class MultipleRolesPerMachineNotAllowedInCaaSP(SesDevException):
+    def __init__(self):
+        super(MultipleRolesPerMachineNotAllowedInCaaSP, self).__init__(
+            "Multiple roles per machine detected. This is not allowed in CaaSP "
+            "clusters. For a single-node cluster, use the --single-node option "
+            "or --roles=\"[master]\" (in this special case, the master node "
+            "will function also as a worker node)")
+
+
 class NodeDoesNotExist(SesDevException):
     def __init__(self, node):
         super(NodeDoesNotExist, self).__init__(

--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -33,7 +33,7 @@ function wait_for_workers_ready {
     interval_seconds="10"
     while true ; do
         set -x
-        ACTUAL_NUMBER_OF_WORKERS="$(kubectl get nodes 2>/dev/null | egrep -c "worker[0-9]\s+Ready")"
+        ACTUAL_NUMBER_OF_WORKERS="$(kubectl get nodes 2>/dev/null | egrep -c "worker[0-9]+\s+Ready")"
         set +x
         echo "workers in cluster (actual/expected): $ACTUAL_NUMBER_OF_WORKERS/{{ worker_nodes }} (${remaining_seconds} seconds to timeout)"
         remaining_seconds="$(( remaining_seconds - interval_seconds ))"


### PR DESCRIPTION
This PR is a mixed bag of `caasp4` cleanups and fixes:

1. caasp4 clusters must not have more than one role per machine, which might not be clear to all users
2. the regex for counting worker nodes would only work up to 10 worker nodes, but there's no reason why it couldn't handle more
3. finally, I found that we were adding disks even when the user doesn't need them - add a commit to address that
