### PR TITLE
Bootstrap minion no longer required to have admin role

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -151,7 +151,7 @@ class Constant():
                      ["storage", "mon", "mgr", "mds", "rgw", "nfs"]],
         "octopus": [["admin", "master", "client", "prometheus", "grafana", "alertmanager",
                      "node-exporter"],
-                    ["admin", "bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
+                    ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
                     ["storage", "mon", "mgr", "mds", "igw", "nfs", "node-exporter"],
                     ["storage", "mon", "mgr", "mds", "rgw", "nfs", "node-exporter"]]
     }

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -837,9 +837,6 @@ deployment might not be completely destroyed.
             ):
                 if self.node_counts['bootstrap'] != 1:
                     raise UniqueRoleViolation('bootstrap', self.node_counts['bootstrap'])
-                for node_roles in self.settings.roles:
-                    if 'bootstrap' in node_roles and 'admin' not in node_roles:
-                        raise NodeMustBeAdminAsWell('bootstrap')
                 if (not self.settings.stop_before_ceph_salt_apply and
                     not self.settings.stop_before_ceph_orch_apply
                 ):


### PR DESCRIPTION
If https://github.com/ceph/ceph-salt/pull/383 is merged, bootstrap minion will no longer be required to have the admin role.

Signed-off-by: Ricardo Marques <rimarques@suse.com>