### PR TITLE
ceph_salt_deployment: expose ceph-salt errors early

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -3,6 +3,7 @@ set -ex
 DEPLOYMENT_SCRIPT="$0"
 
 function err_report {
+    set +x
     local line_number="$1"
     echo "Error in sesdev deployment script trapped!"
     echo "=> hostname: $(hostname)"

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -46,6 +46,7 @@ exit 0
 
 echo "PATH is $PATH"
 type ceph-salt
+ceph-salt --version
 
 {% for node in nodes %}
 {% if not node.has_exclusive_role('client') %}


### PR DESCRIPTION
Until this commit, the first ceph-salt command we executed was

    ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}

When that command fails, we don't really know whether it's a problem
with ceph-salt as a whole, or just the "ceph-salt config" component.

Signed-off-by: Nathan Cutler <ncutler@suse.com>