### PR TITLE
If --ssd option is given, make first additional disk non-rotational

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -144,7 +144,9 @@ def common_create_options(func):
         click.option('--synced-folder', type=str, default=None, multiple=True,
                      help='Set synced-folder to be mounted on the master node. <str:dest>'),
         click.option('--dry-run/--no-dry-run', is_flag=True, default=False,
-                     help='Dry run (do not create any VMs)')
+                     help='Dry run (do not create any VMs)'),
+        click.option('--ssd', is_flag=True, default=False,
+                     help='On VMS with additional disks, make one disk non-rotational')
     ]
     return _decorator_composer(click_options, func)
 
@@ -445,6 +447,7 @@ def _gen_settings_dict(
         scc_pass=None,
         scc_user=None,
         single_node=None,
+        ssd=None,
         stop_before_ceph_orch_apply=None,
         stop_before_ceph_salt_apply=None,
         stop_before_ceph_salt_config=None,
@@ -585,6 +588,9 @@ def _gen_settings_dict(
         settings_dict['dry_run'] = dry_run
         if dry_run:
             settings_dict['non_interactive'] = True
+
+    if ssd is not None:
+        settings_dict['ssd'] = ssd
 
     if encrypted_osds is not None:
         settings_dict['encrypted_osds'] = encrypted_osds

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -180,15 +180,18 @@ class Deployment():
             else:
                 storage_nodes = self.node_counts["worker"]
         Log.debug("_generate_nodes: storage_nodes == {}".format(storage_nodes))
-        if not self.settings.explicit_num_disks:
-            if storage_nodes:
-                if storage_nodes == 1:
-                    self.settings.override('num_disks', 4)
-                elif storage_nodes == 2:
-                    self.settings.override('num_disks', 3)
-                else:
-                    # go with the default
-                    pass
+        if not self.settings.explicit_num_disks and storage_nodes:
+            new_num_disks = None
+            if storage_nodes == 1:
+                new_num_disks = 4
+            elif storage_nodes == 2:
+                new_num_disks = 3
+            else:
+                new_num_disks = self.settings.num_disks  # go with the default
+            if self.settings.ssd and new_num_disks:
+                new_num_disks += 1
+            if new_num_disks:
+                self.settings.override('num_disks', new_num_disks)
 
     @property
     def _dep_dir(self):

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -507,6 +507,7 @@ class Deployment():
             'makecheck_stop_before_install_deps': self.settings.makecheck_stop_before_install_deps,
             'makecheck_stop_before_run_make_check':
                 self.settings.makecheck_stop_before_run_make_check,
+            'ssd': self.settings.ssd,
         }
 
         scripts = {}

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -235,6 +235,11 @@ SETTINGS = {
         'help': 'Whether --single-node was given on the command line',
         'default': False,
     },
+    'ssd': {
+        'type': bool,
+        'help': 'Makes one of the additional disks be non-rotational',
+        'default': False,
+    },
     'stop_before_ceph_orch_apply': {
         'type': bool,
         'help': 'Stops deployment before ceph orch apply',

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -11,6 +11,13 @@ echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/host
 {% endif %}
 {% endfor %}
 
+# if --ssd option was given, set rotational flag on first additional disk
+{% if ssd %}
+if [ -f /sys/block/vdb/queue/rotational ] ; then
+    echo "0" > /sys/block/vdb/queue/rotational
+fi
+{% endif %} {# ssd #}
+
 # distribute SSH keys
 cat /home/vagrant/.ssh/{{ ssh_key_name }}.pub >> /home/vagrant/.ssh/authorized_keys
 [ ! -e "/root/.ssh" ] && mkdir /root/.ssh


### PR DESCRIPTION
This commit adds support for simulating mixed SSD/HDD clusters. For the
time being, we keep it simple:

1. if --ssd is not given, all disks are rotational (as before)
2. if --ssd is given, the first additional disk on each node is set to
   "non-rotational", thereby simulating an SSD

In other words, this commit does not add support for complicated
configurations like

1. multiple SSDs per node
2. clusters where disk HW configurations vary from node to node

Fixes: https://github.com/SUSE/sesdev/issues/37
Signed-off-by: Nathan Cutler <ncutler@suse.com>