### PR TITLE
Add makecheck-specific repos only in "sesdev create makecheck"

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -102,12 +102,45 @@ class Constant():
         'ubuntu-bionic': 'apt',
     }
 
+    OS_MAKECHECK_REPOS = {
+        'sles-12-sp3': {
+            'sdk': 'http://dist.suse.de/ibs/SUSE/Products/SLE-SDK/12-SP3/x86_64/product/',
+            'sdk-update': 'http://dist.suse.de/ibs/SUSE/Updates/SLE-SDK/12-SP3/x86_64/update/',
+        },
+        'sles-15-sp1': {
+            'desktop-apps': 'http://download.suse.de/ibs/SUSE/Products/'
+                            'SLE-Module-Desktop-Applications/15-SP1/x86_64/product/',
+            'desktop-apps-update': 'http://download.suse.de/ibs/SUSE/Updates/'
+                                   'SLE-Module-Desktop-Applications/15-SP1/x86_64/update/',
+            'dev-tools': 'http://dist.suse.de/ibs/SUSE/Products/'
+                         'SLE-Module-Development-Tools/15-SP1/x86_64/product/',
+            'dev-tools-update': 'http://dist.suse.de/ibs/SUSE/Products/'
+                                'SLE-Module-Development-Tools/15-SP1/x86_64/product/',
+            'workstation': 'http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/'
+                           'SLE-15-SP1-Product-WE-POOL-x86_64-Media1/',
+            'workstation-update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Product-WE/15-SP1/'
+                                  'x86_64/update/',
+        },
+        'sles-15-sp2': {
+            'desktop-apps': 'http://download.suse.de/ibs/SUSE/Products/'
+                            'SLE-Module-Desktop-Applications/15-SP2/x86_64/product/',
+            'desktop-apps-update': 'http://download.suse.de/ibs/SUSE/Updates/'
+                                   'SLE-Module-Desktop-Applications/15-SP2/x86_64/update/',
+            'dev-tools': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/'
+                         '15-SP2/x86_64/product/',
+            'dev-tools-update': 'http://download.suse.de/ibs/SUSE/Updates/'
+                                'SLE-Module-Development-Tools/15-SP2/x86_64/update/',
+            'workstation': 'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/'
+                           'SLE-15-SP2-Product-WE-POOL-x86_64-Media1/',
+            'workstation-update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Product-WE/15-SP2/'
+                                  'x86_64/update/',
+        },
+    }
+
     OS_REPOS = {
         'sles-12-sp3': {
             'base': 'http://dist.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/',
             'update': 'http://dist.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/',
-            'sdk': 'http://dist.suse.de/ibs/SUSE/Products/SLE-SDK/12-SP3/x86_64/product/',
-            'sdk-update': 'http://dist.suse.de/ibs/SUSE/Updates/SLE-SDK/12-SP3/x86_64/update/',
             'storage': 'http://dist.suse.de/ibs/SUSE/Products/Storage/5/x86_64/product/',
             'storage-update': 'http://dist.suse.de/ibs/SUSE/Updates/Storage/5/x86_64/update/'
         },
@@ -122,18 +155,6 @@ class Constant():
                            'SLE-Module-Server-Applications/15-SP1/x86_64/product/',
             'server-apps-update': 'http://download.suse.de/ibs/SUSE/Updates/'
                                   'SLE-Module-Server-Applications/15-SP1/x86_64/update/',
-            'desktop-apps': 'http://download.suse.de/ibs/SUSE/Products/'
-                            'SLE-Module-Desktop-Applications/15-SP1/x86_64/product/',
-            'desktop-apps-update': 'http://download.suse.de/ibs/SUSE/Updates/'
-                                   'SLE-Module-Desktop-Applications/15-SP1/x86_64/update/',
-            'dev-tools': 'http://dist.suse.de/ibs/SUSE/Products/'
-                         'SLE-Module-Development-Tools/15-SP1/x86_64/product/',
-            'dev-tools-update': 'http://dist.suse.de/ibs/SUSE/Products/'
-                                'SLE-Module-Development-Tools/15-SP1/x86_64/product/',
-            'workstation': 'http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/'
-                           'SLE-15-SP1-Product-WE-POOL-x86_64-Media1/',
-            'workstation-update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Product-WE/15-SP1/'
-                                  'x86_64/update/',
             'storage': 'http://download.suse.de/ibs/SUSE/Products/Storage/6/x86_64/product/',
             'storage-update': 'http://download.suse.de/ibs/SUSE/Updates/Storage/6/x86_64/update/'
         },
