### PR TITLE
provision.sh: trap CTRL-C as well as errors

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -14,6 +14,7 @@ function err_report {
 }
 
 # ensure Vagrant doesn't destroy the master node when the script fails
+trap 'err_report $LINENO' INT
 trap 'err_report $LINENO' ERR
 
 ls -lR /home/vagrant


### PR DESCRIPTION
Vagrant 2.2.10 has a regression where it removes the master node
(immediately) when the provisioner returns a non-zero exit status.

Return zero even on CTRL-C and, as a bonus, show the line number the
script was at when CTRL-C was pressed.

Signed-off-by: Nathan Cutler <ncutler@suse.com>