### PR TITLE
caasp: update to caasp 4.5

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -875,7 +875,7 @@ def pacific(deployment_id, deploy, **kwargs):
               help="Deploy SES using rook in CaasP")
 def caasp4(deployment_id, deploy, **kwargs):
     """
-    Creates a CaaSP cluster using SLES 15 SP1
+    Creates a CaaSP cluster using SLES 15 SP2
     """
     _prep_kwargs(kwargs)
     settings_dict = _gen_settings_dict('caasp4', **kwargs)

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -255,12 +255,20 @@ class Constant():
             ],
         },
         'caasp4': {
-            'sles-15-sp1': [
-                'http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/'
+            'sles-15-sp2': [
+                'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/'
+                'product/',
+                'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/'
+                'update/',
+                'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Public-Cloud/15-SP2/x86_64/'
+                'product/',
+                'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Public-Cloud/15-SP2/x86_64/'
+                'update/',
+                'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Public-Cloud/15-SP1/x86_64/'
+                'update/',
+                'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/CaaSP:/4.5/'
                 'standard/',
-                'http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/',
-                'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/'
-                'product/'
+                'http://download.suse.de/ibs/SUSE/Updates/SUSE-CAASP/4.5/x86_64/update/'
             ],
         },
         'makecheck': {
@@ -306,7 +314,7 @@ class Constant():
         'nautilus': 'leap-15.1',
         'octopus': 'leap-15.2',
         'pacific': 'leap-15.2',
-        'caasp4': 'sles-15-sp1',
+        'caasp4': 'sles-15-sp2',
         'makecheck': 'tumbleweed',
     }
 

--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -47,7 +47,7 @@ function wait_for_workers_ready {
     set -ex
 }
 
-zypper --non-interactive install skuba skuba-update
+zypper --non-interactive install skuba
 
 touch /tmp/ready
 

--- a/seslib/templates/caasp/provision.sh.j2
+++ b/seslib/templates/caasp/provision.sh.j2
@@ -9,9 +9,8 @@ echo "sles ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/sles
 cp -r /root/.ssh/ /home/sles/
 chown -R sles:users /home/sles/.ssh/
 
-zypper --non-interactive install cri-o-kubeadm-criconfig kubernetes-kubeadm kubernetes-kubelet kubernetes-client podman SUSEConnect nfs-client
+zypper --non-interactive install SUSEConnect nfs-client
 
-zypper --non-interactive install --type pattern SUSE-CaaSP-Node
 
 {% if node.has_role('master') %}
 {% include "caasp/master.sh.j2" %}


### PR DESCRIPTION
Update repos and image for CaaSP deployment to SLE15 SP2.
There still a need for Pub Cloud SP1 repo for one dependency (CaaSP
would fix it later).

Signed-off-by: Denis Kondratenko <denis.kondratenko@suse.com>