### PR TITLE
replace-ceph-salt should also sync salt runners

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -1235,6 +1235,10 @@ deployment might not be completely destroyed.
         ssh_cmd.append("salt '*' saltutil.sync_all")
         tools.run_sync(ssh_cmd)
 
+        ssh_cmd = self._ssh_cmd(master_node)
+        ssh_cmd.append("salt-run saltutil.sync_runners")
+        tools.run_sync(ssh_cmd)
+
     def replace_mgr_modules(self, local=None, pr=None, branch=None, repo=None, langs=None):
         if self.settings.version in ['nautilus', 'ses6', 'octopus', 'ses7', 'pacific']:
             pass  # replace-mgr-modules is expected to work with these


### PR DESCRIPTION
https://github.com/ceph/ceph-salt/pull/329 will introduce `ceph-salt` runners, so `sesdev replace-ceph-salt` should be adapted to also sync runners.

Signed-off-by: Ricardo Marques <rimarques@suse.com>