### PR TITLE
sesdev: handle "all" as a possible argument to box command handlers

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -356,9 +356,9 @@ def remove_box(box_name, **kwargs):
     box_obj = Box(settings)
     #
     # determine which box(es) are to be removed
-    remove_all_boxes = kwargs.get('all_boxes', False)
     boxes_to_remove = None
-    if remove_all_boxes:
+    # pylint: disable=E1101
+    if settings.all_boxes:
         boxes_to_remove = box_obj.printable_list()
     else:
         if box_name:
@@ -460,19 +460,21 @@ def create():
     """
 
 
-def _gen_box_settings_dict(libvirt_host,
-                           libvirt_user,
-                           libvirt_private_key_file,
-                           libvirt_storage_pool,
-                           libvirt_networks,
+# pylint: disable=W0622
+def _gen_box_settings_dict(libvirt_host=None,
+                           libvirt_user=None,
+                           libvirt_private_key_file=None,
+                           libvirt_storage_pool=None,
+                           libvirt_networks=None,
                            all_boxes=None,
+                           all=None,
                            non_interactive=None,
                            force=None,
                            ):
     settings_dict = {}
 
-    if all_boxes:
-        pass
+    if all_boxes or all:
+        settings_dict['all_boxes'] = True
 
     if non_interactive or force:
         settings_dict['non_interactive'] = True
@@ -497,6 +499,7 @@ def _gen_box_settings_dict(libvirt_host,
 
 def _gen_settings_dict(
         version,
+        all_boxes=None,
         bluestore=None,
         ceph_branch=None,
         ceph_repo=None,
@@ -568,6 +571,9 @@ def _gen_settings_dict(
         else:
             raise VersionNotKnown(version)
         settings_dict['roles'] = _parse_roles(roles_string)
+
+    if all_boxes is not None:
+        settings_dict['all_boxes'] = all_boxes
 
     if single_node is not None:
         settings_dict['single_node'] = single_node

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -10,6 +10,11 @@ from .log import Log
 
 SETTINGS = {
     # RESERVED KEY, DO NOT USE: 'strict'
+    'all_boxes': {
+        'type': bool,
+        'help': 'Whether all boxes should be operated upon',
+        'default': False,
+    },
     'caasp_deploy_ses': {
         'type': bool,
         'help': 'Deploy SES using rook in CaasP',


### PR DESCRIPTION
We want the argument to be "all_boxes", but with some version of Click
it ends up as "all", causing the following error:

```
~/projects/sesdev(master) » sesdev box remove leap-15.2
Traceback (most recent call last):
  File "/home/rimarques/projects/sesdev/venv/bin/sesdev", line 11, in <module>
    load_entry_point('sesdev', 'console_scripts', 'sesdev')()
  File "/home/rimarques/projects/sesdev/sesdev/__init__.py", line 41, in sesdev_main
    cli(prog_name='sesdev')
  File "/home/rimarques/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/rimarques/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/rimarques/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/rimarques/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/rimarques/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/rimarques/projects/sesdev/venv/lib/python3.8/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/rimarques/projects/sesdev/sesdev/__init__.py", line 353, in remove_box
    settings_dict = _gen_box_settings_dict(**kwargs)
TypeError: _gen_box_settings_dict() got an unexpected keyword argument 'all'
```

Fixes: https://github.com/SUSE/sesdev/issues/507
Signed-off-by: Nathan Cutler <ncutler@suse.com>