### PR TITLE
cleanup: streamline unit testing and code linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ matrix:
   include:
   - python: 3.6
     env: TOX_ENV=py36
-  - python: 3.7
-    env: TOX_ENV=py37
-  - python: 3.7
+  - python: 3.8
+    env: TOX_ENV=py38
+  - python: 3.8
     env: TOX_ENV=lint
 before_install:
 - sudo apt-get -y install libvirt-dev

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -661,8 +661,8 @@ def _gen_settings_dict(
                                        "Path to the source synced folder must exist",
                                        src)
 
-        except ValueError:
-            raise OptionFormatError('--synced-folder', "src:dst", folder)
+        except ValueError as exc:
+            raise OptionFormatError('--synced-folder', "src:dst", folder) from exc
     settings_dict['synced_folder'] = [folder.split(':') for folder in synced_folder]
 
     return settings_dict

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -226,7 +226,7 @@ def cli(
         vagrant_debug=None,
         verbose=None,
         work_path=None,
-        ):
+):
     """
     Welcome to the sesdev tool.
 
@@ -455,7 +455,7 @@ def _gen_settings_dict(
         synced_folder=None,
         username=None,
         vagrant_box=None,
-        ):
+):
 
     settings_dict = {}
 
@@ -594,7 +594,7 @@ def _gen_settings_dict(
             Log.info(
                 "User explicitly specified only --ceph-salt-repo; assuming --ceph-salt-branch {}"
                 .format(Constant.CEPH_SALT_BRANCH)
-                )
+            )
             ceph_salt_branch = Constant.CEPH_SALT_BRANCH
 
     if ceph_salt_branch is not None:
@@ -602,7 +602,7 @@ def _gen_settings_dict(
             Log.info(
                 "User explicitly specified only --ceph-salt-branch; assuming --ceph-salt-repo {}"
                 .format(Constant.CEPH_SALT_REPO)
-                )
+            )
             ceph_salt_repo = Constant.CEPH_SALT_REPO
 
     if ceph_salt_repo:
@@ -693,13 +693,13 @@ def _create_command(deployment_id, deploy, settings_dict):
                          'd=show details again) ?'),
                         type=str,
                         default="y",
-                        )
+                    )
                 else:
                     really_want_to = click.prompt(
                         'Proceed with deployment (y=yes, n=no, d=show details) ?',
                         type=str,
                         default="y",
-                        )
+                    )
                 really_want_to = really_want_to.lower()[0]
                 # pylint: disable=consider-using-in
                 if really_want_to == 'y' or not really_want_to:
@@ -712,13 +712,13 @@ def _create_command(deployment_id, deploy, settings_dict):
                     click.echo(dep.configuration_report(
                         show_deployment_wide_params=True,
                         show_individual_vms=False,
-                        ))
+                    ))
                 if really_want_to == 'd':
                     details_already_shown = True
                     click.echo(dep.configuration_report(
                         show_deployment_wide_params=False,
                         show_individual_vms=True,
-                        ))
+                    ))
         try:
             if really_want_to:
                 dep.vet_configuration()
@@ -964,7 +964,7 @@ def add_repo(deployment_id, **kwargs):
             name='custom_repo_{}'.format(tools.gen_random_string(6)),
             url=kwargs['custom_repo'],
             priority=Constant.ZYPPER_PRIO_ELEVATED if kwargs['repo_priority'] else None
-            )
+        )
     dep.add_repo_subcommand(custom_repo, kwargs['update'], _print_log)
 
 
@@ -991,7 +991,7 @@ def destroy(deployment_id, **kwargs):
         really_want_to = click.confirm(
             'Do you really want to destroy {} {}'.format(len(matching_deployments), cluster_word),
             default=True,
-            )
+        )
         if not really_want_to:
             raise click.Abort()
     for dep in matching_deployments:
@@ -1057,7 +1057,7 @@ def list_deps(format_opt):
                 "version": version,
                 "status": status,
                 "nodes": list(nodes),
-                })
+            })
         else:
             p_table.add_row([dep.dep_id, version, status, node_names])
     if format_opt in ['json']:
@@ -1101,7 +1101,7 @@ def redeploy(deployment_id, **kwargs):
             really_want_to = click.confirm(
                 'Do you want to continue with the deployment?',
                 default=True,
-                )
+            )
         if not really_want_to:
             raise click.Abort()
     dep = Deployment.load(deployment_id)
@@ -1236,7 +1236,7 @@ def start(deployment_id, node=None):
     click.echo("Starting {} {}".format(
         len(matching_deployments),
         _cluster_singular_or_plural(matching_deployments),
-        ))
+    ))
     if len(matching_deployments) > 1 and node:
         click.echo("Ignoring node advice because DEPLOYMENT_SPEC is a glob")
         node = None
@@ -1257,7 +1257,7 @@ def stop(deployment_id, node=None):
     click.echo("Stopping {} {}".format(
         len(matching_deployments),
         _cluster_singular_or_plural(matching_deployments),
-        ))
+    ))
     if len(matching_deployments) > 1 and node:
         click.echo("Ignoring node advice because DEPLOYMENT_SPEC is a glob")
         node = None

--- a/seslib/box.py
+++ b/seslib/box.py
@@ -36,7 +36,7 @@ class Box():
                         os.path.expanduser('~'),
                         '.ssh',
                         self.libvirt_private_key_file
-                        )
+                    )
                 uri += '?keyfile={}'.format(self.libvirt_private_key_file)
         else:
             uri = 'qemu:///system'

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -191,7 +191,7 @@ class Constant():
     ]
 
     ROLES_SINGLE_NODE = {
-        "caasp4":  "[ master ]",
+        "caasp4": "[ master ]",
         "luminous": "[ master, storage, mon, mgr, mds, igw, rgw, nfs, openattic ]",
         "nautilus": "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
                     "nfs ]",
@@ -328,4 +328,4 @@ class Constant():
             cls.PATH_TO_QA = os.path.join(
                 os.path.dirname(full_path_to_sesdev_executable),
                 '../qa/'
-                )
+            )

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -386,8 +386,8 @@ class Deployment():
             version = self.settings.version
             os_setting = self.settings.os
             version_repos = self.settings.version_devel_repos[version][os_setting]
-        except KeyError:
-            raise VersionOSNotSupported(self.settings.version, self.settings.os)
+        except KeyError as exc:
+            raise VersionOSNotSupported(self.settings.version, self.settings.os) from exc
 
         # version_repos might contain URLs with a "magic priority prefix" -- see
         # https://github.com/SUSE/sesdev/issues/162

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -448,8 +448,8 @@ class Deployment():
             'nodes': list(self.nodes.values()),
             'cluster_json': json.dumps({
                 "num_disks": self.settings.num_disks,
-                "roles_of_nodes": self.roles_of_nodes
-                }, sort_keys=True, indent=4),
+                "roles_of_nodes": self.roles_of_nodes,
+            }, sort_keys=True, indent=4),
             'master': self.master,
             'suma': self.suma,
             'domain': self.settings.domain.format(self.dep_id),

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -151,12 +151,12 @@ class Deployment():
             self.settings.override(
                 'makecheck_ceph_repo',
                 Constant.MAKECHECK_DEFAULT_REPO_BRANCH[self.settings.os]['repo']
-                )
+            )
         if not self.settings.makecheck_ceph_branch:
             self.settings.override(
                 'makecheck_ceph_branch',
                 Constant.MAKECHECK_DEFAULT_REPO_BRANCH[self.settings.os]['branch']
-                )
+            )
 
     def _maybe_tweak_roles(self):
         if self.settings.version in Constant.CORE_VERSIONS:
@@ -354,7 +354,7 @@ class Deployment():
                     name='suma_client_tools',
                     url='https://download.opensuse.org/repositories/systemsmanagement:/'
                         'Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/'
-                    ))
+                ))
 
             # from https://www.uyuni-project.org/uyuni-docs/uyuni/installation/install-vm.html
             if 'suma' in node_roles:
@@ -372,7 +372,7 @@ class Deployment():
                     url='https://download.opensuse.org/repositories/systemsmanagement:/'
                         'Uyuni:/Master/images-openSUSE_Leap_15.1/repo/'
                         'Uyuni-Server-POOL-x86_64-Media1/'
-                    ))
+                ))
 
             for repo_obj in self.settings.custom_repos:
                 node.add_custom_repo(repo_obj)
@@ -601,7 +601,7 @@ class Deployment():
                 ["vagrant", "box", "add", "--provider", "libvirt", "--name",
                  self.settings.os, Constant.OS_BOX_MAPPING[self.settings.os]],
                 log_handler
-                )
+            )
 
     def _vagrant_up(self, node, log_handler):
         cmd = ["vagrant", "up"]
@@ -812,7 +812,7 @@ deployment might not be completely destroyed.
                         result += (
                             "                         (CAVEAT: the 'admin' role is assumed"
                             " even though not explicitly given!)\n"
-                            )
+                        )
                 result += "     - fqdn:             {}\n".format(v.fqdn)
                 if v.public_address:
                     result += "     - public_address:   {}\n".format(v.public_address)
@@ -910,9 +910,9 @@ deployment might not be completely destroyed.
         for line in out.split('\n'):
             line = line.strip()
             if line.startswith('HostName'):
-                address = line[len('HostName')+1:]
+                address = line[len('HostName') + 1:]
             elif line.startswith('ProxyCommand'):
-                proxycmd = line[len('ProxyCommand')+1:]
+                proxycmd = line[len('ProxyCommand') + 1:]
 
         if address is None:
             raise VagrantSshConfigNoHostName(name)
@@ -962,14 +962,14 @@ deployment might not be completely destroyed.
                 " -o 'StrictHostKeyChecking no'"
                 " -o 'UserKnownHostsFile /dev/null'"
                 " -o 'PasswordAuthentication no'"
-                )
+            )
         else:
             retval = [
                 "-o", "IdentitiesOnly yes",
                 "-o", "StrictHostKeyChecking no",
                 "-o", "UserKnownHostsFile /dev/null",
                 "-o", "PasswordAuthentication no",
-                ]
+            ]
         return retval
 
     def _ssh_cmd(self, name, command=None):
@@ -978,7 +978,7 @@ deployment might not be completely destroyed.
             "ssh",
             "root@{}".format(address),
             "-i", dep_private_key
-            ]
+        ]
         _cmd.extend(self.__boilerplate_ssh_options())
         if proxycmd is not None:
             _cmd.extend(["-o", "ProxyCommand={}".format(proxycmd)])
@@ -1037,7 +1037,7 @@ deployment might not be completely destroyed.
             dep_private_key,
             self.__boilerplate_ssh_options(string=True),
             proxycmd_opt
-            )])
+        )])
         if host_is_source:
             _cmd.extend([source_path, 'root@{}:{}'.format(address, destination_path)])
         elif host_is_destination:
@@ -1058,7 +1058,7 @@ deployment might not be completely destroyed.
         log_handler("=> Running supportconfig on deployment ID: {} (OS: {})\n".format(
             self.dep_id,
             self.settings.os
-            ))
+        ))
         ssh_cmd = ('timeout', '1h', 'supportconfig',)
         self.ssh(name, ssh_cmd)
         log_handler("=> Grabbing the resulting tarball from the cluster node\n")
@@ -1085,7 +1085,7 @@ deployment might not be completely destroyed.
             ["vagrant", "provision", "--provision-with", "qa-test"],
             log_handler,
             self._dep_dir
-            )
+        )
 
     def add_repo_subcommand(self, custom_repo, update, log_handler):
         if self.settings.version in Constant.CORE_VERSIONS:
@@ -1099,16 +1099,18 @@ deployment might not be completely destroyed.
                     priority_opt = "--priority={} ".format(custom_repo.priority)
                 self.ssh(
                     node_name,
-                    ("zypper --non-interactive addrepo --no-gpgcheck --refresh {}{} {}"
-                     .format(priority_opt, custom_repo.url, custom_repo.name)).split()
-                    )
+                    (
+                        "zypper --non-interactive addrepo --no-gpgcheck --refresh {}{} {}"
+                        .format(priority_opt, custom_repo.url, custom_repo.name)
+                    ).split()
+                )
         else:  # no repo given explicitly: use "devel" repo
             provision_target = "add-devel-repo-and-update" if update else "add-devel-repo"
             tools.run_async(
                 ["vagrant", "provision", "--provision-with", provision_target],
                 log_handler,
                 self._dep_dir
-                )
+            )
 
     def _find_service_node(self, service):
         if service in ['prometheus', 'grafana'] and self.settings.version == 'ses5':

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -4,26 +4,26 @@ class SesDevException(Exception):
 
 class AddRepoNoUpdateWithExplicitRepo(SesDevException):
     def __init__(self):
-        super(AddRepoNoUpdateWithExplicitRepo, self).__init__(
+        super().__init__(
             "The --update option does not work with an explicit custom repo."
-            )
+        )
 
 
 class BadMakeCheckRolesNodes(SesDevException):
     def __init__(self):
-        super(BadMakeCheckRolesNodes, self).__init__(
+        super().__init__(
             "\"makecheck\" deployments only work with a single node with role "
             "\"makecheck\". Since this is the default, you can simply omit "
             "the --roles option when running \"sesdev create makecheck\"."
-            )
+        )
 
 
 class CmdException(SesDevException):
     def __init__(self, command, retcode, stderr):
-        super(CmdException, self).__init__(
+        super().__init__(
             "Command '{}' failed: ret={} stderr:\n{}"
             .format(command, retcode, stderr)
-            )
+        )
         self.command = command
         self.retcode = retcode
         self.stderr = stderr
@@ -31,253 +31,285 @@ class CmdException(SesDevException):
 
 class DebugWithoutLogFileDoesNothing(SesDevException):
     def __init__(self):
-        super(DebugWithoutLogFileDoesNothing, self).__init__(
-            "--debug without --log-file has no effect (maybe you want --verbose?)")
+        super().__init__(
+            "--debug without --log-file has no effect (maybe you want --verbose?)"
+        )
 
 
 class DepIDIllegalChars(SesDevException):
     def __init__(self, dep_id):
-        super(DepIDIllegalChars, self).__init__(
+        super().__init__(
             "Deployment ID \"{}\" contains illegal characters. Valid characters for "
             "hostnames are ASCII(7) letters from a to z, the digits from 0 to 9, and "
-            "the hyphen (-).".format(dep_id))
+            "the hyphen (-).".format(dep_id)
+        )
 
 
 class DepIDWrongLength(SesDevException):
     def __init__(self, length):
-        super(DepIDWrongLength, self).__init__(
+        super().__init__(
             "Deployment ID must be from 1 to 63 characters in length "
-            "(yours had {} characters)".format(length))
+            "(yours had {} characters)".format(length)
+        )
 
 
 class DeploymentAlreadyExists(SesDevException):
     def __init__(self, dep_id):
-        super(DeploymentAlreadyExists, self).__init__(
-            "A deployment with the same id '{}' already exists".format(dep_id))
+        super().__init__(
+            "A deployment with the same id '{}' already exists".format(dep_id)
+        )
 
 
 class DeploymentDoesNotExists(SesDevException):
     def __init__(self, dep_id):
-        super(DeploymentDoesNotExists, self).__init__(
-            "Deployment '{}' does not exist".format(dep_id))
+        super().__init__(
+            "Deployment '{}' does not exist".format(dep_id)
+        )
 
 
 class DuplicateRolesNotSupported(SesDevException):
     def __init__(self, role):
-        super(DuplicateRolesNotSupported, self).__init__(
+        super().__init__(
             "A node with more than one \"{r}\" role was detected. "
             "sesdev does not support more than one \"{r}\" role per node.".format(r=role)
-            )
+        )
 
 
 class ExclusiveRoles(SesDevException):
     def __init__(self, role_a, role_b):
-        super(ExclusiveRoles, self).__init__(
+        super().__init__(
             "Cannot have both roles '{}' and '{}' in the same deployment"
-            .format(role_a, role_b))
+            .format(role_a, role_b)
+        )
 
 
 class ExplicitAdminRoleNotAllowed(SesDevException):
     def __init__(self):
-        super(ExplicitAdminRoleNotAllowed, self).__init__(
+        super().__init__(
             "Though it is still recognized in existing deployments, the explicit "
             "\"admin\" role is deprecated and new deployments are not allowed to "
             "have it. When sesdev deploys Ceph/SES versions that use an \"admin\" "
             "role, all nodes in the deployment will get that role implicitly. "
-            "(TL;DR remove the \"admin\" role and try again!)")
+            "(TL;DR remove the \"admin\" role and try again!)"
+        )
 
 
 class MultipleRolesPerMachineNotAllowedInCaaSP(SesDevException):
     def __init__(self):
-        super(MultipleRolesPerMachineNotAllowedInCaaSP, self).__init__(
+        super().__init__(
             "Multiple roles per machine detected. This is not allowed in CaaSP "
             "clusters. For a single-node cluster, use the --single-node option "
             "or --roles=\"[master]\" (in this special case, the master node "
-            "will function also as a worker node)")
+            "will function also as a worker node)"
+        )
 
 
 class NodeDoesNotExist(SesDevException):
     def __init__(self, node):
-        super(NodeDoesNotExist, self).__init__(
-            "Node '{}' does not exist in this deployment".format(node))
+        super().__init__(
+            "Node '{}' does not exist in this deployment".format(node)
+        )
 
 
 class NoGaneshaRolePostNautilus(SesDevException):
     def __init__(self):
-        super(NoGaneshaRolePostNautilus, self).__init__(
+        super().__init__(
             "You specified a \"ganesha\" role. In cephadm, NFS-Ganesha daemons "
             "are referred to as \"nfs\" daemons, so in sesdev the role has been "
             "renamed to \"nfs\". Please change all instances of \"ganesha\" to "
-            "\"nfs\" in your roles string and try again")
+            "\"nfs\" in your roles string and try again"
+        )
 
 
 class NoExplicitRolesWithSingleNode(SesDevException):
     def __init__(self):
-        super(NoExplicitRolesWithSingleNode, self).__init__(
+        super().__init__(
             "The --roles and --single-node options are mutually exclusive. "
-            "One may be given, or the other, but not both at the same time.")
+            "One may be given, or the other, but not both at the same time."
+        )
 
 
 class NoPrometheusGrafanaInSES5(SesDevException):
     def __init__(self):
-        super(NoPrometheusGrafanaInSES5, self).__init__(
+        super().__init__(
             "The DeepSea version used in SES5 does not recognize 'prometheus' "
             "or 'grafana' as roles in policy.cfg (instead, it _always_ deploys "
             "these two services on the Salt Master node. For this reason, sesdev "
             "does not permit these roles to be used with ses5."
-            )
+        )
 
 
 class NoStorageRolesCephadm(SesDevException):
     def __init__(self, offending_role):
-        super(NoStorageRolesCephadm, self).__init__(
+        super().__init__(
             "No \"storage\" roles were given, but currently sesdev does not "
             "support this due to the presence of one or more {} roles in the "
-            "cluster configuration.".format(offending_role))
+            "cluster configuration.".format(offending_role)
+        )
 
 
 class NoStorageRolesDeepsea(SesDevException):
     def __init__(self, version):
-        super(NoStorageRolesDeepsea, self).__init__(
+        super().__init__(
             "No \"storage\" roles were given, but currently sesdev does not "
             "support this configuration when deploying a {} "
-            "cluster.".format(version))
+            "cluster.".format(version)
+        )
 
 
 class NoSourcePortForPortForwarding(SesDevException):
     def __init__(self):
-        super(NoSourcePortForPortForwarding, self).__init__(
-            "No source port specified for port forwarding")
+        super().__init__(
+            "No source port specified for port forwarding"
+        )
 
 
 class NoSupportConfigTarballFound(SesDevException):
     def __init__(self, node):
-        super(NoSupportConfigTarballFound, self).__init__(
-            "No supportconfig tarball found on node {}".format(node))
+        super().__init__(
+            "No supportconfig tarball found on node {}".format(node)
+        )
 
 
 class OptionFormatError(SesDevException):
     def __init__(self, option, expected_type, value):
-        super(OptionFormatError, self).__init__(
+        super().__init__(
             "Wrong format for option '{}': expected format: '{}', actual format: '{}'"
-            .format(option, expected_type, value))
+            .format(option, expected_type, value)
+        )
 
 
 class OptionNotSupportedInVersion(SesDevException):
     def __init__(self, option, version):
-        super(OptionNotSupportedInVersion, self).__init__(
-            "Option '{}' not supported with version '{}'".format(option, version))
+        super().__init__(
+            "Option '{}' not supported with version '{}'".format(option, version)
+        )
 
 
 class OptionValueError(SesDevException):
     def __init__(self, option, message, value):
-        super(OptionValueError, self).__init__(
+        super().__init__(
             "Wrong value for option '{}'. {}. Actual value: '{}'"
-            .format(option, message, value))
+            .format(option, message, value)
+        )
 
 
 class ProductOptionOnlyOnSES(SesDevException):
     def __init__(self, version):
-        super(ProductOptionOnlyOnSES, self).__init__(
+        super().__init__(
             "You asked to create a {} cluster with the --product option, "
             "but this option only works with versions starting with \"ses\""
-            .format(version))
+            .format(version)
+        )
 
 
 class RoleNotKnown(SesDevException):
     def __init__(self, role):
-        super(RoleNotKnown, self).__init__(
-            "Role '{}' is not supported by sesdev".format(role))
+        super().__init__(
+            "Role '{}' is not supported by sesdev".format(role)
+        )
 
 
 class RoleNotSupported(SesDevException):
     def __init__(self, role, version):
-        super(RoleNotSupported, self).__init__(
-            "Role '{}' is not supported in version '{}'".format(role, version))
+        super().__init__(
+            "Role '{}' is not supported in version '{}'".format(role, version)
+        )
 
 
 class ScpInvalidSourceOrDestination(SesDevException):
     def __init__(self):
-        super(ScpInvalidSourceOrDestination, self).__init__(
-            "Either source or destination must contain a ':' - not both or neither")
+        super().__init__(
+            "Either source or destination must contain a ':' - not both or neither"
+        )
 
 
 class ServiceNotFound(SesDevException):
     def __init__(self, service):
-        super(ServiceNotFound, self).__init__(
-            "Service '{}' was not found in this deployment".format(service))
+        super().__init__(
+            "Service '{}' was not found in this deployment".format(service)
+        )
 
 
 class ServicePortForwardingNotSupported(SesDevException):
     def __init__(self, service):
-        super(ServicePortForwardingNotSupported, self).__init__(
+        super().__init__(
             "Service '{}' not supported for port forwarding. Specify manually the service source "
-            "and destination ports".format(service))
+            "and destination ports".format(service)
+        )
 
 
 class SettingIncompatibleError(SesDevException):
     def __init__(self, setting1, value1, setting2, value2):
-        super(SettingIncompatibleError, self).__init__(
+        super().__init__(
             "Setting {} = {} and {} = {} are incompatible"
-            .format(setting1, value1, setting2, value2))
+            .format(setting1, value1, setting2, value2)
+        )
 
 
 class SettingNotKnown(SesDevException):
     def __init__(self, setting):
-        super(SettingNotKnown, self).__init__(
-            "Setting '{}' is not known - please open a bug report!".format(setting))
+        super().__init__(
+            "Setting '{}' is not known - please open a bug report!".format(setting)
+        )
 
 
 class SettingTypeError(SesDevException):
     def __init__(self, setting, expected_type, value):
-        super(SettingTypeError, self).__init__(
+        super().__init__(
             "Wrong value type for setting '{}': expected type: '{}', actual value='{}' ('{}')"
-            .format(setting, expected_type, value, type(value)))
+            .format(setting, expected_type, value, type(value))
+        )
 
 
 class SubcommandNotSupportedInVersion(SesDevException):
     def __init__(self, subcmd, version):
-        super(SubcommandNotSupportedInVersion, self).__init__(
-            "Subcommand {} not supported in '{}'".format(subcmd, version))
+        super().__init__(
+            "Subcommand {} not supported in '{}'".format(subcmd, version)
+        )
 
 
 class SupportconfigOnlyOnSLE(SesDevException):
     def __init__(self):
-        super(SupportconfigOnlyOnSLE, self).__init__(
+        super().__init__(
             "sesdev supportconfig depends on the 'supportconfig' RPM, which is "
             "available only on SUSE Linux Enterprise"
-            )
+        )
 
 
 class UniqueRoleViolation(SesDevException):
     def __init__(self, role, number):
-        super(UniqueRoleViolation, self).__init__(
+        super().__init__(
             "There must be one, and only one, '{role}' role "
             "(you gave {number} '{role}' roles)".format(role=role, number=number)
-            )
+        )
 
 
 class VagrantBoxDoesNotExist(SesDevException):
     def __init__(self, box):
-        super(VagrantBoxDoesNotExist, self).__init__(
+        super().__init__(
             "The vagrant box '{}' does not exist. Please add it with `vagrant box add ...` command"
-            .format(box))
+            .format(box)
+        )
 
 
 class VagrantSshConfigNoHostName(SesDevException):
     def __init__(self, name):
-        super(VagrantSshConfigNoHostName, self).__init__(
+        super().__init__(
             "Could not get HostName info from 'vagrant ssh-config {}' command"
-            .format(name))
+            .format(name)
+        )
 
 
 class VersionNotKnown(SesDevException):
     def __init__(self, version):
-        super(VersionNotKnown, self).__init__(
-            "Unknown deployment version: '{}'".format(version))
+        super().__init__(
+            "Unknown deployment version: '{}'".format(version)
+        )
 
 
 class VersionOSNotSupported(SesDevException):
     def __init__(self, version, os):
-        super(VersionOSNotSupported, self).__init__(
-            "Combination of version '{}' and OS '{}' not supported".format(version, os))
+        super().__init__(
+            "Combination of version '{}' and OS '{}' not supported".format(version, os)
+        )

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -92,8 +92,10 @@ exit 0
 
 {% if use_salt %}
 salt -G 'ceph-salt:member' state.apply ceph-salt
+echo "\"salt state.apply\" exit code: $?"
 {% else %}
 stdbuf -o0 ceph-salt -ldebug apply --non-interactive
+echo "\"ceph-salt apply\" exit code: $?"
 {% endif %}
 
 {% if stop_before_ceph_orch_apply %}
@@ -136,6 +138,7 @@ done
 set -x
 
 ceph status
+echo "\"ceph status\" exit code: $?"
 
 {% set service_spec_core = "/root/service_spec_core.yml" %}
 rm -f {{ service_spec_core }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ console_scripts =
 [options.extras_require]
 dev =
     pytest
+    pytest-pycodestyle
     pycodestyle
     pylint
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ dev =
     pytest-pycodestyle
     pycodestyle
     pylint
+    tox
 
 [pycodestyle]
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,4 @@ def get_version_from_spec():
 
 setup(
     version=get_version_from_spec(),
-    setup_cfg=True)
+    )

--- a/tests/test_is_a_glob.py
+++ b/tests/test_is_a_glob.py
@@ -2,6 +2,7 @@ import pytest
 
 from sesdev import _is_a_glob
 
+
 def test_pytest_is_a_glob():
     assert _is_a_glob("*"), "test failed"
     assert _is_a_glob("foo*"), "test failed"

--- a/tests/test_pytest_smoke.py
+++ b/tests/test_pytest_smoke.py
@@ -1,4 +1,5 @@
 import pytest
 
+
 def test_pytest_smoke():
     assert True, "test failed"

--- a/tests/test_sesdev_parse_roles.py
+++ b/tests/test_sesdev_parse_roles.py
@@ -2,6 +2,7 @@ import pytest
 
 from sesdev import _parse_roles
 
+
 def test_pytest_parse_roles():
     assert _parse_roles('[master]') == [["master"]], "test failed"
     assert _parse_roles('[[master]]') == [["master"]], "test failed"

--- a/tests/test_vet_dep_id.py
+++ b/tests/test_vet_dep_id.py
@@ -3,6 +3,7 @@ import pytest
 from seslib.deployment import _vet_dep_id
 from seslib.exceptions import DepIDWrongLength, DepIDIllegalChars
 
+
 def test_vet_dep_id():
     assert _vet_dep_id("hooholopar") == "hooholopar"
     assert _vet_dep_id("oron1anio0") == "oron1anio0"
@@ -15,7 +16,7 @@ def test_vet_dep_id():
             "hooholoparhooholoparhooholoparhooholoparhooh"
             "hooholoparhooholoparhooholoparhooholoparhooh"
             "hooholoparhooholoparhooholoparhooholoparhooh"
-            )
+        )
         _vet_dep_id(long_string)
     with pytest.raises(DepIDIllegalChars):
         _vet_dep_id("hooholopar;")

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,9 @@ minversion = 2.4
 skipsdist = True
 basepython = python3
 
+[pycodestyle]
+ignore = E126,E131,W503,W504
+
 [testenv]
 usedevelop = True
 install_command = pip install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,8 @@
 [tox]
-envlist = py36,py38,lint
+envlist = py36,lint
 minversion = 2.4
 skipsdist = True
 basepython = python3
-
-[pycodestyle]
-ignore = E126,E131,W503,W504
 
 [testenv]
 usedevelop = True
@@ -19,5 +16,3 @@ commands =
 commands =
   pylint sesdev
   pylint seslib
-  pycodestyle sesdev
-  pycodestyle seslib

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,lint
+envlist = py36,py38,lint
 minversion = 2.4
 skipsdist = True
 basepython = python3
@@ -11,11 +11,13 @@ ignore = E126,E131,W503,W504
 usedevelop = True
 install_command = pip install {opts} {packages}
 extras = dev
-commands = pytest {posargs: -vv}
+commands =
+  pytest {posargs: -vv}
+  pytest --pycodestyle {posargs: -vv}
 
 [testenv:lint]
 commands =
-  pylint seslib
-  pycodestyle seslib
   pylint sesdev
+  pylint seslib
   pycodestyle sesdev
+  pycodestyle seslib


### PR DESCRIPTION
This patchset

- streamlines the project's overall unit testing and code linting (tox/pytest/pylint/pycodestyle)
- runs the tests against Python 3.8 instead of 3.7
- runs pycodestyle from within pytest, instead of having it has a separate step