### PR TITLE
Make "sesdev box list" and "sesdev box remove" accept globs

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -10,7 +10,7 @@ from prettytable import PrettyTable
 import click
 import pkg_resources
 
-from seslib.box import Box
+from sesdev.box import box_list_handler, box_remove_handler
 from seslib.constant import Constant
 from seslib.deployment import Deployment
 from seslib.exceptions import \
@@ -316,139 +316,6 @@ $ sesdev create octopus --roles="[master, mon, mgr], \\
 
 
 @cli.group()
-def box():
-    """
-    Commands for manipulating Vagrant Boxes
-    """
-
-
-@box.command(name='list')
-@libvirt_options
-def list_boxes(**kwargs):
-    """
-    List all Vagrant Boxes installed in the system.
-    """
-    settings_dict = _gen_box_settings_dict(**kwargs)
-    settings = Settings(**settings_dict)
-    box_obj = Box(settings)
-    box_names = box_obj.printable_list()
-    if box_names:
-        click.echo("List of all Vagrant Boxes installed in the system")
-        click.echo("-------------------------------------------------")
-    for box_name in box_names:
-        click.echo(box_name)
-
-
-@box.command(name='remove')
-@click.argument('box_name', required=False)
-@libvirt_options
-@click.option('--non-interactive', '-n', '--force', '-f',
-              is_flag=True,
-              help='Allow to remove Vagrant Box(es) without user confirmation',
-              )
-@click.option('--all-boxes', '--all', is_flag=True, help='Remove all Vagrant Boxes in the system')
-def remove_box(box_name, **kwargs):
-    """
-    Remove a Vagrant Box installed in the system by sesdev.
-
-    This involves first removing the corresponding image from the libvirt
-    storage pool, and then running 'vagrant box remove' on it.
-    """
-    settings_dict = _gen_box_settings_dict(**kwargs)
-    interactive = not settings_dict.get('non_interactive', False)
-    settings = Settings(**settings_dict)
-    box_obj = Box(settings)
-    #
-    # determine which box(es) are to be removed
-    remove_all_boxes = kwargs.get('all_boxes', False)
-    boxes_to_remove = None
-    if remove_all_boxes:
-        boxes_to_remove = box_obj.printable_list()
-    else:
-        if box_name:
-            if not box_obj.exists(box_name):
-                # but it might be an alias
-                if box_name in Constant.OS_BOX_ALIASES:
-                    dealiased_box_name = Constant.OS_BOX_ALIASES[box_name]
-                    if box_obj.exists(dealiased_box_name):
-                        box_name = dealiased_box_name
-                    else:
-                        raise BoxDoesNotExist(box_name)
-                else:
-                    raise BoxDoesNotExist(box_name)
-            boxes_to_remove = [box_name]
-        else:
-            raise RemoveBoxNeedsBoxNameOrAllOption
-    box_word = None
-    if boxes_to_remove:
-        box_word = _box_singular_or_plural(boxes_to_remove)
-    else:
-        return None
-    if interactive:
-        if boxes_to_remove:
-            click.echo("You have asked to remove the following Vagrant Boxes")
-            click.echo("----------------------------------------------------")
-            for box_to_remove in boxes_to_remove:
-                click.echo(box_to_remove)
-            click.echo()
-        really_want_to = click.confirm(
-            'Do you really want to remove {} {}'.format(len(boxes_to_remove), box_word),
-            default=True,
-        )
-        if not really_want_to:
-            raise click.Abort()
-    #
-    # remove the boxes
-    deps = Deployment.list(True)
-    problems_encountered = False
-    boxes_removed_count = 0
-    for box_being_removed in boxes_to_remove:
-        Log.info("Attempting to remove Vagrant Box ->{}<- ...".format(box_being_removed))
-        #
-        # existing deployments might be using this box
-        existing_deployments = []
-        for dep in deps:
-            if box_being_removed == dep.settings.os:
-                existing_deployments.append(dep.dep_id)
-        if existing_deployments:
-            if len(existing_deployments) == 1:
-                Log.warning("The following deployment is already using Vagrant Box ->{}<-:"
-                            .format(box_being_removed)
-                            )
-            else:
-                Log.warning("The following deployments are already using Vagrant Box ->{}<-:"
-                            .format(box_being_removed)
-                            )
-            for dep_id in existing_deployments:
-                Log.warning("        {}".format(dep_id))
-            click.echo()
-            if len(existing_deployments) == 1:
-                Log.warning("It must be destroyed first!")
-            else:
-                Log.warning("These must be destroyed first!")
-            problems_encountered = True
-            continue
-        image_to_remove = box_obj.get_image_by_box(box_being_removed)
-        if image_to_remove:
-            Log.info("Found related image ->{}<- in libvirt storage pool"
-                     .format(image_to_remove))
-            box_obj.remove_image(image_to_remove)
-            Log.info("Libvirt image removed.")
-        box_obj.remove_box(box_being_removed)
-        Log.info("Vagrant Box ->{}<- removed.".format(box_being_removed))
-        boxes_removed_count += 1
-    if boxes_removed_count != 1:
-        click.echo("{} Vagrant Boxes were removed".format(boxes_removed_count))
-    if problems_encountered:
-        Log.warning("sesdev tried to remove {} Vagrant Box(es), but "
-                    "problems were encountered."
-                    .format(len(boxes_to_remove))
-                    )
-        click.echo("Use \"sesdev box list\" to check current state")
-    return None
-
-
-@cli.group()
 def create():
     """
     Creates a new Vagrant based SES cluster.
@@ -462,41 +329,6 @@ def create():
 
     $ sesdev create <command> --help
     """
