### PR TITLE
qa: wait for grafanas to show up before counting them

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -449,6 +449,23 @@ function maybe_wait_for_igws_test {
     fi
 }
 
+function maybe_wait_for_grafanas_test {
+    if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
+        local expected_grafanas="$1"
+        echo
+        echo "WWWW: maybe_wait_for_grafanas_test"
+        if [ "$expected_grafanas" -gt "0" ] ; then
+            _wait_for grafana "$expected_grafanas"
+            echo "WWWW: maybe_wait_for_grafanas_test: OK"
+            echo
+        else
+            echo "No Grafanas expected: nothing to wait for."
+            echo "WWWW: maybe_wait_for_grafanas_test: SKIPPED"
+            echo
+        fi
+    fi
+}
+
 function mgr_is_available_test {
     echo
     echo "WWWW: mgr_is_available_test"

--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -187,11 +187,12 @@ ceph_daemon_versions_test "$STRICT_VERSIONS"
 
 # wait for deployed daemons to show up and cluster to reach HEALTH_OK
 mgr_is_available_test
-maybe_wait_for_osd_nodes_test "$OSD_NODES"  # it might take a long time for OSD nodes to show up
-maybe_wait_for_mdss_test "$MDS_NODES"  # it might take a long time for MDSs to be ready
-maybe_wait_for_rgws_test "$RGW_NODES"  # it might take a long time for RGWs to be ready
-maybe_wait_for_nfss_test "$NFS_NODES"  # it might take a long time for NFSs to be ready
-maybe_wait_for_igws_test "$IGW_NODES"  # it might take a long time for NFSs to be ready
+maybe_wait_for_osd_nodes_test "$OSD_NODES"
+maybe_wait_for_mdss_test "$MDS_NODES"
+maybe_wait_for_rgws_test "$RGW_NODES"
+maybe_wait_for_nfss_test "$NFS_NODES"
+maybe_wait_for_igws_test "$IGW_NODES"
+maybe_wait_for_grafanas_test "$GRAFANA_NODES"
 ceph_health_test
 
 # check that OSDs have the expected objectstore


### PR DESCRIPTION
As we know, cephadm deployments are asynchronous. In practice, this
means you issue a "ceph orch apply" command and it returns quickly,
but you have to wait for the results.

Until now, the preceding IGW wait took long enough that any remaining
daemons got deployed in the meantime. But recently we saw the following
failure in the Jenkins CI environment:

    master: WWWW: number_of_services_expected_vs_orch_ls_test
    master: MGR services (orch ls/expected): 1/1
    master: MON services (orch ls/expected): 1/1
    master: MDS services (orch ls/expected): 1/1
    master: RGW services (orch ls/expected): 1/1
    master: NFS services (orch ls/expected): 1/1
    master: IGW services (orch ls/expected): 1/1
    master: Prometheus services (orch ls/expected): 1/1
    master: Grafana services (orch ls/expected): 0/1
    master: alertmanager services (orch ls/expected): 1/1
    master: node-manager services (orch ls/expected): 1/1
    master: ERROR: Detected disparity between expected number of services and "ceph orch ls"!
    master: WWWW: number_of_services_expected_vs_orch_ls_test: FAIL

which we address by adding a grafana wait to the existing list of waits.

Signed-off-by: Nathan Cutler <ncutler@suse.com>