### PR TITLE
[DNM DOES NOT WORK] salt/provision.sh: set pillar root for ceph-salt-formula

### DIFF
--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -21,8 +21,9 @@ git checkout {{ ceph_salt_git_branch }}
 
 pip install --prefix /usr .
 # install ceph-salt-formula
-cp -r ceph-salt-formula/salt/* /srv/salt/
-chown -R salt:salt /srv
+mkdir -p /usr/share/ceph-salt/
+cp -r ceph-salt-formula/salt/* /usr/share/ceph-salt/
+chown -R salt:salt /usr/share/ceph-salt/
 {% else %}
 # ceph-salt-formula is installed automatically as a dependency of ceph-salt
 zypper --non-interactive install ceph-salt

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -19,7 +19,7 @@ cat /etc/salt/minion
 systemctl enable salt-minion
 systemctl start salt-minion
 
-{% endif %} {# deploy_salt #}
+{% endif %}{# deploy_salt #}
 
 touch /tmp/ready
 
@@ -30,11 +30,16 @@ zypper --non-interactive install salt-master
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
 sed -i -e '/^#/d' /etc/salt/master
 sed -i -e '/^\s*$/d' /etc/salt/master
+{% if version in ['octopus', 'ses7', 'pacific'] %}
 cat >> /etc/salt/master <<EOF
+file_roots:
+  base:
+    - /usr/share/ceph-salt
 pillar_roots:
   base:
     - /usr/share/ceph-salt
 EOF
+{% endif %}{# version in ['octopus', 'ses7', 'pacific'] #}
 
 # dump /etc/salt/master for the sake of the log
 cat /etc/salt/master
@@ -43,7 +48,7 @@ systemctl enable salt-master
 systemctl start salt-master
 sleep 5
 systemctl restart salt-minion
-{% endif %} {# node == master #}
+{% endif %}{# node == master #}
 
 set +x
 rm -f /tmp/ready-*
@@ -75,16 +80,16 @@ IPV6_CMD="ip -6 addr | grep 'scope global dynamic mngtmpaddr' | sed -e 's/.*inet
 IPV6_HOST="$(bash -c "$IPV6_CMD") {{ _node.fqdn }} {{ _node.name }}"
 {% else %}
 IPV6_HOST="$(ssh {{ _node.name }} $IPV6_CMD) {{ _node.fqdn }} {{ _node.name }}"
-{% endif %} {# _node == node #}
+{% endif %}{# _node == node #}
 {% for __node in nodes %}
 {% if __node == node %}
 echo $IPV6_HOST >> /etc/hosts
 {% else %}
 ssh {{ __node.name }} "echo \"$IPV6_HOST\" >> /etc/hosts"
-{% endif %} {# _node == node #}
+{% endif %}{# _node == node #}
 {% endfor %}
 {% endfor %}
-{% endif %} {# ipv6 #}
+{% endif %}{# ipv6 #}
 
 {% if node == master %}
 set +x
@@ -104,6 +109,6 @@ set -x
 salt-key -Ay
 
 {% include "salt/wait_for_minions.j2" %}
-{% endif %} {# node == master #}
+{% endif %}{# node == master #}
 
-{% endif %} {# node == master or node == suma #}
+{% endif %}{# node == master or node == suma #}

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -6,12 +6,27 @@
 
 {% if deploy_salt %}
 zypper --non-interactive install salt-minion
+
+# point minion at master
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
-sed -i -e '/^#/d' /etc/salt/minion
-sed -i -e '/^\s*$/d' /etc/salt/minion
 
 # change salt log level to info
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/minion
+
+# remove comments and empty lines
+sed -i -e '/^#/d' /etc/salt/minion
+sed -i -e '/^\s*$/d' /etc/salt/minion
+
+{% if version in ['octopus', 'ses7', 'pacific'] %}
+cat >> /etc/salt/minion <<EOF
+file_roots:
+  base:
+    - /usr/share/ceph-salt
+pillar_roots:
+  base:
+    - /usr/share/ceph-salt
+EOF
+{% endif %}{# version in ['octopus', 'ses7', 'pacific'] #}
 
 # dump /etc/salt/minion for the sake of the log
 cat /etc/salt/minion

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -7,6 +7,8 @@
 {% if deploy_salt %}
 zypper --non-interactive install salt-minion
 sed -i 's/^#master:.*/master: {{ master.name }}/g' /etc/salt/minion
+sed -i -e '/^#/d' /etc/salt/minion
+sed -i -e '/^\s*$/d' /etc/salt/minion
 
 # change salt log level to info
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/minion
@@ -23,6 +25,9 @@ touch /tmp/ready
 {% if node == master %}
 zypper --non-interactive install salt-master
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
+sed -i -e '/^#/d' /etc/salt/master
+sed -i -e '/^\s*$/d' /etc/salt/master
+
 systemctl enable salt-master
 systemctl start salt-master
 sleep 5

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -13,6 +13,9 @@ sed -i -e '/^\s*$/d' /etc/salt/minion
 # change salt log level to info
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/minion
 
+# dump /etc/salt/minion for the sake of the log
+cat /etc/salt/minion
+
 systemctl enable salt-minion
 systemctl start salt-minion
 
@@ -27,6 +30,9 @@ zypper --non-interactive install salt-master
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
 sed -i -e '/^#/d' /etc/salt/master
 sed -i -e '/^\s*$/d' /etc/salt/master
+
+# dump /etc/salt/master for the sake of the log
+cat /etc/salt/master
 
 systemctl enable salt-master
 systemctl start salt-master

--- a/seslib/templates/salt/provision.sh.j2
+++ b/seslib/templates/salt/provision.sh.j2
@@ -30,6 +30,11 @@ zypper --non-interactive install salt-master
 sed -i 's/^#log_level: warning/log_level: info/g' /etc/salt/master
 sed -i -e '/^#/d' /etc/salt/master
 sed -i -e '/^\s*$/d' /etc/salt/master
+cat >> /etc/salt/master <<EOF
+pillar_roots:
+  base:
+    - /usr/share/ceph-salt
+EOF
 
 # dump /etc/salt/master for the sake of the log
 cat /etc/salt/master


### PR DESCRIPTION
The whole idea of a Salt Formula is to avoid using `/srv` to enable state files to be packaged (e.g. in an RPM).

Until now, though, we were installing part of the `ceph-salt-formula` Salt Formula under `/srv`.

Stop doing that.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
