### PR TITLE
ceph-salt: set some network-related config params explicitly

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -94,6 +94,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.suma = None
         self.vagrant_box = None
         self.box = Box(settings)
+        self.bootstrap_mon_ip = None
         self._populate_roles()
         self._count_roles()
         self._populate_os()
@@ -303,6 +304,9 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                     networks = ('node.vm.network :private_network, autostart: true, ip:'
                                 '"{}"').format(public_address)
 
+            if 'bootstrap' in node_roles:
+                self.bootstrap_mon_ip = public_address
+
             node = Node(name,
                         fqdn,
                         node_roles,
@@ -511,6 +515,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                 self.settings.makecheck_stop_before_run_make_check,
             'ssd': self.settings.ssd,
             'reasonable_timeout_in_seconds': Constant.REASONABLE_TIMEOUT_IN_SECONDS,
+            'public_network': "{}0/24".format(self.settings.public_network),
+            'bootstrap_mon_ip': self.bootstrap_mon_ip,
         }
 
         scripts = {}

--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -63,6 +63,7 @@ ceph-salt config /ssh/ generate
 ceph-salt config /time_server/server_hostname set {{ master.fqdn }}
 {% set external_timeserver = "pool.ntp.org" %}
 ceph-salt config /time_server/external_servers add {{ external_timeserver }}
+ceph-salt config /time_server/subnet set {{ public_network }}
 
 {% if image_path %}
 ceph-salt config /cephadm_bootstrap/ceph_image_path set {{ image_path }}
@@ -76,6 +77,7 @@ ceph-salt config /cephadm_bootstrap/ceph_conf/global set "osd crush chooseleaf t
 ceph-salt config /cephadm_bootstrap/dashboard/username set admin
 ceph-salt config /cephadm_bootstrap/dashboard/password set admin
 ceph-salt config /cephadm_bootstrap/dashboard/force_password_update disable
+ceph-salt config /cephadm_bootstrap/mon_ip set {{ bootstrap_mon_ip }}
 
 ceph-salt config ls
 ceph-salt export --pretty


### PR DESCRIPTION
When there are multiple possibilities for

    /time_server/subnet
    /cephadm_bootstrap/mon_ip

ceph-salt has no way of knowing which one is "correct", and chooses
effectively at random.

Fixes: https://github.com/SUSE/sesdev/issues/467
Signed-off-by: Nathan Cutler <ncutler@suse.com>