### PR TITLE
Split ceph_salt_deployment.sh into two

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -138,6 +138,8 @@ class Constant():
         },
     }
 
+    REASONABLE_TIMEOUT_IN_SECONDS = 1800
+
     ROLES_DEFAULT = {
         "caasp4": [["master"], ["worker"], ["worker"], ["loadbalancer"]],
         "luminous": [["master", "client", "openattic"],

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -507,6 +507,7 @@ class Deployment():
             'makecheck_stop_before_run_make_check':
                 self.settings.makecheck_stop_before_run_make_check,
             'ssd': self.settings.ssd,
+            'reasonable_timeout_in_seconds': Constant.REASONABLE_TIMEOUT_IN_SECONDS,
         }
 
         scripts = {}

--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -1,0 +1,157 @@
+
+set -ex
+
+{% if ceph_salt_git_repo and ceph_salt_git_branch %}
+# install ceph-salt
+cd /root
+git clone {{ ceph_salt_git_repo }}
+cd ceph-salt
+zypper --non-interactive install autoconf gcc python3-devel python3-pip python3-curses
+
+{% if ceph_salt_fetch_github_pr_heads %}
+# fetch the available PRs (HEAD) from github. With that, "ceph_salt_git_branch" can be something like "origin/pr/127" to checkout a github PR
+git fetch origin "+refs/pull/*/head:refs/remotes/origin/pr/*"
+{% endif %}
+{% if ceph_salt_fetch_github_pr_merges %}
+# fetch the available PRs (MERGE) from github. With that, "ceph_salt_git_branch" can be something like "origin/pr-merged/127" to checkout a github PR
+git fetch origin "+refs/pull/*/merge:refs/remotes/origin/pr-merged/*"
+{% endif %}
+
+git checkout {{ ceph_salt_git_branch }}
+
+pip install --prefix /usr .
+# install ceph-salt-formula
+cp -r ceph-salt-formula/salt/* /srv/salt/
+chown -R salt:salt /srv
+{% else %}
+# ceph-salt-formula is installed automatically as a dependency of ceph-salt
+zypper --non-interactive install ceph-salt
+{% endif %}
+
+systemctl restart salt-master
+{% include "salt/wait_for_minions.j2" %}
+
+{% if use_salt %}
+salt '*' saltutil.pillar_refresh
+salt '*' saltutil.sync_all
+sleep 2
+{% endif %}
+
+{% if stop_before_ceph_salt_config %}
+set +x
+echo "Stopping the deployment now because --stop-before-ceph-salt-config option was given."
+set -x
+exit 0
+{% endif %} {# stop_before_ceph_salt_config #}
+
+echo "PATH is $PATH"
+type ceph-salt
+ceph-salt --version
+
+{% for node in nodes %}
+{% if not node.has_exclusive_role('client') %}
+ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
+ceph-salt config /ceph_cluster/roles/cephadm add {{ node.fqdn }}
+{% endif %}
+{% if node.has_role('admin') %}
+ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
+{% endif %}
+{% endfor %}
+ceph-salt config /ceph_cluster/roles/bootstrap set {{ cephadm_bootstrap_node.fqdn }}
+
+ceph-salt config /ssh/ generate
+ceph-salt config /time_server/server_hostname set {{ master.fqdn }}
+{% set external_timeserver = "pool.ntp.org" %}
+ceph-salt config /time_server/external_servers add {{ external_timeserver }}
+
+{% if image_path %}
+ceph-salt config /cephadm_bootstrap/ceph_image_path set {{ image_path }}
+{% endif %}
+
+{% if storage_nodes < 3 %}
+ceph-salt config /cephadm_bootstrap/ceph_conf add global
+ceph-salt config /cephadm_bootstrap/ceph_conf/global set "osd crush chooseleaf type" 0
+{% endif %}
+
+ceph-salt config /cephadm_bootstrap/dashboard/username set admin
+ceph-salt config /cephadm_bootstrap/dashboard/password set admin
+ceph-salt config /cephadm_bootstrap/dashboard/force_password_update disable
+
+ceph-salt config ls
+ceph-salt export --pretty
+ceph-salt status
+
+zypper repos --details
+zypper info cephadm | grep -E '(^Repo|^Version)'
+ceph-salt --version
+
+{% if stop_before_ceph_salt_apply %}
+set +x
+echo "Stopping the deployment now because --stop-before-ceph-salt-apply option was given."
+set -x
+exit 0
+{% endif %} {# stop_before_ceph_salt_apply #}
+
+{% if use_salt %}
+salt -G 'ceph-salt:member' state.apply ceph-salt
+echo "\"salt state.apply\" exit code: $?"
+{% else %}
+stdbuf -o0 ceph-salt -ldebug apply --non-interactive
+echo "\"ceph-salt apply\" exit code: $?"
+{% endif %}
+
+{% if stop_before_ceph_orch_apply %}
+set +x
+echo "Stopping the deployment now because --stop-before-ceph-orch-apply option was given."
+set -x
+exit 0
+{% endif %} {# stop_before_ceph_orch_apply #}
+
+# Wait for the bootstrap MON+MGR to appear
+
+function number_of_foos_in_bootstrap_cephadm_ls {
+    local foo="$1"
+    set -x
+    ssh {{ cephadm_bootstrap_node.fqdn }} cephadm ls | jq "[ .[].name | select(startswith(\"$foo\")) ] | length"
+    set +x
+}
+
+set +x
+timeout_seconds="{{ reasonable_timeout_in_seconds }}"
+remaining_seconds="$timeout_seconds"
+interval_seconds="30"
+while true ; do
+    ACTUAL_NUMBER_OF_MONS="$(number_of_foos_in_bootstrap_cephadm_ls mon)"
+    ACTUAL_NUMBER_OF_MGRS="$(number_of_foos_in_bootstrap_cephadm_ls mgr)"
+    echo "MONs in cluster (actual/expected): $ACTUAL_NUMBER_OF_MONS/1 (${remaining_seconds} seconds to timeout)"
+    echo "MGRs in cluster (actual/expected): $ACTUAL_NUMBER_OF_MGRS/1 (${remaining_seconds} seconds to timeout)"
+    remaining_seconds="$(( remaining_seconds - interval_seconds ))"
+    [ "$ACTUAL_NUMBER_OF_MONS" -ge "1" ] && [ "$ACTUAL_NUMBER_OF_MGRS" -ge "1" ] && break
+    if [ "$remaining_seconds" -le "0" ] ; then
+        set -x
+        ceph status
+        set +x
+        echo "It seems unlikely that the bootstrap MON and MGR will ever appear. Bailing out!"
+        false
+    fi  
+    echo "..."
+    sleep "$interval_seconds"
+done
+if [ "$ACTUAL_NUMBER_OF_MONS" -gt "1" ] ; then
+    echo
+    echo
+    echo "WARNING: \"cephadm bootstrap\" deployed more MONs than expected!"
+    echo
+    echo
+fi
+if [ "$ACTUAL_NUMBER_OF_MGRS" -gt "1" ] ; then
+    echo
+    echo
+    echo "WARNING: \"cephadm bootstrap\" deployed more MGRs than expected!"
+    echo
+    echo
+fi
+set -x
+
+ceph status
+echo "\"ceph status\" exit code: $?"

--- a/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
@@ -1,163 +1,4 @@
 
-set -ex
-
-REASONABLE_TIMEOUT_IN_SECONDS="1800"
-
-{% if ceph_salt_git_repo and ceph_salt_git_branch %}
-# install ceph-salt
-cd /root
-git clone {{ ceph_salt_git_repo }}
-cd ceph-salt
-zypper --non-interactive install autoconf gcc python3-devel python3-pip python3-curses
-
-{% if ceph_salt_fetch_github_pr_heads %}
-# fetch the available PRs (HEAD) from github. With that, "ceph_salt_git_branch" can be something like "origin/pr/127" to checkout a github PR
-git fetch origin "+refs/pull/*/head:refs/remotes/origin/pr/*"
-{% endif %}
-{% if ceph_salt_fetch_github_pr_merges %}
-# fetch the available PRs (MERGE) from github. With that, "ceph_salt_git_branch" can be something like "origin/pr-merged/127" to checkout a github PR
-git fetch origin "+refs/pull/*/merge:refs/remotes/origin/pr-merged/*"
-{% endif %}
-
-git checkout {{ ceph_salt_git_branch }}
-
-pip install --prefix /usr .
-# install ceph-salt-formula
-cp -r ceph-salt-formula/salt/* /srv/salt/
-chown -R salt:salt /srv
-{% else %}
-# ceph-salt-formula is installed automatically as a dependency of ceph-salt
-zypper --non-interactive install ceph-salt
-{% endif %}
-
-systemctl restart salt-master
-{% include "salt/wait_for_minions.j2" %}
-
-{% if use_salt %}
-salt '*' saltutil.pillar_refresh
-salt '*' saltutil.sync_all
-sleep 2
-{% endif %}
-
-{% if stop_before_ceph_salt_config %}
-set +x
-echo "Stopping the deployment now because --stop-before-ceph-salt-config option was given."
-set -x
-exit 0
-{% endif %} {# stop_before_ceph_salt_config #}
-
-echo "PATH is $PATH"
-type ceph-salt
-ceph-salt --version
-
-{% for node in nodes %}
-{% if not node.has_exclusive_role('client') %}
-ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
-ceph-salt config /ceph_cluster/roles/cephadm add {{ node.fqdn }}
-{% endif %}
-{% if node.has_role('admin') %}
-ceph-salt config /ceph_cluster/roles/admin add {{ node.fqdn }}
-{% endif %}
-{% endfor %}
-ceph-salt config /ceph_cluster/roles/bootstrap set {{ cephadm_bootstrap_node.fqdn }}
-
-ceph-salt config /ssh/ generate
-ceph-salt config /time_server/server_hostname set {{ master.fqdn }}
-{% set external_timeserver = "pool.ntp.org" %}
-ceph-salt config /time_server/external_servers add {{ external_timeserver }}
-
-{% if image_path %}
-ceph-salt config /cephadm_bootstrap/ceph_image_path set {{ image_path }}
-{% endif %}
-
-{% if storage_nodes < 3 %}
-ceph-salt config /cephadm_bootstrap/ceph_conf add global
-ceph-salt config /cephadm_bootstrap/ceph_conf/global set "osd crush chooseleaf type" 0
-{% endif %}
-
-ceph-salt config /cephadm_bootstrap/dashboard/username set admin
-ceph-salt config /cephadm_bootstrap/dashboard/password set admin
-ceph-salt config /cephadm_bootstrap/dashboard/force_password_update disable
-
-ceph-salt config ls
-ceph-salt export --pretty
-ceph-salt status
-
-zypper repos --details
-zypper info cephadm | grep -E '(^Repo|^Version)'
-ceph-salt --version
-
-{% if stop_before_ceph_salt_apply %}
-set +x
-echo "Stopping the deployment now because --stop-before-ceph-salt-apply option was given."
-set -x
-exit 0
-{% endif %} {# stop_before_ceph_salt_apply #}
-
-{% if use_salt %}
-salt -G 'ceph-salt:member' state.apply ceph-salt
-echo "\"salt state.apply\" exit code: $?"
-{% else %}
-stdbuf -o0 ceph-salt -ldebug apply --non-interactive
-echo "\"ceph-salt apply\" exit code: $?"
-{% endif %}
-
-{% if stop_before_ceph_orch_apply %}
-set +x
-echo "Stopping the deployment now because --stop-before-ceph-orch-apply option was given."
-set -x
-exit 0
-{% endif %} {# stop_before_ceph_orch_apply #}
-
-# Wait for the bootstrap MON+MGR to appear
-
-function number_of_foos_in_bootstrap_cephadm_ls {
-    local foo="$1"
-    set -x
-    ssh {{ cephadm_bootstrap_node.fqdn }} cephadm ls | jq "[ .[].name | select(startswith(\"$foo\")) ] | length"
-    set +x
-}
-
-set +x
-timeout_seconds="$REASONABLE_TIMEOUT_IN_SECONDS"
-remaining_seconds="$timeout_seconds"
-interval_seconds="30"
-while true ; do
-    ACTUAL_NUMBER_OF_MONS="$(number_of_foos_in_bootstrap_cephadm_ls mon)"
-    ACTUAL_NUMBER_OF_MGRS="$(number_of_foos_in_bootstrap_cephadm_ls mgr)"
-    echo "MONs in cluster (actual/expected): $ACTUAL_NUMBER_OF_MONS/1 (${remaining_seconds} seconds to timeout)"
-    echo "MGRs in cluster (actual/expected): $ACTUAL_NUMBER_OF_MGRS/1 (${remaining_seconds} seconds to timeout)"
-    remaining_seconds="$(( remaining_seconds - interval_seconds ))"
-    [ "$ACTUAL_NUMBER_OF_MONS" -ge "1" ] && [ "$ACTUAL_NUMBER_OF_MGRS" -ge "1" ] && break
-    if [ "$remaining_seconds" -le "0" ] ; then
-        set -x
-        ceph status
-        set +x
-        echo "It seems unlikely that the bootstrap MON and MGR will ever appear. Bailing out!"
-        false
-    fi  
-    echo "..."
-    sleep "$interval_seconds"
-done
-if [ "$ACTUAL_NUMBER_OF_MONS" -gt "1" ] ; then
-    echo
-    echo
-    echo "WARNING: \"cephadm bootstrap\" deployed more MONs than expected!"
-    echo
-    echo
-fi
-if [ "$ACTUAL_NUMBER_OF_MGRS" -gt "1" ] ; then
-    echo
-    echo
-    echo "WARNING: \"cephadm bootstrap\" deployed more MGRs than expected!"
-    echo
-    echo
-fi
-set -x
-
-ceph status
-echo "\"ceph status\" exit code: $?"
-
 {% set service_spec_core = "/root/service_spec_core.yml" %}
 rm -f {{ service_spec_core }}
 touch {{ service_spec_core }}
@@ -238,7 +79,7 @@ function number_of_osds_in_ceph_osd_tree {
 EXPECTED_NUMBER_OF_OSDS="{{ total_osds }}"
 
 set +x
-timeout_seconds="$((REASONABLE_TIMEOUT_IN_SECONDS * 2))"
+timeout_seconds="$(({{ reasonable_timeout_in_seconds }} * 2))"
 remaining_seconds="$timeout_seconds"
 interval_seconds="30"
 while true ; do
@@ -311,7 +152,7 @@ function number_of_foos_ceph_orch_ls {
 EXPECTED_NUMBER_OF_MDSS="{{ mds_nodes }}"
 
 set +x
-timeout_seconds="$REASONABLE_TIMEOUT_IN_SECONDS"
+timeout_seconds="{{ reasonable_timeout_in_seconds }}"
 remaining_seconds="$timeout_seconds"
 interval_seconds="30"
 while true ; do
@@ -410,5 +251,3 @@ ceph orch apply -i {{ service_spec_gw }}
 {% endif %} {# rgw_nodes > 0 or igw_nodes > 0 #}
 
 {% endif %} {# storage_nodes > 0 #}
-
-{% include "salt/qa_test.j2" %}

--- a/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
@@ -180,5 +180,3 @@ sleep 5
 {% endif %} {# deepsea_need_stage_4 #}
 
 echo "deployment complete!"
-
-{% include "salt/qa_test.j2" %}

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -76,6 +76,7 @@ salt-key -Ay
 {% if deployment_tool == "deepsea" %}
 {% if node == master %}
 {% include "salt/deepsea/deepsea_deployment.sh.j2" %}
+{% include "salt/qa_test.j2" %}
 {% endif %} {# node == master #}
 {% endif %} {# deployment_tool == "deepsea" #}
 
@@ -86,7 +87,11 @@ salt-key -Ay
 
 # deploy ceph cluster via ceph-salt and cephadm
 {% if deployment_tool == "cephadm" %}
-{% include "salt/ceph-salt/ceph_salt_deployment.sh.j2" %}
+{% if node == master %}
+{% include "salt/ceph-salt/deployment_day_1.sh.j2" %}
+{% include "salt/ceph-salt/deployment_day_2.sh.j2" %}
+{% include "salt/qa_test.j2" %}
+{% endif %} {# node == master #}
 {% endif %} {# deployment_tool == "cephadm" #}
 
 {% endif %} {# node == master or node == suma #}


### PR DESCRIPTION
We are distinguishing between Day 1 (bootstrapping) and Day 2, so it
makes sense to have these separate in sesdev as well.

Signed-off-by: Nathan Cutler <ncutler@suse.com>