### PR TITLE
ceph-salt: enable user to control which nodes get "admin" role

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -282,7 +282,7 @@ fi
 if [ "$SES7" ] ; then
     sesdev --verbose box remove --non-interactive sles-15-sp2
     run_cmd sesdev --verbose create ses7 --dry-run
-    run_cmd sesdev --verbose create ses7 --non-interactive --roles "[master,storage,mon,mgr]" --qa-test ses7-mini
+    run_cmd sesdev --verbose create ses7 --non-interactive --roles "[admin,master,bootstrap,storage,mon,mgr]" --qa-test ses7-mini
     run_cmd sesdev --verbose destroy --non-interactive ses7-mini
     run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --qa-test ses7-1node
     run_cmd sesdev --verbose destroy --non-interactive ses7-1node

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -166,11 +166,11 @@ function make_salt_master_an_admin_node_test {
     echo
     echo "WWWW: make_salt_master_an_admin_node_test"
     _zypper_install_on_master ceph-common
+    set -x
     mkdir -p "/etc/ceph"
     if [ -f "$ADMIN_KEYRING" ] || [ -f "$CEPH_CONF" ] ; then
         true
     else
-        set -x
         arbitrary_mon_node="$(_first_x_node mon)"
         if [ ! -f "$ADMIN_KEYRING" ] ; then
             _copy_file_from_minion_to_master "$arbitrary_mon_node" "$ADMIN_KEYRING"
@@ -179,9 +179,7 @@ function make_salt_master_an_admin_node_test {
         if [ ! -f "$CEPH_CONF" ] ; then
             _copy_file_from_minion_to_master "$arbitrary_mon_node" "$CEPH_CONF"
         fi
-        set +x
     fi
-    set -x
     test -f "$ADMIN_KEYRING"
     test -f "$CEPH_CONF"
     set +x

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -23,6 +23,8 @@ function _first_x_node {
     local role=$1
     if [ "$role" = "igw" ] ; then
         echo "${IGW_NODE_LIST%%,*}"
+    elif [ "$role" = "bootstrap" ] ; then
+        echo "${BOOTSTRAP_NODE}"
     elif [ "$role" = "mds" ] ; then
         echo "${MDS_NODE_LIST%%,*}"
     elif [ "$role" = "mgr" ] ; then

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -32,9 +32,7 @@ function usage {
     echo "for use in SUSE Enterprise Storage testing"
     echo
     echo "Usage:"
-    echo "  $SCRIPTNAME [-h,--help] [--igw=X] [--mds=X] [--mgr=X]"
-    echo "  [--mon=X] [--nfs=X] [--strict-versions] [--rgw=X]"
-    echo "  [--total-nodes=X]"
+    echo "  $SCRIPTNAME [-h,--help] [options as shown below]"
     echo
     echo "Options:"
     echo "    --help               Display this usage message"

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -149,8 +149,9 @@ class Constant():
                      ["storage", "mon", "mgr", "rgw", "igw"],
                      ["storage", "mon", "mgr", "mds", "igw", "nfs"],
                      ["storage", "mon", "mgr", "mds", "rgw", "nfs"]],
-        "octopus": [["master", "client", "prometheus", "grafana", "alertmanager", "node-exporter"],
-                    ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
+        "octopus": [["admin", "master", "client", "prometheus", "grafana", "alertmanager",
+                     "node-exporter"],
+                    ["admin", "bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
                     ["storage", "mon", "mgr", "mds", "igw", "nfs", "node-exporter"],
                     ["storage", "mon", "mgr", "mds", "rgw", "nfs", "node-exporter"]]
     }
@@ -195,8 +196,8 @@ class Constant():
         "luminous": "[ master, storage, mon, mgr, mds, igw, rgw, nfs, openattic ]",
         "nautilus": "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
                     "nfs ]",
-        "octopus": "[ master, bootstrap, storage, mon, mgr, mds, igw, rgw, nfs, "
-                   "prometheus, grafana, alertmanager, node-exporter ]",
+        "octopus": "[ master, admin, bootstrap, storage, mon, mgr, mds, igw, rgw, "
+                   "nfs, prometheus, grafana, alertmanager, node-exporter ]",
     }
 
     SSH_KEY_NAME = 'sesdev'  # do NOT use 'id_rsa'

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -19,9 +19,9 @@ from .exceptions import \
                         DepIDIllegalChars, \
                         DuplicateRolesNotSupported, \
                         ExclusiveRoles, \
-                        ExplicitAdminRoleNotAllowed, \
                         MultipleRolesPerMachineNotAllowedInCaaSP, \
                         NodeDoesNotExist, \
+                        NodeMustBeAdminAsWell, \
                         NoGaneshaRolePostNautilus, \
                         NoPrometheusGrafanaInSES5, \
                         NoSourcePortForPortForwarding, \
@@ -449,7 +449,9 @@ class Deployment():
             'cluster_json': json.dumps({
                 "num_disks": self.settings.num_disks,
                 "roles_of_nodes": self.roles_of_nodes,
-            }, sort_keys=True, indent=4),
+                "cephadm_bootstrap_node": (cephadm_bootstrap_node.name if
+                                           cephadm_bootstrap_node else ''),
+                }, sort_keys=True, indent=4),
             'master': self.master,
             'suma': self.suma,
             'domain': self.settings.domain.format(self.dep_id),
@@ -822,10 +824,6 @@ deployment might not be completely destroyed.
         return result
 
     def vet_configuration(self):
-        # "admin" role exists for backwards compatibility with existing
-        # deployments only, and should not be used for new deployments
-        if self.node_counts['admin'] != 0:
-            raise ExplicitAdminRoleNotAllowed()
         # all deployment versions except "makecheck" require one, and only one, master role
         if self.settings.version == 'makecheck':
             if len(self.nodes) == 1 and self.node_counts['makecheck'] == 1:
@@ -836,9 +834,23 @@ deployment might not be completely destroyed.
             if self.node_counts['master'] != 1:
                 raise UniqueRoleViolation('master', self.node_counts['master'])
         # octopus and beyond require one, and only one, bootstrap role
+        # and bootstrap must have admin role as well (unless this is
+        # merely a partial deployment - then we don't care)
         if self.settings.version in ['ses7', 'octopus', 'pacific']:
-            if self.node_counts['bootstrap'] != 1:
-                raise UniqueRoleViolation('bootstrap', self.node_counts['bootstrap'])
+            if (not self.settings.stop_before_ceph_salt_config and
+                not self.settings.stop_before_ceph_salt_apply
+            ):
+                if self.node_counts['bootstrap'] != 1:
+                    raise UniqueRoleViolation('bootstrap', self.node_counts['bootstrap'])
+                for node_roles in self.settings.roles:
+                    if 'bootstrap' in node_roles and 'admin' not in node_roles:
+                        raise NodeMustBeAdminAsWell('bootstrap')
+                if (not self.settings.stop_before_ceph_salt_apply and
+                    not self.settings.stop_before_ceph_orch_apply
+                ):
+                    for node_roles in self.settings.roles:
+                        if 'master' in node_roles and 'admin' not in node_roles:
+                            raise NodeMustBeAdminAsWell('master')
         # clusters with no OSDs can be deployed only in certain circumstances
         if self.settings.version in ['ses5', 'nautilus', 'ses6']:
             if self.node_counts['storage'] == 0:

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -276,12 +276,7 @@ class Deployment():
                     fqdn = 'node{}.{}'.format(node_id,
                                               self.settings.domain.format(self.dep_id))
             else:
-                admin_node_processed = False
-                if self.existing and 'admin' in node_roles and not admin_node_processed:
-                    admin_node_processed = True  # only do this once, for backwards compatibility
-                    name = 'admin'
-                    fqdn = 'admin.{}'.format(self.settings.domain.format(self.dep_id))
-                elif 'master' in node_roles or 'suma' in node_roles or 'makecheck' in node_roles:
+                if 'master' in node_roles or 'suma' in node_roles or 'makecheck' in node_roles:
                     name = 'master'
                     fqdn = 'master.{}'.format(self.settings.domain.format(self.dep_id))
                 else:

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -111,6 +111,17 @@ class NodeDoesNotExist(SesDevException):
         )
 
 