-
-
-def _gen_box_settings_dict(libvirt_host,
-                           libvirt_user,
-                           libvirt_private_key_file,
-                           libvirt_storage_pool,
-                           libvirt_networks,
-                           all_boxes=None,
-                           non_interactive=None,
-                           force=None,
-                           ):
-    settings_dict = {}
-
-    if all_boxes:
-        pass
-
-    if non_interactive or force:
-        settings_dict['non_interactive'] = True
-
-    if libvirt_host:
-        settings_dict['libvirt_host'] = libvirt_host
-
-    if libvirt_user:
-        settings_dict['libvirt_user'] = libvirt_user
-
-    if libvirt_private_key_file:
-        settings_dict['libvirt_private_key_file'] = libvirt_private_key_file
-
-    if libvirt_storage_pool:
-        settings_dict['libvirt_storage_pool'] = libvirt_storage_pool
-
-    if libvirt_networks:
-        settings_dict['libvirt_networks'] = libvirt_networks
-
-    return settings_dict
 
 
 def _gen_settings_dict(
@@ -1045,12 +877,6 @@ def _maybe_glob_deps(deployment_id):
     return matching_deployments
 
 
-def _box_singular_or_plural(an_iterable):
-    if len(an_iterable) == 1:
-        return "Vagrant Box"
-    return "Vagrant Boxes"
-
-
 def _cluster_singular_or_plural(an_iterable):
     if len(an_iterable) == 1:
         return "cluster"
@@ -1082,6 +908,40 @@ def add_repo(deployment_id, **kwargs):
             priority=Constant.ZYPPER_PRIO_ELEVATED if kwargs['repo_priority'] else None
         )
     dep.add_repo_subcommand(custom_repo, kwargs['update'], _print_log)
+
+
+@cli.group()
+def box():
+    """
+    Commands to manipulate Vagrant Boxes
+    """
+
+
+@box.command(name='list')
+@libvirt_options
+def list_boxes(**kwargs):
+    """
+    List all Vagrant Boxes installed in the system.
+    """
+    box_list_handler(**kwargs)
+
+
+@box.command(name='remove')
+@click.argument('box_name', required=False)
+@libvirt_options
+@click.option('--non-interactive', '-n', '--force', '-f',
+              is_flag=True,
+              help='Allow to remove Vagrant Box(es) without user confirmation',
+             )
+@click.option('--all-boxes', '--all', is_flag=True, help='Remove all Vagrant Boxes in the system')
+def remove_box(box_name, **kwargs):
+    """
+    Remove a Vagrant Box installed in the system by sesdev.
+
+    This involves first removing the corresponding image from the libvirt
+    storage pool, and then running 'vagrant box remove' on it.
+    """
+    box_remove_handler(box_name, **kwargs)
 
 
 @cli.command()

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -26,7 +26,6 @@ from seslib.exceptions import \
                               OptionNotSupportedInContext, \
                               OptionNotSupportedInVersion, \
                               OptionValueError, \
-                              RemoveBoxNeedsBoxNameOrAllOption, \
                               VersionNotKnown, \
                               YouMustProvide
 from seslib.log import Log