@@ -146,18 +167,6 @@ class Constant():
                            'SLE-Module-Server-Applications/15-SP2/x86_64/product/',
             'server-apps-update': 'http://download.suse.de/ibs/SUSE/Updates/'
                                   'SLE-Module-Server-Applications/15-SP2/x86_64/update/',
-            'desktop-apps': 'http://download.suse.de/ibs/SUSE/Products/'
-                            'SLE-Module-Desktop-Applications/15-SP2/x86_64/product/',
-            'desktop-apps-update': 'http://download.suse.de/ibs/SUSE/Updates/'
-                                   'SLE-Module-Desktop-Applications/15-SP2/x86_64/update/',
-            'dev-tools': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/'
-                         '15-SP2/x86_64/product/',
-            'dev-tools-update': 'http://download.suse.de/ibs/SUSE/Updates/'
-                                'SLE-Module-Development-Tools/15-SP2/x86_64/update/',
-            'workstation': 'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/'
-                           'SLE-15-SP2-Product-WE-POOL-x86_64-Media1/',
-            'workstation-update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Product-WE/15-SP2/'
-                                  'x86_64/update/',
             'storage7-media': 'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/'
                               'SES7/images/repo/SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/',
         },

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -97,6 +97,11 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.vagrant_box = None
         self.box = Box(settings)
         self.bootstrap_mon_ip = None
+        self.version_devel_repos = None
+        self.os_base_repos = None
+        self.ceph_salt_fetch_github_pr_heads = None
+        self.ceph_salt_fetch_github_pr_merges = None
+        self.cephadm_bootstrap_node = None
         self.__populate_roles()
         self.__count_roles()
         self.__populate_os()
@@ -387,57 +392,72 @@ class Deployment():  # use Deployment.create() to create a Deployment object
 
             self.nodes[node.name] = node
 
-    def _generate_vagrantfile(self):
+    def __set_version_devel_repos(self):
         try:
             version = self.settings.version
             os_setting = self.settings.os
-            version_repos = self.settings.version_devel_repos[version][os_setting]
+            version_devel_repos = self.settings.version_devel_repos[version][os_setting]
         except KeyError as exc:
             raise VersionOSNotSupported(self.settings.version, self.settings.os) from exc
         #
         # version_repos might contain URLs with a "magic priority prefix" -- see
         # https://github.com/SUSE/sesdev/issues/162
-        version_repos_prio = []
-        for repo in version_repos:
-            version_repos_dict = {}
+        self.version_devel_repos = []
+        for repo in version_devel_repos:
+            version_devel_repos_dict = {}
             prio_match = re.match(r'^(\d.+)!(http.*)', repo)
             if prio_match:
