### PR TITLE
contrib/standalone.sh: remove config.yaml even when failing

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -31,6 +31,7 @@ function final_report {
     rm "$FINAL_REPORT"
     rm "$TEMP_FILE"
     rm "$CMD_OUTPUT"
+    rm "$HOME/.sesdev/config.yaml"
     exit 0
 }
 


### PR DESCRIPTION
When a test failed, the config.yaml that was created for testing
purposes was being left behind.

Signed-off-by: Nathan Cutler <ncutler@suse.com>