@@ -914,25 +913,28 @@ def box():
 @libvirt_options
 def list_boxes(box_name, **kwargs):
     """
-    List all Vagrant Boxes installed in the system.
+    List Vagrant Boxes installed in the system.
+
+    When no argument is provided, lists all boxes. The optional argument can be
+    either a literal box name, a box alias, or a glob (globs match against
+    literal box names, only).
     """
     box_list_handler(box_name, **kwargs)
 
 
 @box.command(name='remove')
-@click.argument('box_name', required=False)
+@click.argument('box_name')
 @libvirt_options
 @click.option('--non-interactive', '-n', '--force', '-f',
               is_flag=True,
               help='Allow to remove Vagrant Box(es) without user confirmation',
              )
-@click.option('--all-boxes', '--all', is_flag=True, help='Remove all Vagrant Boxes in the system')
 def remove_box(box_name, **kwargs):
     """
-    Remove a Vagrant Box installed in the system by sesdev.
+    Remove one or more Vagrant Boxes that were installed in the system by sesdev.
 
-    This involves first removing the corresponding image from the libvirt
-    storage pool, and then running 'vagrant box remove' on it.
+    Takes one mandatory argument, which can be either a literal box name, a box
+    alias, or a glob (globs match against literal box names, only).
     """
     box_remove_handler(box_name, **kwargs)
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -857,17 +857,9 @@ def makecheck(deployment_id, **kwargs):
     _create_command(deployment_id, settings_dict)
 
 
-def _is_a_glob(a_string):
-    """
-    Return True or False depending on whether a_string appears to be a glob
-    """
-    pattern = re.compile(r'[\*\[\]\{\}\?]')
-    return bool(pattern.search(a_string))
-
-
 def _maybe_glob_deps(deployment_id):
     matching_deployments = None
-    if _is_a_glob(deployment_id):
+    if tools.is_a_glob(deployment_id):
         deps = Deployment.list(True)
         dep_ids = [d.dep_id for d in deps]
         matching_dep_ids = fnmatch.filter(dep_ids, deployment_id)
@@ -918,12 +910,13 @@ def box():
 
 
 @box.command(name='list')
+@click.argument('box_name', required=False)
 @libvirt_options
-def list_boxes(**kwargs):
+def list_boxes(box_name, **kwargs):
     """
     List all Vagrant Boxes installed in the system.
     """
-    box_list_handler(**kwargs)
+    box_list_handler(box_name, **kwargs)
 
 
 @box.command(name='remove')

--- a/sesdev/box.py
+++ b/sesdev/box.py
@@ -16,16 +16,17 @@ def _singular_or_plural(an_iterable):
     return "Vagrant Boxes"
 
 
-def box_list_handler(**kwargs):
+def box_list_handler(box_name, **kwargs):
+    Log.debug("box_list_handler: called with box_name ->{}<-".format(box_name))
     settings_dict = _gen_box_settings_dict(**kwargs)
     settings = Settings(**settings_dict)
     box_obj = Box(settings)
-    box_names = box_obj.printable_list()
-    if box_names:
+    list_lines = box_obj.printable_list()
+    if list_lines:
         click.echo("List of all Vagrant Boxes installed in the system")
         click.echo("-------------------------------------------------")
-    for box_name in box_names:
-        click.echo(box_name)
+    for line in list_lines:
+        click.echo(line)
 
 
 def box_remove_handler(box_name, **kwargs):

