### PR TITLE
ceph-salt: deploy and smoke-test node-exporter

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -539,6 +539,8 @@ function number_of_services_expected_vs_orch_ls_test {
         orch_ls_grafanas="$(json_ses7_orch_ls grafana)"
         local orch_ls_alertmanagers
         orch_ls_alertmanagers="$(json_ses7_orch_ls alertmanager)"
+        local orch_ls_node_exporters
+        orch_ls_node_exporters="$(json_ses7_orch_ls node-exporter)"
         local success
         success="yes"
         local expected_mgrs
@@ -551,6 +553,7 @@ function number_of_services_expected_vs_orch_ls_test {
         local expected_prometheuses
         local expected_grafanas
         local expected_alertmanagers
+        local expected_node_exporters
         [ "$MGR_NODES" ] && expected_mgrs="$MGR_NODES"
         [ "$MON_NODES" ] && expected_mons="$MON_NODES"
         [ "$MDS_NODES" ] && expected_mdss="$MDS_NODES"
@@ -561,6 +564,7 @@ function number_of_services_expected_vs_orch_ls_test {
         [ "$PROMETHEUS_NODES" ] && expected_prometheuses="$PROMETHEUS_NODES"
         [ "$GRAFANA_NODES" ] && expected_grafanas="$GRAFANA_NODES"
         [ "$ALERTMANAGER_NODES" ] && expected_alertmanagers="$ALERTMANAGER_NODES"
+        [ "$NODE_EXPORTER_NODES" ] && expected_node_exporters="$NODE_EXPORTER_NODES"
         echo "MGR services (orch ls/expected): $orch_ls_mgrs/$expected_mgrs"
         if [ "$orch_ls_mgrs" = "$expected_mgrs" ] ; then
             true  # normal success case
@@ -587,6 +591,8 @@ function number_of_services_expected_vs_orch_ls_test {
         [ "$orch_ls_grafanas" = "$expected_grafanas" ] || success=""
         echo "alertmanager services (orch ls/expected): $orch_ls_alertmanagers/$expected_alertmanagers"
         [ "$orch_ls_alertmanagers" = "$expected_alertmanagers" ] || success=""
+        echo "node-manager services (orch ls/expected): $orch_ls_node_exporters/$expected_node_exporters"
+        [ "$orch_ls_node_exporters" = "$expected_node_exporters" ] || success=""
         if [ "$success" ] ; then
             echo "WWWW: number_of_services_expected_vs_orch_ls_test: OK"
             echo
@@ -623,6 +629,8 @@ function _orch_ps_test {
     orch_ps_grafanas="$(json_ses7_orch_ps grafana)"
     local orch_ps_alertmanagers
     orch_ps_alertmanagers="$(json_ses7_orch_ps alertmanager)"
+    local orch_ps_node_exporters
+    orch_ps_node_exporters="$(json_ses7_orch_ps node-exporter)"
     ## commented-out osds pending resolution of
     ## - https://bugzilla.suse.com/show_bug.cgi?id=1172791
     ## - https://github.com/SUSE/sesdev/pull/203
@@ -638,6 +646,7 @@ function _orch_ps_test {
     local expected_prometheuses
     local expected_grafanas
     local expected_alertmanagers
+    local expected_node_exporters
     [ "$MGR_NODES" ] && expected_mgrs="$MGR_NODES"
     [ "$MON_NODES" ] && expected_mons="$MON_NODES"
     [ "$MDS_NODES" ] && expected_mdss="$MDS_NODES"
@@ -648,6 +657,7 @@ function _orch_ps_test {
     [ "$PROMETHEUS_NODES" ] && expected_prometheuses="$PROMETHEUS_NODES"
     [ "$GRAFANA_NODES" ] && expected_grafanas="$GRAFANA_NODES"
     [ "$ALERTMANAGER_NODES" ] && expected_alertmanagers="$ALERTMANAGER_NODES"
+    [ "$NODE_EXPORTER_NODES" ] && expected_node_exporters="$NODE_EXPORTER_NODES"
     echo "MGR daemons (orch ps/expected): $orch_ps_mgrs/$expected_mgrs"
     if [ "$orch_ps_mgrs" = "$expected_mgrs" ] ; then
         true  # normal success case
@@ -674,6 +684,8 @@ function _orch_ps_test {
     [ "$orch_ps_grafanas" = "$expected_grafanas" ] || success=""
     echo "alertmanager daemons (orch ps/expected): $orch_ps_alertmanagers/$expected_alertmanagers"
     [ "$orch_ps_alertmanagers" = "$expected_alertmanagers" ] || success=""
+    echo "node-manager services (orch ps/expected): $orch_ps_node_exporters/$expected_node_exporters"
+    [ "$orch_ps_node_exporters" = "$expected_node_exporters" ] || success=""
     if [ "$success" ] ; then
         return 0
     else
@@ -1177,6 +1189,8 @@ function _monitoring_smoke_test {
         nodes_list="$GRAFANA_NODE_LIST"
     elif [ "$daemon_type" = "alertmanager" ] ; then
         nodes_list="$ALERTMANAGER_NODE_LIST"
+    elif [ "$daemon_type" = "node-exporter" ] ; then
+        nodes_list="$NODE_EXPORTER_NODE_LIST"
     else
         echo "_monitoring_smoke_test: badness, bailing out!"
         false
@@ -1186,7 +1200,7 @@ function _monitoring_smoke_test {
     local run_the_test="yes"
     [ -z "$nodes_list" ]       && run_the_test=""
     [ "$VERSION_ID" = "12.3" ] && run_the_test=""
-    if [ "$daemon_type" = "node-exporter" ] ; then
+    if [ "$daemon_type" = "alertmanager" ] || [ "$daemon_type" = "node-exporter" ] ; then
         [ "$VERSION_ID" = "15.1" ] && run_the_test=""
     fi
     if [ "$run_the_test" ] ; then
@@ -1203,6 +1217,8 @@ function _monitoring_smoke_test {
             default_port="3000"
         elif [ "$daemon_type" = "alertmanager" ] ; then
             default_port="9093"
+        elif [ "$daemon_type" = "node-exporter" ] ; then
+            default_port="9100"
         else
             echo "_monitoring_smoke_test: extreme badness, bailing out!"
             false
@@ -1265,4 +1281,8 @@ function grafana_smoke_test {
 
 function alertmanager_smoke_test {
     _monitoring_smoke_test "alertmanager" "title.Alertmanager"
+}
+
+function node_exporter_smoke_test {
+    _monitoring_smoke_test "node-exporter" "title.Node.Exporter"
 }

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -35,40 +35,42 @@ function usage {
     echo "  $SCRIPTNAME [-h,--help] [options as shown below]"
     echo
     echo "Options:"
-    echo "    --help                   Display this usage message"
-    echo "    --alertmanager-nodes     expected number of nodes with alertmanager"
-    echo "    --grafana-nodes          expected number of nodes with Grafana"
-    echo "    --igw-nodes              expected number of nodes with iSCSI Gateway"
-    echo "    --mds-nodes              expected number of nodes with MDS"
-    echo "    --mgr-nodes              expected number of nodes with MGR"
-    echo "    --mon-nodes              expected number of nodes with MON"
-    echo "    --nfs-nodes              expected number of nodes with NFS"
-    echo "    --osd-nodes              expected number of nodes with OSD"
-    echo "    --prometheus-nodes       expected number of nodes with Prometheus"
-    echo "    --rgw-nodes              expected number of nodes with RGW"
-    echo "    --node-list              comma-separated list of all nodes in cluster"
-    echo "    --alertmanager-node-list comma-separated list of nodes with alertmanager"
-    echo "    --grafana-node-list      comma-separated list of nodes with Grafana"
-    echo "    --igw-node-list          comma-separated list of nodes with iSCSI Gateway"
-    echo "    --mds-node-list          comma-separated list of nodes with MDS"
-    echo "    --mgr-node-list          comma-separated list of nodes with MGR"
-    echo "    --mon-node-list          comma-separated list of nodes with MON"
-    echo "    --nfs-node-list          comma-separated list of nodes with NFS"
-    echo "    --osd-node-list          comma-separated list of nodes with OSD"
-    echo "    --prometheus-node-list   comma-separated list of nodes with Prometheus"
-    echo "    --rgw-node-list          comma-separated list of nodes with RGW"
-    echo "    --osds                   expected total number of OSDs in cluster"
-    echo "    --filestore-osds         whether there are FileStore OSDs in cluster"
-    echo "    --strict-versions        Insist that daemon versions match \"ceph --version\""
-    echo "    --total-nodes            expected total number of nodes in cluster"
-    echo "    --deployment-version     deployment version (e.g. \"pacific\")"
+    echo "    --help                    Display this usage message"
+    echo "    --alertmanager-nodes      expected number of nodes with alertmanager"
+    echo "    --grafana-nodes           expected number of nodes with Grafana"
+    echo "    --igw-nodes               expected number of nodes with iSCSI Gateway"
+    echo "    --mds-nodes               expected number of nodes with MDS"
+    echo "    --mgr-nodes               expected number of nodes with MGR"
+    echo "    --mon-nodes               expected number of nodes with MON"
+    echo "    --nfs-nodes               expected number of nodes with NFS"
+    echo "    --node-exporter-nodes     expected number of nodes with node-exporter"
+    echo "    --osd-nodes               expected number of nodes with OSD"
+    echo "    --prometheus-nodes        expected number of nodes with Prometheus"
+    echo "    --rgw-nodes               expected number of nodes with RGW"
+    echo "    --node-list               comma-separated list of all nodes in cluster"
+    echo "    --alertmanager-node-list  comma-separated list of nodes with alertmanager"
+    echo "    --grafana-node-list       comma-separated list of nodes with Grafana"
+    echo "    --igw-node-list           comma-separated list of nodes with iSCSI Gateway"
+    echo "    --mds-node-list           comma-separated list of nodes with MDS"
+    echo "    --mgr-node-list           comma-separated list of nodes with MGR"
+    echo "    --mon-node-list           comma-separated list of nodes with MON"
+    echo "    --nfs-node-list           comma-separated list of nodes with NFS"
+    echo "    --node-exporter-node-list comma-separated list of nodes with node-exporter"
+    echo "    --osd-node-list           comma-separated list of nodes with OSD"
+    echo "    --prometheus-node-list    comma-separated list of nodes with Prometheus"
+    echo "    --rgw-node-list           comma-separated list of nodes with RGW"
+    echo "    --osds                    expected total number of OSDs in cluster"
+    echo "    --filestore-osds          whether there are FileStore OSDs in cluster"
+    echo "    --strict-versions         Insist that daemon versions match \"ceph --version\""
+    echo "    --total-nodes             expected total number of nodes in cluster"
+    echo "    --deployment-version      deployment version (e.g. \"pacific\")"
     exit 1
 }
 
 assert_enhanced_getopt
 
 TEMP=$(getopt -o h \
---long "help,alertmanager-nodes:,alertmanager-node-list:,grafana-nodes:,grafana-node-list:,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,osd-nodes:,osd-node-list:,prometheus-nodes:,prometheus-node-list:,rgw-nodes:,rgw-node-list:,osds:,filestore-osds,strict-versions,total-nodes:,node-list:,deployment-version:" \
+--long "help,alertmanager-nodes:,alertmanager-node-list:,grafana-nodes:,grafana-node-list:,igw-nodes:,igw-node-list:,mds-nodes:,mds-node-list:,mgr-nodes:,mgr-node-list:,mon-nodes:,mon-node-list:,nfs-nodes:,nfs-node-list:,node-exporter-nodes:,node-exporter-node-list:,osd-nodes:,osd-node-list:,prometheus-nodes:,prometheus-node-list:,rgw-nodes:,rgw-node-list:,osds:,filestore-osds,strict-versions,total-nodes:,node-list:,deployment-version:" \
 -n 'health-ok.sh' -- "$@") || ( echo "Terminating..." >&2 ; exit 1 )
 eval set -- "$TEMP"
 
@@ -89,6 +91,8 @@ MON_NODES=""
 MON_NODE_LIST=""
 NFS_NODES=""
 NFS_NODE_LIST=""
+NODE_EXPORTER_NODES=""
+NODE_EXPORTER_NODE_LIST=""
 OSD_NODES=""
 OSD_NODE_LIST=""
 PROMETHEUS_NODES=""
@@ -119,6 +123,8 @@ while true ; do
         --mon-node-list) shift ; MON_NODE_LIST="$1" ; shift ;;
         --nfs-nodes) shift ; NFS_NODES="$1" ; shift ;;
         --nfs-node-list) shift ; NFS_NODE_LIST="$1" ; shift ;;
+        --node-exporter-nodes) shift ; NODE_EXPORTER_NODES="$1" ; shift ;;
+        --node-exporter-node-list) shift ; NODE_EXPORTER_NODE_LIST="$1" ; shift ;;
         --osd-nodes) shift ; OSD_NODES="$1" ; shift ;;
         --osd-node-list) shift ; OSD_NODE_LIST="$1" ; shift ;;
         --prometheus-nodes) shift ; PROMETHEUS_NODES="$1" ; shift ;;
@@ -148,6 +154,7 @@ test "$MDS_NODES"
 test "$MGR_NODES"
 test "$MON_NODES"
 test "$NFS_NODES"
+test "$NODE_EXPORTER_NODES"
 test "$OSD_NODES"
 test "$PROMETHEUS_NODES"
 test "$RGW_NODES"
@@ -158,6 +165,7 @@ test "$MDS_NODE_LIST"
 test "$MGR_NODE_LIST"
 test "$MON_NODE_LIST"
 test "$NFS_NODE_LIST"
+test "$NODE_EXPORTER_NODE_LIST"
 test "$OSD_NODE_LIST"
 test "$PROMETHEUS_NODE_LIST"
 test "$RGW_NODE_LIST"
@@ -209,3 +217,4 @@ nfs_maybe_mount_export_and_touch_file
 prometheus_smoke_test
 grafana_smoke_test
 alertmanager_smoke_test
+node_exporter_smoke_test

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -482,6 +482,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'grafana_node_list': ','.join(self.nodes_with_role["grafana"]),
             'alertmanager_nodes': self.node_counts["alertmanager"],
             'alertmanager_node_list': ','.join(self.nodes_with_role["alertmanager"]),
+            'node_exporter_nodes': self.node_counts["node-exporter"],
+            'node_exporter_node_list': ','.join(self.nodes_with_role["node-exporter"]),
             'nfs_nodes': self.node_counts["nfs"],
             'nfs_node_list': ','.join(self.nodes_with_role["nfs"]),
             'igw_nodes': self.node_counts["igw"],

--- a/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
@@ -301,6 +301,21 @@ placement:
 EOF
 {% endif %} {# alertmanager_nodes > 0 #}
 
+{% if node_exporter_nodes > 0 %}
+cat >> {{ service_spec_gw }} << 'EOF'
+---
+service_type: node-exporter
+service_id: node-exporter
+placement:
+    hosts:
+{% for node in nodes %}
+{% if node.has_role('node-exporter') %}
+        - '{{ node.name }}'
+{% endif %}
+{% endfor %}
+EOF
+{% endif %} {# node_exporter_nodes > 0 #}
+
 cat {{ service_spec_gw }}
 ceph orch apply -i {{ service_spec_gw }}
 

--- a/seslib/templates/salt/cluster_json.j2
+++ b/seslib/templates/salt/cluster_json.j2
@@ -29,7 +29,7 @@ SUCCESS="yes"
 for role in $ROLES_OF_THIS_NODE ; do
     REGEX=""
     [ "$role" = "storage" ] && role="osd"
-    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ] || [ "$role" = "prometheus" ] || [ "$role" = "grafana" ] || [ "$role" = "alertmanager" ] ; then
+    if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] || [ "$role" = "rgw" ] || [ "$role" = "nfs" ] || [ "$role" = "igw" ] || [ "$role" = "prometheus" ] || [ "$role" = "grafana" ] || [ "$role" = "alertmanager" ] || [ "$role" = "node-exporter" ] ; then
         if [ "$role" = "mon" ] || [ "$role" = "mgr" ] || [ "$role" = "osd" ] || [ "$role" = "mds" ] ; then
             if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
                 REGEX="^ceph-$FSID@$role.+loaded active running"
@@ -75,6 +75,12 @@ for role in $ROLES_OF_THIS_NODE ; do
         elif [ "$role" = "alertmanager" ] ; then
             if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
                 REGEX="^ceph-$FSID@alertmanager.+loaded active running"
+            else
+                REGEX=""
+            fi
+        elif [ "$role" = "node-exporter" ] ; then
+            if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
+                REGEX="^ceph-$FSID@node-exporter.+loaded active running"
             else
                 REGEX=""
             fi

--- a/seslib/templates/salt/qa_test.j2
+++ b/seslib/templates/salt/qa_test.j2
@@ -10,10 +10,11 @@ set -x
     ~ " --alertmanager-nodes=" ~ alertmanager_nodes
     ~ " --grafana-nodes=" ~ grafana_nodes
     ~ " --igw-nodes=" ~ igw_nodes
-    ~ " --nfs-nodes=" ~ nfs_nodes
     ~ " --mds-nodes=" ~ mds_nodes
     ~ " --mgr-nodes=" ~ mgr_nodes
     ~ " --mon-nodes=" ~ mon_nodes
+    ~ " --nfs-nodes=" ~ nfs_nodes
+    ~ " --node-exporter-nodes=" ~ node_exporter_nodes
     ~ " --osd-nodes=" ~ storage_nodes
     ~ " --prometheus-nodes=" ~ prometheus_nodes
     ~ " --rgw-nodes=" ~ rgw_nodes
@@ -21,10 +22,11 @@ set -x
     ~ " --alertmanager-node-list=" ~ alertmanager_node_list
     ~ " --grafana-node-list=" ~ grafana_node_list
     ~ " --igw-node-list=" ~ igw_node_list
-    ~ " --nfs-node-list=" ~ nfs_node_list
     ~ " --mds-node-list=" ~ mds_node_list
     ~ " --mgr-node-list=" ~ mgr_node_list
     ~ " --mon-node-list=" ~ mon_node_list
+    ~ " --nfs-node-list=" ~ nfs_node_list
+    ~ " --node-exporter-node-list=" ~ node_exporter_node_list
     ~ " --osd-node-list=" ~ storage_node_list
     ~ " --prometheus-node-list=" ~ prometheus_node_list
     ~ " --rgw-node-list=" ~ rgw_node_list


### PR DESCRIPTION
With this PR, nodes that have the "node-exporter" role will get a
"node-exporter" service deployed. The "node-exporter" role is only
available in {octopus, ses7, pacific} (in {nautilus, ses6}, DeepSea
deploys the node-exporter together with Prometheus).

The commit also implements a node-exporter smoke test.

With this commit, sesdev can now deploy the full monitoring stack in
{octopus,ses7,pacific}.

Fixes: https://github.com/SUSE/sesdev/issues/354
Signed-off-by: Nathan Cutler <ncutler@suse.com>