### PR TITLE
create: implement --fqdn option

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -159,7 +159,9 @@ def common_create_options(func):
         click.option('--dry-run/--no-dry-run', is_flag=True, default=False,
                      help='Dry run (do not create any VMs)'),
         click.option('--ssd', is_flag=True, default=False,
-                     help='On VMS with additional disks, make one disk non-rotational')
+                     help='On VMS with additional disks, make one disk non-rotational'),
+        click.option('--fqdn', is_flag=True, default=False,
+                     help='Make \'hostname\' command return FQDN')
     ]
     return _decorator_composer(click_options, func)
 
@@ -347,6 +349,7 @@ def _gen_settings_dict(
         domain=None,
         encrypted_osds=None,
         force=None,
+        fqdn=None,
         image_path=None,
         ipv6=None,
         libvirt_host=None,
@@ -516,6 +519,9 @@ def _gen_settings_dict(
 
     if ssd is not None:
         settings_dict['ssd'] = ssd
+
+    if fqdn is not None:
+        settings_dict['fqdn'] = fqdn
 
     if encrypted_osds is not None:
         settings_dict['encrypted_osds'] = encrypted_osds

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -531,6 +531,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'makecheck_stop_before_run_make_check':
                 self.settings.makecheck_stop_before_run_make_check,
             'ssd': self.settings.ssd,
+            'fqdn': self.settings.fqdn,
             'reasonable_timeout_in_seconds': Constant.REASONABLE_TIMEOUT_IN_SECONDS,
             'public_network': self.public_network_segment,
             'bootstrap_mon_ip': self.bootstrap_mon_ip,

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -95,6 +95,11 @@ SETTINGS = {
         'help': 'Whether --ram was given on the command line',
         'default': False,
     },
+    'fqdn': {
+        'type': bool,
+        'help': 'Whether \'hostname\' command returns FQDN or short hostname',
+        'default': False,
+    },
     'filestore_osds': {
         'type': bool,
         'help': 'Whether OSDs should be deployed with FileStore instead of BlueStore',

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -41,7 +41,11 @@ Host *
 EOF
 
 # set hostname
+{% if fqdn %}
+hostnamectl set-hostname {{ node.fqdn }}
+{% else %}
 hostnamectl set-hostname {{ node.name }}
+{% endif %}
 
 # persist the journal
 sed -i -e 's/#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf


### PR DESCRIPTION
When --fqdn is given to any "sesdev create" command:

"hostname" will return FQDN
"hostname -s" will return short hostname

Default behavior (--no-fqdn) is:

"hostname" returns short hostname
"hostname -f" returns FQDN

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

TO DO:

- [ ] `sesdev show`
- [ ] `README.md`
- [ ] `contrib/standalone.sh` (add to `ses6` block?)