### PR TITLE
ceph_salt_deployment: prevent Vagrant from deleting master node

### DIFF
--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -18,7 +18,8 @@ function wait_for_master_ready {
         [ "$ACTUAL_NUMBER_OF_MASTERS" = "1" ] && break
         if [ "$remaining_seconds" -le "0" ] ; then
             echo "It seems unlikely that a master will ever appear. Bailing out!"
-            exit 1
+            set -e
+            false
         fi  
         sleep "$interval_seconds"
     done
@@ -40,7 +41,8 @@ function wait_for_workers_ready {
         [ "$ACTUAL_NUMBER_OF_WORKERS" = "{{ worker_nodes }}" ] && break
         if [ "$remaining_seconds" -le "0" ] ; then
             echo "It seems unlikely that {{ worker_nodes }} workers will ever appear. Bailing out!"
-            exit 1
+            set -e
+            false
         fi  
         sleep "$interval_seconds"
     done

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -1,6 +1,19 @@
-{% include "engine/" + vm_engine + "/vagrant.provision.sh.j2" ignore missing %}
-
 set -ex
+
+DEPLOYMENT_SCRIPT="$0"
+
+function err_report {
+    local line_number="$1"
+    echo "Error in sesdev deployment script trapped!"
+    echo "=> hostname: $(hostname)"
+    echo "=> script: $DEPLOYMENT_SCRIPT"
+    echo "=> line number: $line_number"
+    echo "Bailing out!"
+    exit 0
+}
+
+# ensure Vagrant doesn't destroy the master node when the script fails
+trap 'err_report $LINENO' ERR
 
 ls -lR /home/vagrant
 

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -130,7 +130,7 @@ while true ; do
         ceph status
         set +x
         echo "It seems unlikely that the bootstrap MON and MGR will ever appear. Bailing out!"
-        exit 1
+        false
     fi  
     echo "..."
     sleep "$interval_seconds"
@@ -235,7 +235,7 @@ while true ; do
         ceph status
         set +x
         echo "It seems unlikely that this cluster will ever reach the expected number of OSDs. Bailing out!"
-        exit 1
+        false
     fi  
     sleep "$interval_seconds"
 done

--- a/seslib/templates/salt/cluster_json.j2
+++ b/seslib/templates/salt/cluster_json.j2
@@ -18,8 +18,7 @@ echo "Running $0 on $NAME $VERSION ($PRETTY_NAME)"
 if [ "$VERSION_ID" = "15.2" ] && [ -z "$FSID" ] ; then
     echo "You must provide a Ceph Cluster FSID as an option to this script."
     echo "Bailing out!"
-    echo
-    exit 1
+    false
 fi
 NUM_DISKS="$(cat /home/vagrant/cluster.json | jq -r '.num_disks')"
 ROLES_OF_NODES="$(cat /home/vagrant/cluster.json | jq -r '.roles_of_nodes')"

--- a/seslib/templates/salt/deepsea/create_all_pools_at_once.sh.j2
+++ b/seslib/templates/salt/deepsea/create_all_pools_at_once.sh.j2
@@ -87,7 +87,7 @@ if [ "$OTHER" ] ; then
 fi
 if [ -z "$POOLS" ] ; then
     echo "create_all_pools_at_once: bad arguments"
-    exit 1
+    false
 fi
 echo "About to create pools ->$POOLS<-"
 # shellcheck disable=SC2086

--- a/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
@@ -105,7 +105,7 @@ exit 0
 {% set drive_groups_yml = "/srv/salt/ceph/configuration/files/drive_groups.yml" %}
 if [ ! -e "{{ drive_groups_yml }}" ] ; then
     echo "FATAL: {{ drive_groups_yml }} unexpectedly missing!"
-    exit 1
+    false
 fi
 {% if filestore_osds %}
 echo "  format: filestore" >> {{ drive_groups_yml }}

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -47,7 +47,7 @@ while true ; do
   set +x
   if [ "$count" -gt "$max_count_we_tolerate" ] ; then
       echo "Looped too many times. Something is wrong. Bailing out!"
-      exit 1
+      false
   fi
 done
 set -x

--- a/seslib/templates/salt/wait_for_minions.j2
+++ b/seslib/templates/salt/wait_for_minions.j2
@@ -1,19 +1,20 @@
 
 # make sure all minions are responding
-set +ex
+set +x
 LOOP_COUNT="0"
 while true ; do
   if [ "$LOOP_COUNT" -ge "30" ] ; then
-    echo "ERROR: minion(s) not responding to ping?"
-    exit 1
+    echo "ERROR: minion(s) failed to respond to ping. Bailling out!"
+    set -e
+    false
   fi
   LOOP_COUNT="$((LOOP_COUNT + 1))"
   echo "Pinging {{ nodes | length }} minions..."
-  MINIONS_RESPONDING="$(salt '*' test.ping 2> /dev/null | grep --count True)"
+  MINIONS_RESPONDING="$(salt '*' test.ping 2> /dev/null | grep --count True || true)"
   echo "${MINIONS_RESPONDING} of {{ nodes | length }} minions responded to ping."
   [ "$MINIONS_RESPONDING" = "{{ nodes|length }}" ] && break
   set -x
   sleep 3
   set +x
 done
-set -ex
+set -x

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -69,7 +69,7 @@ if bash -e "{{ devel_repo_script }}" ; then
     true
 else
     echo "{{ devel_repo_script }} failed! Bailing out."
-    exit 1
+    false
 fi
 {% endif %}
 


### PR DESCRIPTION
As of some recent version of Vagrant, it started removing the master
domain (i.e., destroying the master node) whenever the provisioning
script exits with a code other than "0".

Deleting the master node makes it impossible to investigate why the
script failed.

I can't think of any good reason for Vagrant/vagrant-libvirt to behave
like this. It's a recent development. I don't know how to turn the
behavior off, but I can at least work around it by preventing the
deployment script from returning any exit code other than 0.

Signed-off-by: Nathan Cutler <ncutler@suse.com>