+class NodeMustBeAdminAsWell(SesDevException):
+    def __init__(self, role):
+        super().__init__(
+            "Detected node with \"{role}\" role but no \"admin\" role. "
+            "The {role} node must have the \"admin\" role -- otherwise "
+            "\"ceph-salt apply\" will fail. Please make sure the node with "
+            "the \"{role}\" role has the \"admin\" role as well"
+            .format(role=role)
+            )
+
+
 class NoGaneshaRolePostNautilus(SesDevException):
     def __init__(self):
         super().__init__(

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -51,6 +51,8 @@ type ceph-salt
 {% if not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/cephadm add {{ node.fqdn }}
+{% endif %}
+{% if node.has_role('admin') %}
 ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
 {% endif %}
 {% endfor %}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,9 @@ minversion = 2.4
 skipsdist = True
 basepython = python3
 
+[pycodestyle]
+ignore = E123,E124,E126,E129,W503,W504
+
 [testenv]
 usedevelop = True
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
The documentation states that the only node that **must** have an
"admin" role is the bootstrap node. On all other nodes, including the
master node, "admin" is optional.

I realized that our previous approach, which was to apply the "admin"
role to all nodes without exception, might not be ideal for realistic
testing. According to the SES7 manual, this configuration is not
recommended.

So, this commit makes it possible for the user to specify which nodes
get the "admin" role when deploying {octopus,ses7,pacific} clusters, 
with the caveat that then "admin" role must be given on nodes that 
have the "bootstrap" and/or the "master" role. (On the "master" node,
"admin" is not strictly required, but it seems safe to assume that most
real-life deployments will have it, since it's natural to want to run ceph
CLI commands on the master node.)

Signed-off-by: Nathan Cutler <ncutler@suse.com>
