### PR TITLE
Add ability to use Ubuntu "Bionic Beaver" 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The Jenkins CI tests that `sesdev` can be used to deploy a single-node Ceph
          * [octopus from filesystems:ceph:octopus&#8203;:upstream](#octopus-from-filesystemscephoctopusupstream)
          * [ses7 from Devel:Storage:7.0](#ses7-from-develstorage70)
          * [ses7 from Devel:Storage:7.0:CR](#ses7-from-develstorage70cr)
+      * [Deploying non-SUSE environments](#deploying-non-suse-environments)
+         * [Ubuntu "Bionic Beaver" 18.04](#ubuntu-bionic-beaver-1804)
    * [List existing deployments](#list-existing-deployments)
    * [SSH access to a cluster](#ssh-access-to-a-cluster)
    * [Copy files into and out of a cluster](#copy-files-into-and-out-of-a-cluster)
@@ -441,8 +443,8 @@ Some caveats apply:
 3. For `octopus`, `ses7`, and `pacific`, the only roles required are `master`
    and `bootstrap`. While it is possible to stop the deployment script at
    various stages (see `sesdev create octopus --help` for details), in general
-   the deployment script will try to "do the right thing" according to the roles
-   given.
+   sesdev will try to deploy Ceph services/daemons according to the roles
+   given by the user.
 4. You can specify a node with no roles like so: `[]`
 5. Ordinarily, a node gets extra disks ("OSD disks") only when the `storage`
    role is specified. However, to facilitate deployment of "bare bone" clusters,
@@ -744,6 +746,23 @@ Note: The elevated priority on the `Devel:Storage:7.0:CR` repo is needed to
 ensure that the ceph package from that project gets installed even if RPM
 evaluates its version number to be lower than that of the ceph packages in the
 SES7 Product and `Devel:Storage:7.0` repos.
+
+#### Deploying non-SUSE environments
+
+sesdev has limited ability to deploy non-SUSE environments. Read on for details.
+
+##### Ubuntu "Bionic Beaver" 18.04
+
+Ubuntu Bionic is supported with the `octopus` deployment version. For example:
+
+```
+sesdev create octopus --os ubuntu-bionic
+sesdev create octopus --single-node --os ubuntu-bionic
+```
+
+This will create Ubuntu 18.04 VMs and bootstrap a Ceph Octopus cluster on them
+using `cephadm bootstrap`. To stop the deployment before bootstrap, give the
+`--stop-before-cephadm-bootstrap` option.
 
 ### List existing deployments
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -84,11 +84,13 @@ def deepsea_options(func):
 def ceph_salt_options(func):
     click_options = [
         click.option('--stop-before-ceph-salt-config', is_flag=True, default=False,
-                     help='Allows to stop deployment before creating ceph-salt configuration'),
+                     help='Stop deployment before creating ceph-salt configuration'),
         click.option('--stop-before-ceph-salt-apply', is_flag=True, default=False,
-                     help='Allows to stop deployment before applying ceph-salt configuration'),
+                     help='Stop deployment before applying ceph-salt configuration'),
+        click.option('--stop-before-cephadm-bootstrap', is_flag=True, default=False,
+                     help='Stop deployment before running "cephadm bootstrap"'),
         click.option('--stop-before-ceph-orch-apply', is_flag=True, default=False,
-                     help='Allows to stop deployment before applying ceph orch service spec'),
+                     help='Stop deployment before applying ceph orch service spec'),
         click.option('--ceph-salt-repo', type=str, default=None,
                      help='ceph-salt Git repo URL'),
         click.option('--ceph-salt-branch', type=str, default=None,
@@ -107,7 +109,8 @@ def common_create_options(func):
                      help='List of roles for each node. Example for two nodes: '
                           '[master, client, prometheus],[storage, mon, mgr]'),
         click.option('--os', type=click.Choice(['leap-15.1', 'leap-15.2', 'tumbleweed',
-                                                'sles-12-sp3', 'sles-15-sp1', 'sles-15-sp2']),
+                                                'sles-12-sp3', 'sles-15-sp1', 'sles-15-sp2',
+                                                'ubuntu-bionic']),
                      default=None, help='OS (open)SUSE distro'),
         click.option('--deploy/--no-deploy', default=True,
                      help="Don't run the deployment phase. Just generate the Vagrantfile"),
@@ -511,6 +514,7 @@ def _gen_settings_dict(
         ssd=None,
         stop_before_ceph_orch_apply=None,
         stop_before_ceph_salt_apply=None,
+        stop_before_cephadm_bootstrap=None,
         stop_before_ceph_salt_config=None,
         stop_before_deepsea_stage=None,
         stop_before_git_clone=None,
@@ -679,6 +683,9 @@ def _gen_settings_dict(
 
     if stop_before_ceph_salt_apply is not None:
         settings_dict['stop_before_ceph_salt_apply'] = stop_before_ceph_salt_apply
+
+    if stop_before_cephadm_bootstrap is not None:
+        settings_dict['stop_before_cephadm_bootstrap'] = stop_before_cephadm_bootstrap
 
     if stop_before_ceph_orch_apply is not None:
         settings_dict['stop_before_ceph_orch_apply'] = stop_before_ceph_orch_apply

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -55,6 +55,10 @@ class Constant():
             'repo': 'https://github.com/ceph/ceph',
             'branch': 'master',
         },
+        'ubuntu-bionic': {
+            'repo': 'https://github.com/ceph/ceph',
+            'branch': 'master',
+        },
     }
 
     METADATA_FILENAME = ".metadata"
@@ -62,6 +66,7 @@ class Constant():
     OS_ALIASED_BOXES = {
         'opensuse/Leap-15.2.x86_64': 'leap-15.2',
         'opensuse/Tumbleweed.x86_64': 'tumbleweed',
+        'generic/ubuntu1804': 'ubuntu-bionic',
     }
 
     OS_BOX_ALIASES = {v: k for k, v in OS_ALIASED_BOXES.items()}
@@ -84,6 +89,17 @@ class Constant():
         'opensuse/Leap-15.2.x86_64': 'opensuse/Leap-15.2.x86_64',
         'sles-15-sp2': 'http://download.suse.de/ibs/Virtualization:/Vagrant:/SLE-15-SP2/images/'
                        'SLES15-SP2-Vagrant.x86_64-libvirt.box',
+        'generic/ubuntu1804': 'generic/ubuntu1804',
+    }
+
+    OS_PACKAGE_MANAGER_MAPPING = {
+        'sles-12-sp3': 'zypper',
+        'sles-15-sp1': 'zypper',
+        'sles-15-sp2': 'zypper',
+        'leap-15.1': 'zypper',
+        'leap-15.2': 'zypper',
+        'tumbleweed': 'zypper',
+        'ubuntu-bionic': 'apt',
     }
 
     OS_REPOS = {
@@ -249,6 +265,7 @@ class Constant():
                 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/'
                 'openSUSE_Tumbleweed'
             ],
+            'ubuntu-bionic': [],
         },
         'pacific': {
             'leap-15.2': [

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -435,6 +435,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'sesdev_path_to_qa': Constant.PATH_TO_QA,
             'dep_id': self.dep_id,
             'os': self.settings.os,
+            'package_manager': Constant.OS_PACKAGE_MANAGER_MAPPING[self.settings.os],
             'vm_engine': self.settings.vm_engine,
             'libvirt_host': self.settings.libvirt_host,
             'libvirt_user': self.settings.libvirt_user,
@@ -457,7 +458,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'version': self.settings.version,
             'deploy_salt': bool(self.settings.version != 'makecheck' and
                                 self.settings.version != 'caasp4' and
-                                not self.suma),
+                                not self.suma and
+                                not self.settings.os.startswith('ubuntu')),
             'stop_before_stage': self.settings.stop_before_stage,
             'deployment_tool': self.settings.deployment_tool,
             'version_repos_prio': version_repos_prio,
@@ -912,6 +914,15 @@ deployment might not be completely destroyed.
                 raise RoleNotSupported('worker', self.settings.version)
             if self.node_counts['loadbalancer'] > 0:
                 raise RoleNotSupported('loadbalancer', self.settings.version)
+        # experimental Ubuntu Bionic
+        if self.settings.os == 'ubuntu-bionic':
+            if self.settings.version in ['octopus']:
+                pass  # we support
+            else:
+                raise VersionOSNotSupported(
+                                            self.settings.os,
+                                            self.settings.version
+                                            )
         # no node may have more than one of any role
         for node in self.settings.roles:
             for role in Constant.ROLES_KNOWN:

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -327,9 +327,10 @@ class VersionNotKnown(SesDevException):
 
 
 class VersionOSNotSupported(SesDevException):
-    def __init__(self, version, os):
+    def __init__(self, version, operating_system):
         super().__init__(
-            "Combination of version '{}' and OS '{}' not supported".format(version, os)
+            "sesdev does not know how to deploy \"{}\" on operating system \"{}\""
+            .format(version, operating_system)
         )
 
 

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -250,6 +250,11 @@ SETTINGS = {
         'help': 'Stops deployment before ceph-salt apply',
         'default': False,
     },
+    'stop_before_cephadm_bootstrap': {
+        'type': bool,
+        'help': 'Stops deployment before cephadm bootstrap',
+        'default': False,
+    },
     'stop_before_ceph_salt_config': {
         'type': bool,
         'help': 'Stops deployment before ceph-salt config',

--- a/seslib/templates/apt.j2
+++ b/seslib/templates/apt.j2
@@ -1,0 +1,42 @@
+# upstream.j2 (part of provision.sh.j2)
+
+# add upstream Ceph package signing key
+wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
+
+# add upstream release repo
+# (to be replaced by "cephadm add-repo", below, when
+# https://tracker.ceph.com/issues/45009 is fixed)
+{% if os == 'ubuntu-bionic' %}
+{% set codename = 'bionic' %}
+{% else %}
+echo "BADNESS: UNSUPPORTED OS {os}. Bailing out!"
+exit 0
+{% endif %} {# os == 'ubuntu-bionic' #}
+apt-add-repository 'deb https://download.ceph.com/debian-{{ version }}/ {{ codename }} main'
+
+# download cephadm source code
+curl --silent --remote-name --location https://github.com/ceph/ceph/raw/{{ version }}/src/cephadm/cephadm
+chmod +x cephadm
+
+# add upstream release repo and install "the real cephadm" from it
+# ./cephadm add-repo --release {{ version }}  # broken: see https://tracker.ceph.com/issues/45009
+
+# add Kubic project repos for podman
+source /etc/os-release
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl --silent -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | apt-key add -
+
+# update apt cache
+apt-get update
+apt-cache policy
+
+# install podman
+apt-get -y install podman
+
+# install cephadm DEB package
+./cephadm install
+which cephadm
+rm -f ./cephadm
+
+cephadm install ceph-common
+cephadm install rbd-nbd

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -54,8 +54,15 @@ hostnamectl set-hostname {{ node.name }}
 sed -i -e 's/#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf
 systemctl restart systemd-journald
 
-# zypper-related setup (tweak settings, repos, system packages)
-{% include "zypper.j2" %}
+{% if package_manager == 'zypper' %}
+{% include "zypper.j2" ignore missing %}
+{% elif package_manager == 'apt' %}
+{% include "apt.j2" ignore missing %}
+{% elif package_manager == 'yum' %}
+{% include "yum.j2" ignore missing %}
+{% elif package_manager == 'dnf' %}
+{% include "dnf.j2" ignore missing %}
+{% endif %} {# package_manager #}
 
 # sync clocks if needed
 {% include "sync_clocks.j2" %}
@@ -67,5 +74,7 @@ systemctl restart systemd-journald
 {% include "caasp/provision.sh.j2" %}
 {% elif version == 'makecheck' %}
 {% include "makecheck/provision.sh.j2" %}
-{% endif %}
+{% elif os.startswith('ubuntu') %}
+{% include "ubuntu/provision.sh.j2" %}
+{% endif %} {# deploy_salt or suma #}
 

--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -94,6 +94,12 @@ set -x
 exit 0
 {% endif %} {# stop_before_ceph_salt_apply #}
 
+{% if stop_before_cephadm_bootstrap %}
+set +x
+echo "Stopping the deployment now because --stop-before-cephadm-bootstrap option was given"
+exit 0
+{% endif %} {# stop_before_cephadm_bootstrap #}
+
 {% if use_salt %}
 salt -G 'ceph-salt:member' state.apply ceph-salt
 echo "\"salt state.apply\" exit code: $?"

--- a/seslib/templates/ubuntu/provision.sh.j2
+++ b/seslib/templates/ubuntu/provision.sh.j2
@@ -1,0 +1,12 @@
+# ubuntu/provision.sh.j2 (part of provision.sh.j2)
+
+{% if stop_before_cephadm_bootstrap %}
+set +x
+echo "Stopping the deployment before \"cephadm bootstrap\" because --stop-before-cephadm-bootstrap was given"
+exit 0
+{% endif %} {# stop_before_cephadm_bootstrap #}
+
+{% if node == master %}
+mkdir -p /etc/ceph
+cephadm bootstrap --mon-ip {{ bootstrap_mon_ip }}
+{% endif %} {# node == master #}


### PR DESCRIPTION
With this commit, one can do, e.g.:

    sesdev create octopus --os ubuntu-bionic

This will attempt to complete a Day 1 deployment (up to and including
"cephadm bootstrap") but Day 2 is not implemented yet, so sesdev roles
other than "master" and "bootstrap" are ignored in this initial
implementation.

https://github.com/SUSE/sesdev/issues/485
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

TO DO:

- [x] pass `contrib/standalone.sh`
- [x] documentation