### PR TITLE
cephadm: allow preparation of cluster for manual deployment

### DIFF
--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -48,7 +48,7 @@ echo "PATH is $PATH"
 type ceph-salt
 
 {% for node in nodes %}
-{% if node.has_roles() and not node.has_exclusive_role('client') %}
+{% if not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/cephadm add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}


### PR DESCRIPTION
Before this commit, the only way to prepare a cluster for manual Day
2 deployment would be to pass the `--stop-before-ceph-orch-apply`
option. But it seems weird to be forced to assign fictional roles just
to get a cluster with X nodes that has just been bootstrapped.

With this commit, machines with no roles at all [1] will still get added
to the cluster. Later, the user can SSH into the cluster and use these
machines in manual Day 2 deployment operations.

[1] For example: `--roles="[master],[mon,mgr,bootstrap],[],[],[]"`

Signed-off-by: Nathan Cutler <ncutler@suse.com>
