### PR TITLE
add label for ses deployment on caasp

### DIFF
--- a/seslib/templates/caasp/master.sh.j2
+++ b/seslib/templates/caasp/master.sh.j2
@@ -190,6 +190,9 @@ rm ${MLBCONFIG}
 
 # deploy and configure rook + Ceph
 
+# add special lable to allow Rook deploy on all nodes
+kubectl label nodes --all node-role.rook-ceph/cluster=any
+
 zypper --non-interactive install rook-k8s-yaml
 cd /usr/share/k8s-yaml/rook/ceph/
 


### PR DESCRIPTION
SUSE config files need special labels for Rook deployment that were added at https://github.com/SUSE/rook/commit/0efbe62733567a41e84c6d26215e41dccbfac365 .
This PR assign `any` label to all nodes so Rook will deploy services on all nodes.