### PR TITLE
deployment: disks even when explicit storage role not given

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -318,13 +318,17 @@ class Deployment():
                     if 'worker' in node_roles or single_node:
                         for _ in range(self.settings.num_disks):
                             node.storage_disks.append(Disk(self.settings.disk_size))
-            else:
+
+            if self.settings.version in Constant.CORE_VERSIONS:
                 if 'suma' in node_roles:
                     self.suma = node
                 if 'storage' in node_roles:
                     if self.settings.cluster_network:
                         node.cluster_address = '{}{}'.format(self.settings.cluster_network,
                                                              200 + node_id)
+                    for _ in range(self.settings.num_disks):
+                        node.storage_disks.append(Disk(self.settings.disk_size))
+                elif self.settings.explicit_num_disks and not node.has_exclusive_role('master'):
                     for _ in range(self.settings.num_disks):
                         node.storage_disks.append(Disk(self.settings.disk_size))
 


### PR DESCRIPTION
When users specify no "storage" roles, but explicitly give the
--num-disks option, assume they intend to deploy OSDs manually.
In such a case, they will expect to have the attached disks on
all nodes except, perhaps, a standalone master node (if any).

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

To Do:

- [x] #436 merged
- [x] rebase this PR to get rid of the commit from #436 
