### PR TITLE
ceph-salt: deploy and smoke-test Grafana

### DIFF
--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -36,6 +36,7 @@ function usage {
     echo
     echo "Options:"
     echo "    --help                 Display this usage message"
+    echo "    --grafana-nodes        expected number of nodes with Grafana"
     echo "    --igw-nodes            expected number of nodes with iSCSI Gateway"
     echo "    --mds-nodes            expected number of nodes with MDS"
     echo "    --mgr-nodes            expected number of nodes with MGR"
@@ -44,14 +45,15 @@ function usage {
     echo "    --osd-nodes            expected number of nodes with OSD"
     echo "    --prometheus-nodes     expected number of nodes with Prometheus"
     echo "    --rgw-nodes            expected number of nodes with RGW"
-    echo "    --node-list            comma-separate list of all nodes in cluster"
+    echo "    --node-list            comma-separated list of all nodes in cluster"
+    echo "    --grafana-node-list    comma-separated list of nodes with Grafana"
     echo "    --igw-node-list        comma-separated list of nodes with iSCSI Gateway"
     echo "    --mds-node-list        comma-separated list of nodes with MDS"
     echo "    --mgr-node-list        comma-separated list of nodes with MGR"
     echo "    --mon-node-list        comma-separated list of nodes with MON"
     echo "    --nfs-node-list        comma-separated list of nodes with NFS"
     echo "    --osd-node-list        comma-separated list of nodes with OSD"
-    echo "    --prometheus-node-list comma-separated list of nodes with OSD"
+    echo "    --prometheus-node-list comma-separated list of nodes with Prometheus"
     echo "    --rgw-node-list        comma-separated list of nodes with RGW"
     echo "    --osds                 expected total number of OSDs in cluster"
     echo "    --filestore-osds       whether there are FileStore OSDs in cluster"
@@ -63,13 +65,15 @@ function usage {
 assert_enhanced_getopt
 
 TEMP=$(getopt -o h \
---long "help,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,prometheus-nodes:,prometheus-node-list:,rgw-nodes:,rgw-node-list:,osds:,filestore-osds,strict-versions,total-nodes:,node-list:" \
+--long "help,grafana-nodes:,grafana-node-list:,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,prometheus-nodes:,prometheus-node-list:,rgw-nodes:,rgw-node-list:,osds:,filestore-osds,strict-versions,total-nodes:,node-list:" \
 -n 'health-ok.sh' -- "$@") || ( echo "Terminating..." >&2 ; exit 1 )
 eval set -- "$TEMP"
 
 # set some global variables
 ADMIN_KEYRING="/etc/ceph/ceph.client.admin.keyring"
 CEPH_CONF="/etc/ceph/ceph.conf"
+GRAFANA_NODES=""
+GRAFANA_NODE_LIST=""
 IGW_NODES=""
 IGW_NODE_LIST=""
 MDS_NODES=""
@@ -95,6 +99,8 @@ NODE_LIST=""
 # process command-line options
 while true ; do
     case "$1" in
+        --grafana-nodes) shift ; GRAFANA_NODES="$1" ; shift ;;
+        --grafana-node-list) shift ; GRAFANA_NODE_LIST="$1" ; shift ;;
         --igw-nodes) shift ; IGW_NODES="$1" ; shift ;;
         --igw-node-list) shift ; IGW_NODE_LIST="$1" ; shift ;;
         --mds-nodes) shift ; MDS_NODES="$1" ; shift ;;
@@ -126,6 +132,7 @@ done
 set +e
 test "$ADMIN_KEYRING"
 test "$CEPH_CONF"
+test "$GRAFANA_NODES"
 test "$IGW_NODES"
 test "$MDS_NODES"
 test "$MGR_NODES"
@@ -134,6 +141,7 @@ test "$NFS_NODES"
 test "$OSD_NODES"
 test "$PROMETHEUS_NODES"
 test "$RGW_NODES"
+test "$GRAFANA_NODE_LIST"
 test "$IGW_NODE_LIST"
 test "$MDS_NODE_LIST"
 test "$MGR_NODE_LIST"
@@ -185,5 +193,6 @@ maybe_rgw_smoke_test
 nfs_maybe_list_objects_in_recovery_pool_test
 nfs_maybe_create_export
 nfs_maybe_mount_export_and_touch_file
-# prometheus smoke test
+# monitoring smoke tests
 prometheus_smoke_test
