### PR TITLE
cephadm/deployment_day_2: do not provide osd service_id

### DIFF
--- a/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_2.sh.j2
@@ -40,7 +40,6 @@ EOF
 cat >> {{ service_spec_core }} << 'EOF'
 ---
 service_type: osd
-service_id: sesdev_osd_deployment
 placement:
     hosts:
 {% for node in nodes %}


### PR DESCRIPTION
The osd service is (apparently) not supposed to have a service_id.

Signed-off-by: Nathan Cutler <ncutler@suse.com>