### PR TITLE
deployment: do not assert if starting an existing deployment

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -737,7 +737,8 @@ deployment might not be completely destroyed.
     def start(self, log_handler, node=None):
         if node and node not in self.nodes:
             raise NodeDoesNotExist(node)
-        assert self.vagrant_box is not None, "vagrant_box is set to None!"
+        if not self.existing:
+            assert self.vagrant_box is not None, "vagrant_box is set to None!"
         self._vagrant_up(node, log_handler)
 
     def __str__(self):


### PR DESCRIPTION
self.vagrant_box is only expected to be set when creating a new
deployment.

Fixes: https://github.com/SUSE/sesdev/issues/487
Signed-off-by: Nathan Cutler <ncutler@suse.com>