### PR TITLE
ceph_salt_deployment: always wait for OSDs to appear

### DIFF
--- a/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
+++ b/seslib/templates/salt/ceph-salt/ceph_salt_deployment.sh.j2
@@ -225,9 +225,7 @@ ceph orch apply -i {{ service_spec_core }} --dry-run
 ceph orch apply -i {{ service_spec_core }}
 {% endif %} {# ceph_orch_apply_needed #}
 
-{% if storage_nodes > 0 %}
-
-{% if mds_nodes > 0 or rgw_nodes > 0 or nfs_nodes > 0 %}
+{% if total_osds > 0 %}
 
 # Wait for OSDs to appear
 function number_of_osds_in_ceph_osd_tree {
@@ -255,6 +253,12 @@ while true ; do
     sleep "$interval_seconds"
 done
 set -x
+
+{% endif %} {# if total_osds > 0 #}
+
+{% if storage_nodes > 0 %}
+
+{% if mds_nodes > 0 or rgw_nodes > 0 or nfs_nodes > 0 %}
 
 NFS_NODES_COMMA_SEPARATED_LIST=""
 {% for node in nodes %}


### PR DESCRIPTION
During integration testing we found that ceph_salt_deployment.sh always
waits for OSDs to appear, except in one test case:

    sesdev create ses7 --roles [admin,master,bootstrap,storage,mon,mgr]

In this case, since there are no gateways, the "wait for OSDs to appear"
routine was not triggered.

This commit revamps the conditionals so the provisioning script always
waits for the OSDs to appear (if there are any OSDs).

Signed-off-by: Nathan Cutler <ncutler@suse.com>