### PR TITLE
Add new msgr2 secure options to sesdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The Jenkins CI tests that `sesdev` can be used to deploy a single-node Ceph
          * [octopus from filesystems:ceph:octopus&#8203;:upstream](#octopus-from-filesystemscephoctopusupstream)
          * [ses7 from Devel:Storage:7.0](#ses7-from-develstorage70)
          * [ses7 from Devel:Storage:7.0:CR](#ses7-from-develstorage70cr)
+      * [With wire encryption](#with-wire-encryption)
       * [Deploying non-SUSE environments](#deploying-non-suse-environments)
          * [Ubuntu "Bionic Beaver" 18.04](#ubuntu-bionic-beaver-1804)
    * [List existing deployments](#list-existing-deployments)
@@ -747,6 +748,35 @@ Note: The elevated priority on the `Devel:Storage:7.0:CR` repo is needed to
 ensure that the ceph package from that project gets installed even if RPM
 evaluates its version number to be lower than that of the ceph packages in the
 SES7 Product and `Devel:Storage:7.0` repos.
+
+#### With wire encryption
+
+The "octopus", "ses7", and "pacific" deployment versions can be told to use wire
+encryption (a feature of the Ceph Messenger v2), where Ceph encrypts its own
+network traffic.
+
+In order to deploy a cluster with Messenger v2 encryption, we need to
+either prioritise 'secure' over 'crc' mode, or only provide 'secure' mode.
+
+The specific ceph options used to accomplish this are:
+
+- `ms_cluster_mode`
+- `ms_service_mode`
+- `ms_client_mode`
+
+By default all of these are set to `crc secure`, which prioritises `crc`
+over full encryption (`secure`).
+
+To tell sesdev to deploy a cluster with wire encryption active, provide one of
+the following two options:
+
+`--msgr2-secure-mode`: This sets the above 3 options to just 'secure'.
+
+`--msgr2-prefer-secure`: This changes the order to `secure crc` so secure
+is prefered over crc.
+
+These only effect msgr2, so anything talking msgr1 (like the RBD and CephFS
+kernel clients) will be unencrypted.
 
 #### Deploying non-SUSE environments
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -99,6 +99,10 @@ def ceph_salt_options(func):
                      help='registry path from which to download Ceph base container image'),
         click.option('--salt/--ceph-salt', default=False,
                      help='Use "salt" (instead of "ceph-salt") to run ceph-salt formula'),
+        click.option('--msgr2-secure-mode', is_flag=True, default=False,
+                     help='enable "ms_*_mode" options to secure'),
+        click.option('--msgr2-prefer-secure', is_flag=True, default=False,
+                     help='enable "ms_*_mode" to prefer secure (change to "secure crc")'),
     ]
     return _decorator_composer(click_options, func)
 
@@ -535,6 +539,8 @@ def _gen_settings_dict(
         stop_before_run_make_check=None,
         synced_folder=None,
         username=None,
+        msgr2_secure_mode=None,
+        msgr2_prefer_secure=None,
 ):
 
     settings_dict = {}
@@ -750,6 +756,11 @@ def _gen_settings_dict(
         except ValueError as exc:
             raise OptionFormatError('--synced-folder', "src:dst", folder) from exc
     settings_dict['synced_folder'] = [folder.split(':') for folder in synced_folder]
+
+    if msgr2_secure_mode:
+        settings_dict['msgr2_secure_mode'] = True
+    if msgr2_prefer_secure:
+        settings_dict['msgr2_prefer_secure'] = True
 
     return settings_dict
 

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -528,6 +528,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'reasonable_timeout_in_seconds': Constant.REASONABLE_TIMEOUT_IN_SECONDS,
             'public_network': "{}0/24".format(self.settings.public_network),
             'bootstrap_mon_ip': self.bootstrap_mon_ip,
+            'msgr2_secure_mode': self.settings.msgr2_secure_mode,
+            'msgr2_prefer_secure': self.settings.msgr2_prefer_secure,
         }
 
         scripts = {}

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -309,6 +309,16 @@ SETTINGS = {
         'help': 'VM engine to use for VM deployment. Current options [libvirt]',
         'default': 'libvirt',
     },
+    'msgr2_secure_mode': {
+        'type': bool,
+        'help': 'Set "ms_*_mode" options to "secure"',
+        'default': False,
+    },
+    'msgr2_prefer_secure': {
+        'type': bool,
+        'help': 'Prioritise secure mode over "crc" in the ms_*_mode options.',
+        'default': False,
+    },
 }
 
 

--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -81,6 +81,20 @@ ceph-salt config /cephadm_bootstrap/ceph_conf add global
 ceph-salt config /cephadm_bootstrap/ceph_conf/global set "osd crush chooseleaf type" 0
 {% endif %}
 
+{% if msgr2_secure_mode %}
+ceph-salt config /cephadm_bootstrap/ceph_conf add global
+ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_cluster_mode secure
+ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_service_mode secure
+ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_client_mode secure
+{% endif %}
+
+{% if msgr2_prefer_secure %}
+ceph-salt config /cephadm_bootstrap/ceph_conf add global
+ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_cluster_mode "secure crc"
+ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_service_mode "secure crc"
+ceph-salt config /cephadm_bootstrap/ceph_conf/global set ms_client_mode "secure crc"
+{% endif %}
+
 ceph-salt config /cephadm_bootstrap/dashboard/username set admin
 ceph-salt config /cephadm_bootstrap/dashboard/password set admin
 ceph-salt config /cephadm_bootstrap/dashboard/force_password_update disable


### PR DESCRIPTION
In order to deploy a cluster with messger v2 encryption we need to
prioritise 'secure' over 'crc' mode or only provide secure mode.
The specific ceph options are:
 - ms_cluster_mode
 - ms_service_mode
 - ms_client_mode

By default all of these are set to 'crc secure' which prioritises 'crc'
over full encryption.

NOTE: there are 3 mon specific options to the above (ms_mon_*_mode) that
by defaults already use 'secure crc' so they'll prefer secure mode first
over crc between the mon nodes when they speak msgr2. Which is awesome.
I could add an option to force mon "secure" too.

This patch adds 2 new flags that control msgr2 secure mode:

 --msgr2-secure-mode: This sets the above 3 options to just 'secure'.
 --msgr2-prefer-secure: This changes the order to 'secure crc' so secure
is prefered over crc.

These only effect msgr2, so anything talking msgr1 (like the kernel
client) will be unencrypted.

Signed-off-by: Matthew Oliver <moliver@suse.com>