### PR TITLE
[DNM] Implement "sesdev link" by adding rules to LIBVIRT_FWI chain

### DIFF
--- a/sesdev.spec
+++ b/sesdev.spec
@@ -46,6 +46,7 @@ Requires:       python3-prettytable
 Requires:       python3-pyyaml >= 3.13
 %endif
 Requires:       python3-click >= 6.7
+Requires:       python3-iptables >= 0.13.0
 Requires:       python3-pycryptodomex >= 3.4.6
 Requires:       python3-setuptools
 Requires:       vagrant > 2.2.2

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -18,6 +18,10 @@ class Constant():
 
     DEBUG = False
 
+    FEATURE = {
+        'iptables': None,
+    }
+
     IMAGE_PATHS = {
         'ses7': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
         'octopus': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph',

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -85,6 +85,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.nodes = {}
         self.node_counts = {}
         self.nodes_with_role = {}
+        self.public_network_segment = "{}0/24".format(self.settings.public_network)
         self.roles_of_nodes = {}
         for role in Constant.ROLES_KNOWN:
             self.node_counts[role] = 0
@@ -231,6 +232,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             else:
                 break
         self.settings.public_network = public_network
+        self.public_network_segment = "{}0/24".format(public_network)
 
         if self._needs_cluster_network():
             existing_networks = [dep.settings.cluster_network for dep in deps

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -111,6 +111,12 @@ class MultipleRolesPerMachineNotAllowedInCaaSP(SesDevException):
         )
 
 
+class FeatureNotAvailable(SesDevException):
+    def __init__(self, feature):
+        super(FeatureNotAvailable, self).__init__(
+            "{}: feature not available".format(feature))
+
+
 class NodeDoesNotExist(SesDevException):
     def __init__(self, node):
         super().__init__(
@@ -186,6 +192,13 @@ class NoSupportConfigTarballFound(SesDevException):
     def __init__(self, node):
         super().__init__(
             "No supportconfig tarball found on node {}".format(node)
+        )
+
+
+class NotRunningAsRoot(SesDevException):
+    def __init__(self):
+        super().__init__(
+            "You are not root. This feature requires root privileges."
         )
 
 

--- a/seslib/iptables.py
+++ b/seslib/iptables.py
@@ -1,0 +1,115 @@
+from .constant import Constant
+from .exceptions import FeatureNotAvailable
+from .log import Log
+from ipaddress import IPv4Network
+
+try:
+    # pylint: disable=import-error
+    import iptc
+    Constant.FEATURE["iptables"] = True
+except ModuleNotFoundError:
+    Constant.FEATURE["iptables"] = False
+
+
+CHAIN = "LIBVIRT_FWI"
+
+
+class IPTables():
+
+    def __init__(self):
+        if not Constant.FEATURE["iptables"]:
+            raise FeatureNotAvailable("iptables")
+        Log.info("Instantiating iptables object")
+        self.table = iptc.Table(iptc.Table.FILTER)
+        self.chain = iptc.Chain(self.table, "LIBVIRT_FWI")
+        self.all_green = False
+
+    @staticmethod
+    def cidr_to_netmask(new_style):
+        Log.debug("cidr_to_netmask: got network segment {}".format(new_style))
+        ip_addr, prefixlen = new_style.split("/")
+        Log.debug("cidr_to_netmask: split into {} and {}".format(ip_addr, prefixlen))
+        assert prefixlen == "24", \
+            "Encountered network with prefixlen other than 24! Bailing out!"
+        return "{}/255.255.255.0".format(ip_addr)
+
+    def dump_chain(self):
+        print("Chain {} with {} rules:".format(CHAIN, len(self.chain.rules)))
+        for rule in self.chain.rules:
+            print("{}".format(iptc.easy.decode_iptc_rule(rule)))
+
+    def traverse_chain(self, network1, network2):
+        Log.info("traverse_chain: Traversing {} rules in chain {}"
+                 .format(len(self.chain.rules), CHAIN)
+                )
+        self.new_rules = {
+           network1: {},
+           network2: {},
+        }
+        position = 0
+        networks_already_set = 0
+        for rule in self.chain.rules:
+            position += 1
+            decoded_rule = iptc.easy.decode_iptc_rule(rule)
+            dst_network = decoded_rule.get('dst')
+            Log.debug("traverse_chain: Examining rule {}".format(decoded_rule))
+            Log.debug("traverse_chain: Destination network is {}".format(dst_network))
+            if dst_network == network1 or dst_network == network2:
+                if decoded_rule['target'] != 'ACCEPT':
+                    continue
+                print('found a rule that looks like this: {}'.format(decoded_rule))
+                # {'dst': '10.20.134.0/24', 'out-interface': 'virbr3',
+                # 'conntrack': {'ctstate': 'RELATED,ESTABLISHED'}, 'target':
+                # 'ACCEPT', 'counters': (0, 0)}
+                assert rule.src == '0.0.0.0/0.0.0.0', \
+                    'Found rule has unexpected src property! Bailing out!'
+                assert decoded_rule['conntrack'], \
+                    'Found rule has no conntrack property! Bailing out!'
+                assert dst_network in [network1, network2], \
+                    'Found rule not one of the networks we were asked to link!  Bailing out!'
+            if dst_network == network1:
+                self.new_rules[network1]['src'] = network1
+                self.new_rules[network1]['dst'] = network2
+                self.new_rules[network1]['out-interface'] = decoded_rule['out-interface']
+                self.new_rules[network1]['position'] = position
+                if networks_already_set:
+                    position += 2
+                networks_already_set += 1
+            if dst_network == network2:
+                self.new_rules[network2]['src'] = network2
+                self.new_rules[network2]['dst'] = network1
+                self.new_rules[network2]['out-interface'] = decoded_rule['out-interface']
+                self.new_rules[network2]['position'] = position
+                if networks_already_set:
+                    position += 2
+                networks_already_set += 1
+        # number of matching rules should be 2, one for each network to be
+        # linked
+        if networks_already_set == 2:
+            self.all_green = True
+        else:
+            assert False, \
+                "Did not find matching rules for both deployments!  Bailing out!"
+        Log.info("traverse_chain: new rules {}".format(self.new_rules))
+
+    def insert_new_rules(self):
+        if self.all_green:
+            rules_already_inserted = 0
+            for ( _, data_for_new_rule) in self.new_rules.items():
+                rule = iptc.Rule()
+                rule.src = self.cidr_to_netmask(data_for_new_rule['src'])
+                rule.out_interface = data_for_new_rule['out-interface']
+                rule.dst = self.cidr_to_netmask(data_for_new_rule['dst'])
+                rule.target = iptc.Target(rule, "ACCEPT")
+                self.chain.insert_rule(rule, position=data_for_new_rule['position'])
+                rules_already_inserted += 1
+                rule = iptc.Rule()
+                rule.src = self.cidr_to_netmask(data_for_new_rule['dst'])
+                rule.out_interface = data_for_new_rule['out-interface']
+                rule.dst = self.cidr_to_netmask(data_for_new_rule['src'])
+                rule.target = iptc.Target(rule, "ACCEPT")
+                self.chain.insert_rule(rule, position=data_for_new_rule['position'])
+                rules_already_inserted += 1
+            print("Inserted {} new rules into chain {}"
+                  .format(rules_already_inserted, CHAIN)
+                 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     libvirt-python >= 5.1.0
     PrettyTable
     pycryptodomex >= 3.4.6
+    python-iptables
     PyYAML >= 3.13
 
 packages =


### PR DESCRIPTION
From the feature request:

"If I deploy two sesdev clusters the network connection between them is
forbidden on iptables level. Sometimes we need to connect the clusters
though (I needed it for testing RBD mirroring. And I can imagine it
could be useful for testing RGW multisite or CephFS snapshots sync)."

Fixes: https://github.com/SUSE/sesdev/issues/396
Signed-off-by: Nathan Cutler <ncutler@suse.com>