--- a/sesdev/box.py
+++ b/sesdev/box.py
@@ -1,0 +1,158 @@
+import click
+
+from seslib.box import Box
+from seslib.constant import Constant
+from seslib.deployment import Deployment
+from seslib.exceptions import \
+                              BoxDoesNotExist, \
+                              RemoveBoxNeedsBoxNameOrAllOption
+from seslib.log import Log
+from seslib.settings import Settings
+
+
+def _singular_or_plural(an_iterable):
+    if len(an_iterable) == 1:
+        return "Vagrant Box"
+    return "Vagrant Boxes"
+
+
+def box_list_handler(**kwargs):
+    settings_dict = _gen_box_settings_dict(**kwargs)
+    settings = Settings(**settings_dict)
+    box_obj = Box(settings)
+    box_names = box_obj.printable_list()
+    if box_names:
+        click.echo("List of all Vagrant Boxes installed in the system")
+        click.echo("-------------------------------------------------")
+    for box_name in box_names:
+        click.echo(box_name)
+
+
+def box_remove_handler(box_name, **kwargs):
+    settings_dict = _gen_box_settings_dict(**kwargs)
+    interactive = not settings_dict.get('non_interactive', False)
+    settings = Settings(**settings_dict)
+    box_obj = Box(settings)
+    #
+    # determine which box(es) are to be removed
+    remove_all_boxes = kwargs.get('all_boxes', False)
+    boxes_to_remove = None
+    if remove_all_boxes:
+        boxes_to_remove = box_obj.printable_list()
+    else:
+        if box_name:
+            if not box_obj.exists(box_name):
+                # but it might be an alias
+                if box_name in Constant.OS_BOX_ALIASES:
+                    dealiased_box_name = Constant.OS_BOX_ALIASES[box_name]
+                    if box_obj.exists(dealiased_box_name):
+                        box_name = dealiased_box_name
+                    else:
+                        raise BoxDoesNotExist(box_name)
+                else:
+                    raise BoxDoesNotExist(box_name)
+            boxes_to_remove = [box_name]
+        else:
+            raise RemoveBoxNeedsBoxNameOrAllOption
+    box_word = None
+    if boxes_to_remove:
+        box_word = _singular_or_plural(boxes_to_remove)
+    else:
+        return None
+    if interactive:
+        if boxes_to_remove:
+            click.echo("You have asked to remove the following Vagrant Boxes")
+            click.echo("----------------------------------------------------")
+            for box_to_remove in boxes_to_remove:
+                click.echo(box_to_remove)
+            click.echo()
+        really_want_to = click.confirm(
+            'Do you really want to remove {} {}'.format(len(boxes_to_remove), box_word),
+            default=True,
+        )
+        if not really_want_to:
+            raise click.Abort()
+    #
+    # remove the boxes
+    deps = Deployment.list(True)
+    problems_encountered = False
+    boxes_removed_count = 0
+    for box_being_removed in boxes_to_remove:
+        Log.info("Attempting to remove Vagrant Box ->{}<- ...".format(box_being_removed))
+        #
+        # existing deployments might be using this box
+        existing_deployments = []
+        for dep in deps:
+            if box_being_removed == dep.settings.os:
+                existing_deployments.append(dep.dep_id)
+        if existing_deployments:
+            if len(existing_deployments) == 1:
+                Log.warning("The following deployment is already using Vagrant Box ->{}<-:"
+                            .format(box_being_removed)
+                            )
+            else:
+                Log.warning("The following deployments are already using Vagrant Box ->{}<-:"
+                            .format(box_being_removed)
+                            )
+            for dep_id in existing_deployments:
+                Log.warning("        {}".format(dep_id))
+            click.echo()
+            if len(existing_deployments) == 1:
+                Log.warning("It must be destroyed first!")
+            else:
+                Log.warning("These must be destroyed first!")
+            problems_encountered = True
+            continue
+        image_to_remove = box_obj.get_image_by_box(box_being_removed)
+        if image_to_remove:
+            Log.info("Found related image ->{}<- in libvirt storage pool"
+                     .format(image_to_remove))
+            box_obj.remove_image(image_to_remove)
+            Log.info("Libvirt image removed.")
+        box_obj.remove_box(box_being_removed)
+        Log.info("Vagrant Box ->{}<- removed.".format(box_being_removed))
+        boxes_removed_count += 1
+    if boxes_removed_count != 1:
+        click.echo("{} Vagrant Boxes were removed".format(boxes_removed_count))
+    if problems_encountered:
+        Log.warning("sesdev tried to remove {} Vagrant Box(es), but "
+                    "problems were encountered."
+                    .format(len(boxes_to_remove))
+                    )
+        click.echo("Use \"sesdev box list\" to check current state")
+    return None
+
+
+def _gen_box_settings_dict(libvirt_host,
+                           libvirt_user,
+                           libvirt_private_key_file,
+                           libvirt_storage_pool,
+                           libvirt_networks,
+                           all_boxes=None,
+                           non_interactive=None,
+                           force=None,
+                           ):
+    settings_dict = {}
+
+    if all_boxes:
+        pass
+
+    if non_interactive or force:
+        settings_dict['non_interactive'] = True
+
+    if libvirt_host:
+        settings_dict['libvirt_host'] = libvirt_host
+
+    if libvirt_user:
+        settings_dict['libvirt_user'] = libvirt_user
+
+    if libvirt_private_key_file:
+        settings_dict['libvirt_private_key_file'] = libvirt_private_key_file
+
+    if libvirt_storage_pool:
+        settings_dict['libvirt_storage_pool'] = libvirt_storage_pool
+
+    if libvirt_networks:
+        settings_dict['libvirt_networks'] = libvirt_networks
+
+    return settings_dict

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -239,14 +239,6 @@ class ProductOptionOnlyOnSES(SesDevException):
         )
 
 
