### PR TITLE
ceph_salt_deployment: explicitly create mds service

### DIFF
--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -256,17 +256,14 @@ while true ; do
 done
 set -x
 
-MDS_NODES_COMMA_SEPARATED_LIST=""
 NFS_NODES_COMMA_SEPARATED_LIST=""
 {% for node in nodes %}
 {% if node.has_role('mds') %}
-MDS_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
 {% endif %}
 {% if node.has_role('nfs') %}
 NFS_NODES_COMMA_SEPARATED_LIST+="{{ node.name }},"
 {% endif %}
 {% endfor %}
-MDS_NODES_COMMA_SEPARATED_LIST="${MDS_NODES_COMMA_SEPARATED_LIST%,*}"
 NFS_NODES_COMMA_SEPARATED_LIST="${NFS_NODES_COMMA_SEPARATED_LIST%,*}"
 
 {% endif %} {# mds_nodes > 0 or rgw_nodes > 0 or nfs_nodes > 0 #}
@@ -288,7 +285,7 @@ placement:
 {% endfor %}
 EOF
 ceph orch apply -i {{ service_spec_mds }}
-ceph fs volume create {{ fs_volume }} "$MDS_NODES_COMMA_SEPARATED_LIST"
+ceph fs volume create {{ fs_volume }}
 sleep 10
 ceph fs status
 sleep 5

--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -273,7 +273,21 @@ NFS_NODES_COMMA_SEPARATED_LIST="${NFS_NODES_COMMA_SEPARATED_LIST%,*}"
 
 {% if mds_nodes > 0 %}
 
+{% set service_spec_mds = "/root/service_spec_mds.yml" %}
 {% set fs_volume = "sesdev_fs" %}
+cat >> {{ service_spec_mds }} << 'EOF'
+---
+service_type: mds
+service_id: {{ fs_volume }}
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('mds') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+ceph orch apply -i {{ service_spec_mds }}
 ceph fs volume create {{ fs_volume }} "$MDS_NODES_COMMA_SEPARATED_LIST"
 sleep 10
 ceph fs status


### PR DESCRIPTION
Until now we were relying on "ceph fs volume create" to create the mds
service (we use the word "service" here in the cephadm sense), but
apparently it no longer does that.

Explicitly deploy the mds service/daemons by compiling a service spec
file and running "ceph orch apply" on it.

Signed-off-by: Nathan Cutler <ncutler@suse.com>