### PR TITLE
constant: add missing SLE-15-SP[12] Product repos

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -147,6 +147,8 @@ class Constant():
         'sles-15-sp1': {
             'product': 'http://dist.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/'
                        'product/',
+            'product-update': 'http://dist.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/'
+                              'x86_64/update/',
             'base': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/'
                     'x86_64/product/',
             'update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/'
@@ -161,6 +163,8 @@ class Constant():
         'sles-15-sp2': {
             'product': 'http://dist.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/'
                        'product/',
+            'product-update': 'http://dist.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/'
+                              'x86_64/update/',
             'base': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/'
                     'x86_64/product/',
             'update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/'

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -159,6 +159,8 @@ class Constant():
             'storage-update': 'http://download.suse.de/ibs/SUSE/Updates/Storage/6/x86_64/update/'
         },
         'sles-15-sp2': {
+            'product': 'http://dist.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/'
+                       'product/',
             'base': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/'
                     'x86_64/product/',
             'update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/'


### PR DESCRIPTION
constant: add missing SLE-15-SP2 Product repo

We have the Product repo for SLE-15-SP1, but had inadvertently omitted
it for SLE-15-SP2.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

constant: add SLE-15-SP[12] Product Update repos

We had the Product "POOL" repos, but their "UPDATE" counterparts were
missing.

Signed-off-by: Nathan Cutler <ncutler@suse.com>