### PR TITLE
Implement "sesdev show DEP_ID --nodes-with-role=ROLE"

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,11 @@ using `cephadm bootstrap`. To stop the deployment before bootstrap, give the
 
 ### Introspect existing deployments
 
+Please note that the `sesdev status` and `sesdev show` commands take
+a `--format` option, which can be used to make the command produce JSON output
+(easily parsable by computer programs) as opposed to the default format
+(intended to be read by humans).
+
 #### List all existing deployments and their overall status
 
 ```
@@ -815,6 +820,18 @@ $ sesdev status
 $ sesdev status <deployment_id> [NODE]
 ```
 
+For example, if I want to see the status of all nodes in deployment "foo":
+
+```
+$ sesdev status foo
+```
+
+If I want to see the status of just one node3 in deployment "foo":
+
+```
+$ sesdev status foo node3
+```
+
 #### Show details of a single existing deployment
 
 ```
@@ -823,8 +840,17 @@ $ sesdev show --detail <deployment_id>
 
 #### Show roles of nodes in an existing deployment
 
+The following command provides all details of a deployment, including the roles
+of all nodes:
+
 ```
 $ sesdev show --detail <deployment_id>
+```
+
+If you need to find which node of a deployment contains role "foo", try this:
+
+```
+$ sesdev show --nodes-with-role=<role> <deployment_id>
 ```
 
 ### SSH access to a cluster

--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -323,6 +323,9 @@ if [ "$SES7" ] ; then
     # dry run
     run_cmd sesdev create ses7 --dry-run
     run_cmd sesdev --verbose create ses7 --non-interactive --roles "[admin,master,bootstrap,storage,mon,mgr]" ses7-mini
+    run_cmd sesdev --verbose show ses7-mini
+    run_cmd sesdev --verbose show --detail ses7-mini
+    run_cmd test "$(sesdev show ses7-mini --format json --nodes-with-role bootstrap | jq -r '.[0]')" = "master"
     run_cmd sesdev --verbose qa-test ses7-mini
     run_cmd sesdev --verbose destroy --non-interactive ses7-mini
     run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node ses7-1node

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -148,6 +148,14 @@ class NoExplicitRolesWithSingleNode(SesDevException):
         )
 
 
+class NoNodeWithRole(SesDevException):
+    def __init__(self, deployment_id, role):
+        super().__init__(
+            "Deployment '{}' has no node with role '{}'"
+            .format(deployment_id, role)
+        )
+
+
 class NoPrometheusGrafanaInSES5(SesDevException):
     def __init__(self):
         super().__init__(
@@ -195,6 +203,15 @@ class OptionFormatError(SesDevException):
         super().__init__(
             "Wrong format for option '{}': expected format: '{}', actual format: '{}'"
             .format(option, expected_type, value)
+        )
+
+
+class OptionNotSupportedInContext(SesDevException):
+    def __init__(self, option):
+        super().__init__(
+            "Option '{}' not supported in this context. Open a bug report if "
+            "you need this functionality."
+            .format(option)
         )
 
 
@@ -340,4 +357,11 @@ class UnsupportedVMEngine(SesDevException):
         super().__init__(
             "Unsupported VM engine ->{}<- encountered. This is a bug: please "
             "report it to the maintainers".format(engine)
+        )
+
+
+class YouMustProvide(SesDevException):
+    def __init__(self, what):
+        super().__init__(
+            "You must provide {}".format(what)
         )


### PR DESCRIPTION
This is needed to implement "ad hoc" test scripts, such as the script
for setting up and testing RGW Multisite between two sesdev clusters.

Fixes: https://github.com/SUSE/sesdev/issues/505
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

TO DO:

- [x] merge #502 
- [x] rebase this PR
- [x] document the new feature in README.md
- [x] --format=json