### PR TITLE
deepsea_deployment: really stop before Stage 0

### DIFF
--- a/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
@@ -29,16 +29,16 @@ sleep 2
 salt '*' grains.set deepsea True
 sleep 5
 
-{% if pre_stage_0_script %}
-{{ pre_stage_0_script }}
-{% endif %}
-
 {% if stop_before_stage == 0 %}
 set +x
 echo "Stopping the deployment now because --stop-before-deepsea-stage=0 option was given."
 set -x
 exit 0
 {% endif %} {# stop_before_stage == 0 #}
+
+{% if pre_stage_0_script %}
+{{ pre_stage_0_script }}
+{% endif %}
 
 echo "PATH is $PATH"
 {% if use_salt %}


### PR DESCRIPTION
If the user gives --stop-before-deepsea-stage=0, then we don't want to
run even the "pre_stage_0" script.

Signed-off-by: Nathan Cutler <ncutler@suse.com>