-                version_repos_dict = {
+                version_devel_repos_dict = {
                     "url": prio_match[2],
                     "priority": prio_match[1],
                 }
             else:
-                version_repos_dict = {
+                version_devel_repos_dict = {
                     "url": repo,
                     "priority": 0,
                 }
-            version_repos_prio.append(version_repos_dict)
-        Log.debug("generate_vagrantfile: version_repos_prio: {}"
-                  .format(version_repos_prio))
+            self.version_devel_repos.append(version_devel_repos_dict)
+        Log.debug("_set_version_devel_repos: self.version_devel_repos: {}"
+                  .format(self.version_devel_repos))
 
+    def __set_os_base_repos(self):
         if self.settings.os in self.settings.os_repos:
-            os_base_repos = list(self.settings.os_repos[self.settings.os].items())
+            self.os_base_repos = list(self.settings.os_repos[self.settings.os].items())
         else:
-            os_base_repos = []
+            self.os_base_repos = []
 
-        # detect whether we need to fetch github PRs
-        ceph_salt_fetch_github_pr_heads = False
-        ceph_salt_fetch_github_pr_merges = False
+    def __analyze_ceph_salt_github_pr_fetching(self):
+        self.ceph_salt_fetch_github_pr_heads = False
+        self.ceph_salt_fetch_github_pr_merges = False
         ceph_salt_git_branch = self.settings.ceph_salt_git_branch
         if ceph_salt_git_branch and ceph_salt_git_branch.startswith('origin/pr/'):
             Log.info("Detected special ceph-salt GitHub PR (HEAD) branch {}"
                      .format(ceph_salt_git_branch)
                      )
-            ceph_salt_fetch_github_pr_heads = True
+            self.ceph_salt_fetch_github_pr_heads = True
         elif ceph_salt_git_branch and ceph_salt_git_branch.startswith('origin/pr-merged/'):
             Log.info("Detected special ceph-salt GitHub PR (MERGE) branch {}"
                      .format(ceph_salt_git_branch)
                      )
-            ceph_salt_fetch_github_pr_merges = True
+            self.ceph_salt_fetch_github_pr_merges = True
 
-        cephadm_bootstrap_node = None
+    def __set_cephadm_bootstrap_node(self):
+        self.cephadm_bootstrap_node = None
         if self.nodes_with_role["bootstrap"]:
-            cephadm_bootstrap_node = self.nodes[self.nodes_with_role["bootstrap"][0]]
+            self.cephadm_bootstrap_node = self.nodes[self.nodes_with_role["bootstrap"][0]]
+
+    def _prepare_to_generate_vagrantfile(self):
+        """
+        Add some properties to the deployment object which are needed for new
+        deployments
+        """
+        self.__set_version_devel_repos()
+        self.__set_os_base_repos()
+        self.__analyze_ceph_salt_github_pr_fetching()
+        self.__set_cephadm_bootstrap_node()
+
+    def _generate_vagrantfile(self):
+        self._prepare_to_generate_vagrantfile()
 
         context = {
             'ssh_key_name': Constant.SSH_KEY_NAME,
@@ -457,8 +477,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'cluster_json': json.dumps({
                 "num_disks": self.settings.num_disks,
                 "roles_of_nodes": self.roles_of_nodes,
-                "cephadm_bootstrap_node": (cephadm_bootstrap_node.name if
-                                           cephadm_bootstrap_node else ''),
+                "cephadm_bootstrap_node": (self.cephadm_bootstrap_node.name if
+                                           self.cephadm_bootstrap_node else ''),
                 }, sort_keys=True, indent=4),
             'master': self.master,
             'suma': self.suma,
@@ -473,13 +493,13 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                                 not self.settings.os.startswith('ubuntu')),
             'stop_before_stage': self.settings.stop_before_stage,
             'deployment_tool': self.settings.deployment_tool,
-            'version_repos_prio': version_repos_prio,
-            'os_base_repos': os_base_repos,
+            'version_devel_repos': self.version_devel_repos,
+            'os_base_repos': self.os_base_repos,
             'devel_repo': self.settings.devel_repo,
             'core_version': self.settings.version in Constant.CORE_VERSIONS,
             'qa_test': self.settings.qa_test,
             'node_list': self.node_list,
-            'cephadm_bootstrap_node': cephadm_bootstrap_node,
+            'cephadm_bootstrap_node': self.cephadm_bootstrap_node,
             'prometheus_nodes': self.node_counts["prometheus"],
             'prometheus_node_list': ','.join(self.nodes_with_role["prometheus"]),
             'grafana_nodes': self.node_counts["grafana"],
@@ -513,8 +533,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'scc_password': self.settings.scc_password,
             'ceph_salt_git_repo': self.settings.ceph_salt_git_repo,
             'ceph_salt_git_branch': self.settings.ceph_salt_git_branch,
-            'ceph_salt_fetch_github_pr_heads': ceph_salt_fetch_github_pr_heads,
-            'ceph_salt_fetch_github_pr_merges': ceph_salt_fetch_github_pr_merges,
+            'ceph_salt_fetch_github_pr_heads': self.ceph_salt_fetch_github_pr_heads,
+            'ceph_salt_fetch_github_pr_merges': self.ceph_salt_fetch_github_pr_merges,
             'stop_before_ceph_salt_config': self.settings.stop_before_ceph_salt_config,
             'stop_before_ceph_salt_apply': self.settings.stop_before_ceph_salt_apply,
             'stop_before_ceph_orch_apply': self.settings.stop_before_ceph_orch_apply,

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -99,6 +99,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.bootstrap_mon_ip = None
         self.version_devel_repos = None
         self.os_base_repos = None
+        self.os_makecheck_repos = None
         self.ceph_salt_fetch_github_pr_heads = None
         self.ceph_salt_fetch_github_pr_merges = None
         self.cephadm_bootstrap_node = None
@@ -426,6 +427,15 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         else:
             self.os_base_repos = []
 
+    def __set_os_makecheck_repos(self):
+        if self.settings.os in self.settings.os_makecheck_repos:
+            self.os_makecheck_repos = \
+                list(
+                    self.settings.os_makecheck_repos[self.settings.os].items()
+                )
+        else:
+            self.os_makecheck_repos = []
+
     def __analyze_ceph_salt_github_pr_fetching(self):
         self.ceph_salt_fetch_github_pr_heads = False
         self.ceph_salt_fetch_github_pr_merges = False
@@ -453,6 +463,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         """
         self.__set_version_devel_repos()
         self.__set_os_base_repos()
+        self.__set_os_makecheck_repos()
         self.__analyze_ceph_salt_github_pr_fetching()
         self.__set_cephadm_bootstrap_node()
 
@@ -495,6 +506,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'deployment_tool': self.settings.deployment_tool,
             'version_devel_repos': self.version_devel_repos,
             'os_base_repos': self.os_base_repos,
+            'os_makecheck_repos': self.os_makecheck_repos,
             'devel_repo': self.settings.devel_repo,
             'core_version': self.settings.version in Constant.CORE_VERSIONS,
             'qa_test': self.settings.qa_test,

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -185,6 +185,11 @@ SETTINGS = {
         'help': 'openSUSE OS version (leap-15.1, tumbleweed, sles-12-sp3, or sles-15-sp1)',
         'default': '',
     },
+    'os_makecheck_repos': {
+        'type': dict,
+        'help': 'repos to add to VMs in "makecheck" environments',
+        'default': Constant.OS_MAKECHECK_REPOS,
+    },
     'os_repos': {
         'type': dict,
         'help': 'repos to add on all VMs of a given operating system (os)',

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -34,6 +34,13 @@ zypper --non-interactive removerepo repo-source-non-oss || true
 zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}
 
+# make check repos
+{% if version == 'makecheck' %}
+{% for os_repo_name, os_repo_url in os_makecheck_repos %}
+zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
+{% endfor %}
+{% endif %} {# version == 'makecheck' #}
+
 # devel repos
 {% set devel_repo_script = "/home/vagrant/add-devel-repo.sh" %}
 cat > {{ devel_repo_script }} << 'EOF'

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -40,8 +40,8 @@ cat > {{ devel_repo_script }} << 'EOF'
 #!/bin/bash
 [[ "$*" =~ "--update" ]] && UPDATE="yes"
 set -x
-{% set devel_repo_count = version_repos_prio|length %}
-{% for _repo in version_repos_prio %}
+{% set devel_repo_count = version_devel_repos|length %}
+{% for _repo in version_devel_repos %}
 {% set devel_repo_name = "devel-repo-" ~ loop.index %}
 zypper addrepo --refresh
 {%- if _repo.priority %}


### PR DESCRIPTION
Some of the repos that we were adding to all deployments were needed
only to support "makecheck". Having them in all deployments can mask
product bugs.

References: https://bugzilla.suse.com/show_bug.cgi?id=1177245
Signed-off-by: Nathan Cutler <ncutler@suse.com>