-class RemoveBoxNeedsBoxNameOrAllOption(SesDevException):
-    def __init__(self):
-        super().__init__(
-            "Either provide the name of a box to be removed or the --all option "
-            "to remove all boxes at once"
-            )
-
-
 class RoleNotKnown(SesDevException):
     def __init__(self, role):
         super().__init__(

--- a/seslib/tools.py
+++ b/seslib/tools.py
@@ -15,8 +15,10 @@ def is_a_glob(a_string):
     """
     Return True or False depending on whether a_string appears to be a glob
     """
-    pattern = re.compile(r'[\*\[\]\{\}\?]')
-    return bool(pattern.search(a_string))
+    if isinstance(a_string, str):
+        pattern = re.compile(r'[\*\[\]\{\}\?]')
+        return bool(pattern.search(a_string))
+    return False
 
 
 def run_sync(command, cwd=None):

--- a/seslib/tools.py
+++ b/seslib/tools.py
@@ -1,6 +1,7 @@
 import fcntl
 import os
 import random
+import re
 import string
 import subprocess
 import sys
@@ -8,6 +9,14 @@ import time
 
 from .exceptions import CmdException
 from .log import Log
+
+
+def is_a_glob(a_string):
+    """
+    Return True or False depending on whether a_string appears to be a glob
+    """
+    pattern = re.compile(r'[\*\[\]\{\}\?]')
+    return bool(pattern.search(a_string))
 
 
 def run_sync(command, cwd=None):

--- a/tests/test_is_a_glob.py
+++ b/tests/test_is_a_glob.py
@@ -1,12 +1,12 @@
 import pytest
 
-from sesdev import _is_a_glob
+from seslib.tools import is_a_glob
 
 
-def test_pytest_is_a_glob():
-    assert _is_a_glob("*"), "test failed"
-    assert _is_a_glob("foo*"), "test failed"
-    assert _is_a_glob("node[123]"), "test failed"
-    assert _is_a_glob("{foo,bar}"), "test failed"
-    assert not _is_a_glob("bamboozle"), "test failed"
-    assert _is_a_glob("node?"), "test failed"
+def test_pytestis_a_glob():
+    assert is_a_glob("*"), "test failed"
+    assert is_a_glob("foo*"), "test failed"
+    assert is_a_glob("node[123]"), "test failed"
+    assert is_a_glob("{foo,bar}"), "test failed"
+    assert not is_a_glob("bamboozle"), "test failed"
+    assert is_a_glob("node?"), "test failed"

--- a/tests/test_is_a_glob.py
+++ b/tests/test_is_a_glob.py
@@ -3,7 +3,7 @@ import pytest
 from seslib.tools import is_a_glob
 
 
-def test_pytestis_a_glob():
+def test_pytest_is_a_glob():
     assert is_a_glob("*"), "test failed"
     assert is_a_glob("foo*"), "test failed"
     assert is_a_glob("node[123]"), "test failed"


### PR DESCRIPTION
With this commit, "sesdev box list" and "sesdev box remove" accept
globs. In the former, the argument is optional.

Examples:

```
sesdev list                              lists all boxes (that have been downloaded)
sesdev list \*                           same as "sesdev list"
sesdev remove                            ERROR (missing mandatory argument)
sesdev remove \*                         removes all boxes
sesdev list o\*                          lists all boxes whose dealiased name starts with "o"
sesdev remove o\*                        removes all boxes whose dealiased name starts with "o"
sesdev list leap-15.2                    ("leap-15.2" is an alias) lists the dealiased box
sesdev remove leap-15.2                  ("leap-15.2" is an alias) removes the dealiased box
sesdev remove opensuse/Leap-15.2.x86_64  removes the box
```

Fixes: https://github.com/SUSE/sesdev/issues/507
Signed-off-by: Nathan Cutler <ncutler@suse.com>