+grafana_smoke_test

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -466,6 +466,8 @@ class Deployment():
             'cephadm_bootstrap_node': cephadm_bootstrap_node,
             'prometheus_nodes': self.node_counts["prometheus"],
             'prometheus_node_list': ','.join(self.nodes_with_role["prometheus"]),
+            'grafana_nodes': self.node_counts["grafana"],
+            'grafana_node_list': ','.join(self.nodes_with_role["grafana"]),
             'nfs_nodes': self.node_counts["nfs"],
             'nfs_node_list': ','.join(self.nodes_with_role["nfs"]),
             'igw_nodes': self.node_counts["igw"],

--- a/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
@@ -194,6 +194,9 @@ ceph nfs cluster ls
 # https://tracker.ceph.com/issues/46606 is fixed
 ceph mgr module enable prometheus
 {% endif %} {# prometheus_nodes > 0 #}
+{% if grafana_nodes > 0 %}
+{% set deploy_monitoring = True %}
+{% endif %} {# grafana_nodes > 0 #}
 
 {% if rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring %}
 
@@ -267,6 +270,21 @@ placement:
 {% endfor %}
 EOF
 {% endif %} {# prometheus_nodes > 0 #}
+
+{% if grafana_nodes > 0 %}
+cat >> {{ service_spec_gw }} << 'EOF'
+---
+service_type: grafana
+service_id: grafana
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('grafana') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+{% endif %} {# grafana_nodes > 0 #}
 
 cat {{ service_spec_gw }}
 ceph orch apply -i {{ service_spec_gw }}

--- a/seslib/templates/salt/cluster_json.j2
+++ b/seslib/templates/salt/cluster_json.j2
@@ -29,7 +29,7 @@ SUCCESS="yes"
 for role in $ROLES_OF_THIS_NODE ; do
     REGEX=""
     [ "$role" = "storage" ] && role="osd"
-    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ] || [ "$role" = "prometheus" ]; then
+    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ] || [ "$role" = "prometheus" ] || [ "$role" = "grafana" ] ; then
         if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] ; then
             if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
@@ -61,6 +61,14 @@ for role in $ROLES_OF_THIS_NODE ; do
                 REGEX="^ceph-$FSID@prometheus.+loaded active running"
             elif [ "$VERSION_ID" = "15.1" ] ; then
                 REGEX="^prometheus\.service.+loaded active running"
+            else
+                REGEX=""
+            fi
+        elif [ "$role" = "grafana" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
+                REGEX="^ceph-$FSID@grafana.+loaded active running"
+            elif [ "$VERSION_ID" = "15.1" ] ; then
+                REGEX="^grafana-server\.service.+loaded active running"
             else
                 REGEX=""
             fi

--- a/seslib/templates/salt/qa_test.j2
+++ b/seslib/templates/salt/qa_test.j2
@@ -6,8 +6,9 @@ set -x
 {% set qa_test_script = "/home/vagrant/qa-test.sh" %}
 {%- set qa_test_cmd = "/home/vagrant/sesdev-qa/health-ok.sh"
     ~ " --total-nodes=" ~ nodes|length
-    ~ " --nfs-nodes=" ~ nfs_nodes
+    ~ " --grafana-nodes=" ~ grafana_nodes
     ~ " --igw-nodes=" ~ igw_nodes
+    ~ " --nfs-nodes=" ~ nfs_nodes
     ~ " --mds-nodes=" ~ mds_nodes
     ~ " --mgr-nodes=" ~ mgr_nodes
     ~ " --mon-nodes=" ~ mon_nodes
@@ -15,8 +16,9 @@ set -x
     ~ " --prometheus-nodes=" ~ prometheus_nodes
     ~ " --rgw-nodes=" ~ rgw_nodes
     ~ " --node-list=" ~ node_list
-    ~ " --nfs-node-list=" ~ nfs_node_list
+    ~ " --grafana-node-list=" ~ grafana_node_list
     ~ " --igw-node-list=" ~ igw_node_list
+    ~ " --nfs-node-list=" ~ nfs_node_list
     ~ " --mds-node-list=" ~ mds_node_list
     ~ " --mgr-node-list=" ~ mgr_node_list
     ~ " --mon-node-list=" ~ mon_node_list


### PR DESCRIPTION
With this PR, nodes that have the "grafana" role will get a "grafana"
service deployed not only in {nautilus, ses6}, but in {octopus,
ses7, pacific} as well.

Fixes: https://github.com/SUSE/sesdev/issues/474
References: https://github.com/SUSE/sesdev/issues/354
Signed-off-by: Nathan Cutler <ncutler@suse.com>