### PR TITLE
deepsea: add ganesha roles to policy.cfg

### DIFF
--- a/seslib/templates/salt/deepsea/nautilus_policy.cfg.j2
+++ b/seslib/templates/salt/deepsea/nautilus_policy.cfg.j2
@@ -7,41 +7,34 @@ role-admin/cluster/*.sls
 {% if node.has_role('storage') %}
 role-storage/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('mon') %}
 role-mon/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('master') %}
 role-master/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('mgr') %}
 role-mgr/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('mds') %}
 role-mds/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('rgw') %}
 role-rgw/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('igw') %}
 role-igw/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('nfs') %}
 role-ganesha/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('prometheus') %}
 role-prometheus/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('grafana') %}
 role-grafana/cluster/{{ node.name }}*.sls
 {% endif %}
-
+{% if node.has_role('ganesha') %}
+role-ganesha/cluster/{{ node.name }}*.sls
+{% endif %}
 {% endfor %}

--- a/seslib/templates/salt/deepsea/ses5_policy.cfg.j2
+++ b/seslib/templates/salt/deepsea/ses5_policy.cfg.j2
@@ -7,39 +7,32 @@ profile-default/cluster/*.sls
 profile-default/stack/default/ceph/minions/*yml
 
 {% for node in nodes: %}
-
 {% if node.has_role('mon') %}
 role-mon/cluster/{{ node.name }}*.sls
 role-mon/stack/default/ceph/minions/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('master') %}
 role-master/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('mgr') %}
 role-mgr/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('mds') %}
 role-mds/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('rgw') %}
 role-rgw/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('igw') %}
 role-igw/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('nfs') %}
 role-ganesha/cluster/{{ node.name }}*.sls
 {% endif %}
-
 {% if node.has_role('openattic') %}
 role-openattic/cluster/{{ node.name }}*.sls
 {% endif %}
-
-
+{% if node.has_role('ganesha') %}
+role-ganesha/cluster/{{ node.name }}*.sls
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
One fine day, we noticed that sesdev was not adding ganesha roles to
policy.cfg in {ses5,nautilus,ses6} clusters.

Signed-off-by: Nathan Cutler <ncutler@suse.com>