### PR TITLE
[DNM] ceph_salt_deployment: reinstate device refresh

### DIFF
--- a/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
@@ -57,6 +57,7 @@ encrypted: true
 objectstore: filestore
 {% endif %}
 EOF
+ceph orch device ls --refresh
 {% endif %} {# storage_nodes > 0 #}
 
 {% if ceph_orch_apply_needed %}


### PR DESCRIPTION
The device refresh step was dropped by
280444e62c213da386ed3bb26b8d8e676c17ce5c under the impression that it
might no longer be needed, but afterwards we started seeing clusters
coming up in HEALTH_WARN (CEPHADM_REFRESH_FAILED: failed to probe
daemons or devices).

References: https://bugzilla.suse.com/show_bug.cgi?id=1173079
Signed-off-by: Nathan Cutler <ncutler@suse.com>