### PR TITLE
provision.sh: disable host checking when SSHing within the cluster

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -80,6 +80,7 @@ class Deployment():
         else:
             self.dep_id = _vet_dep_id(dep_id)
         self.settings = settings
+        self.domain = self.settings.domain.format(self.dep_id)
         self.existing = existing  # True: we are loading, False: we are creating
         self.nodes = {}
         self.node_counts = {}
@@ -254,39 +255,34 @@ class Deployment():
                 if 'master' in node_roles:
                     node_id += 1
                     name = 'master'
-                    fqdn = 'master.{}'.format(self.settings.domain.format(self.dep_id))
+                    fqdn = 'master.{}'.format(self.domain)
                 elif 'worker' in node_roles:
                     worker_id += 1
                     node_id += 1
                     name = 'worker{}'.format(worker_id)
-                    fqdn = 'worker{}.{}'.format(worker_id,
-                                                self.settings.domain.format(self.dep_id))
+                    fqdn = 'worker{}.{}'.format(worker_id, self.domain)
                 elif 'loadbalancer' in node_roles:
                     loadbl_id += 1
                     node_id += 1
                     name = 'loadbl{}'.format(loadbl_id)
-                    fqdn = 'loadbl{}.{}'.format(loadbl_id,
-                                                self.settings.domain.format(self.dep_id))
+                    fqdn = 'loadbl{}.{}'.format(loadbl_id, self.domain)
                 elif 'nfs' in node_roles and self.settings.version == 'caasp4':
                     nfs_id += 1
                     node_id += 1
                     name = 'nfs{}'.format(nfs_id)
-                    fqdn = 'nfs{}.{}'.format(nfs_id,
-                                             self.settings.domain.format(self.dep_id))
+                    fqdn = 'nfs{}.{}'.format(nfs_id, self.domain)
                 else:
                     node_id += 1
                     name = 'node{}'.format(node_id)
-                    fqdn = 'node{}.{}'.format(node_id,
-                                              self.settings.domain.format(self.dep_id))
+                    fqdn = 'node{}.{}'.format(node_id, self.domain)
             else:
                 if 'master' in node_roles or 'suma' in node_roles or 'makecheck' in node_roles:
                     name = 'master'
-                    fqdn = 'master.{}'.format(self.settings.domain.format(self.dep_id))
+                    fqdn = 'master.{}'.format(self.domain)
                 else:
                     node_id += 1
                     name = 'node{}'.format(node_id)
-                    fqdn = 'node{}.{}'.format(node_id,
-                                              self.settings.domain.format(self.dep_id))
+                    fqdn = 'node{}.{}'.format(node_id, self.domain)
 
             networks = ''
             public_address = None
@@ -452,7 +448,7 @@ class Deployment():
                 }, sort_keys=True, indent=4),
             'master': self.master,
             'suma': self.suma,
-            'domain': self.settings.domain.format(self.dep_id),
+            'domain': self.domain,
             'deepsea_git_repo': self.settings.deepsea_git_repo,
             'deepsea_git_branch': self.settings.deepsea_git_branch,
             'version': self.settings.version,

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -27,6 +27,12 @@ ln -s /root/.ssh/{{ ssh_key_name }} /root/.ssh/id_rsa
 ln -s /root/.ssh/{{ ssh_key_name }}.pub /root/.ssh/id_rsa.pub
 cat /root/.ssh/{{ ssh_key_name }}.pub >> /root/.ssh/authorized_keys
 
+# disable host checking when SSHing within the cluster
+cat >> /root/.ssh/config << 'EOF'
+Host *
+   StrictHostKeyChecking no
+EOF
+
 # set hostname
 hostnamectl set-hostname {{ node.name }}
 


### PR DESCRIPTION
Avoid the following error:

    master:~ # ssh node1.ses7.test cephadm ls
    The authenticity of host 'node1.ses7.test (10.20.144.201)' can't be established.
    ECDSA key fingerprint is SHA256:G0eqcFcad9Kys0zcKl4mbncUd33rMc6DZroPTHNKwVg.
    Are you sure you want to continue connecting (yes/no/[fingerprint])?

Fixes: https://github.com/SUSE/sesdev/issues/454
Signed-off-by: Nathan Cutler <ncutler@suse.com>
