### PR TITLE
deployment: use "vagrant up --provision" to start cluster

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -1353,7 +1353,7 @@ def start(deployment_id, node=None):
         click.echo("Ignoring node advice because DEPLOYMENT_SPEC is a glob")
         node = None
     for dep in matching_deployments:
-        dep.start(_print_log, node)
+        dep.start(_print_log, node=node)
         click.echo("Deployment {} started!".format(dep.dep_id))
 
 

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -636,6 +636,10 @@ class Deployment():  # use Deployment.create() to create a Deployment object
 
     def _vagrant_up(self, node, log_handler):
         cmd = ["vagrant", "up"]
+        if self.existing:
+            cmd.extend(["--no-provision"])
+        else:
+            cmd.extend(["--provision"])
         if node is not None:
             cmd.append(node)
         if Constant.VAGRANT_DEBUG:


### PR DESCRIPTION
Existing sesdev deployments are assumed to have completed provisioning already.

This commit eliminates the following useless and confusing lines that
vagrant outputs for each node in the deployment:

==> node2: Machine already provisioned. Run 'vagrant provision` or use the `--provision`
==> node2: flag to force provisioning. Provisioners marked to run always will still run.

Signed-off-by: Nathan Cutler <ncutler@suse.com>