### PR TITLE
Implement "sesdev upgrade" subcommand

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -1471,3 +1471,22 @@ def tunnel(deployment_id, service=None, node=None, remote_port=None, local_port=
                        dep.dep_id)
                    )
     dep.start_port_forwarding(service, node, remote_port, local_port, local_address)
+
+
+@cli.command()
+@click.argument('deployment_id')
+@click.argument('node')
+@click.option('--devel/--product', 'devel_repos', default=True, type=bool, is_flag=True,
+              help="Upgrade to devel or product repos (default: devel)")
+@click.option('--to', 'to_version', default='octopus', type=str, show_default=True,
+              help='The local address to bind the tunnel')
+def upgrade(deployment_id, node, devel_repos, to_version):
+    """
+    What will happen when I issue this command on a node?
+    - old repositories will be wiped out
+    - new repositories will be added
+    - zypper dup
+    - reboot
+    """
+    dep = Deployment.load(deployment_id)
+    dep.upgrade(_print_log, node, devel_repos, to_version)

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -63,6 +63,13 @@ class Constant():
 
     METADATA_FILENAME = ".metadata"
 
+    OPENSUSE_REPOS = {
+        'leap-15.2': {
+            'repo-oss': 'http://download.opensuse.org/distribution/leap/15.2/repo/oss/',
+            'repo-update': 'http://download.opensuse.org/update/leap/15.2/oss/',
+        },
+    }
+
     OS_ALIASED_BOXES = {
         'opensuse/Leap-15.2.x86_64': 'leap-15.2',
         'opensuse/Tumbleweed.x86_64': 'tumbleweed',

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -352,6 +352,14 @@ class UnsupportedVMEngine(SesDevException):
         )
 
 
+class UpgradeNotSupported(SesDevException):
+    def __init__(self, from_version, to_version):
+        super().__init__(
+            "You asked to upgrade a '{}' node to '{}', but this combination "
+            "is not supported".format(from_version, to_version)
+        )
+
+
 class YouMustProvide(SesDevException):
     def __init__(self, what):
         super().__init__(

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -47,6 +47,23 @@ Vagrant.configure("2") do |config|
     node.vm.provision "add-devel-repo-and-update", type: "shell", run: "never" do |s|
       s.inline = "/home/vagrant/add-devel-repo.sh --update"
     end
+
+    node.vm.provision "upgrade-from-nautilus-to-octopus-devel", type: "shell", run: "never" do |s|
+      s.inline = "/home/vagrant/upgrade.sh --from nautilus --to octopus --devel"
+    end
+
+    node.vm.provision "upgrade-from-nautilus-to-octopus-product", type: "shell", run: "never" do |s|
+      s.inline = "/home/vagrant/upgrade.sh --from nautilus --to octopus"
+    end
+
+    node.vm.provision "upgrade-from-ses6-to-ses7-devel", type: "shell", run: "never" do |s|
+      s.inline = "/home/vagrant/upgrade.sh --from ses6 --to ses7 --devel"
+    end
+
+    node.vm.provision "upgrade-from-ses6-to-ses7-product", type: "shell", run: "never" do |s|
+      s.inline = "/home/vagrant/upgrade.sh --from ses6 --to ses7"
+    end
+
   end
 {% endfor %}
 

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -47,7 +47,7 @@ zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
 # devel repos
 {% set devel_repo_script = "/home/vagrant/add-devel-repo.sh" %}
 cat > {{ devel_repo_script }} << 'EOF'
-#!/bin/bash
+#!/bin/bash -x
 [[ "$*" =~ "--update" ]] && UPDATE="yes"
 set -x
 {% set devel_repo_count = version_devel_repos|length %}
@@ -91,6 +91,85 @@ zypper addrepo --no-gpgcheck --refresh
 {%- endif %}
  {{ _repo.url }} {{ _repo.name }}
 {% endfor %}
+
+# populate upgrade script
+{% set upgrade_script = "/home/vagrant/upgrade.sh" %}
+cat > {{ upgrade_script }} << 'EOF'
+#!/bin/bash -x
+TEMP=$(getopt -o h --long "to:,from:,devel" -n 'upgrade.sh' -- "$@") || ( echo "Terminating..." >&2 ; exit 1 )
+eval set -- "$TEMP"
+while true ; do
+    case "$1" in
+        --devel) DEVEL="--devel" ; shift ;;
+        --from) shift ; FROM_VERSION="$1" ; shift ;;
+        --to) shift ; TO_VERSION="$1" ; shift ;;
+        --) shift ; break ;;
+        *) echo "Internal error" ; exit 1 ;;
+    esac
+done
+source /etc/os-release
+if [ "$FROM_VERSION" = "nautilus" ] ; then
+    if [ "$ID" = "opensuse-leap" ] && [ "$VERSION_ID" = "15.1" ] ; then
+        echo "Upgrading from Ceph Nautilus (openSUSE Leap 15.1)"
+    else
+        echo "ID is ->$ID<-"
+        echo "VERSION_ID is ->$VERSION_ID<-"
+        echo "Does not match ->opensuse-leap<- and ->15.1<-"
+        echo "Yet we were asked to upgrade from Ceph Nautilus"
+        exit 1
+    fi
+    if [ "$TO_VERSION" = "octopus" ] ; then
+        echo "Upgrading to Ceph Octopus (openSUSE Leap 15.2)"
+    else
+        echo "TO_VERSION is ->$TO_VERSION<-"
+        echo "Does not match ->octopus<-"
+        echo "Yet we only support upgrading Nautilus to Octopus"
+        exit 1
+    fi
+elif [ "$FROM_VERSION" = "ses6" ] ; then
+    if [ "$ID" = "sles" ] && [ "$VERSION_ID" = "15.1" ] ; then
+        echo "Upgrading from SES6 (SLE-15-SP1)"
+    else
+        echo "ID is ->$ID<-"
+        echo "VERSION_ID is ->$VERSION_ID<-"
+        echo "Does not match ->sles<- and ->15.1<-"
+        echo "Yet we were asked to upgrade from SES6"
+        exit 1
+    fi
+    if [ "$TO_VERSION" = "ses7" ] ; then
+        echo "Upgrading to SES7 (SLE-15-SP2)"
+    else
+        echo "TO_VERSION is ->$TO_VERSION<-"
+        echo "Does not match ->ses7<-"
+        echo "Yet we only support upgrading SES6 to SES7"
+        exit 1
+    fi
+fi
+echo "=> clobber existing repos" > /dev/null
+cp -a /etc/zypp/repos.d /etc/zypp/repos.d.bck
+rm -f /etc/zypp/repos.d/*
+echo "=> add os repos for $TO_VERSION" > /dev/null
+{% for os_repo_name, os_repo_url in os_upgrade_repos %}
+zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
+{% endfor %}
+echo "=> add devel repos for $TO_VERSION" > /dev/null
+if [ "$DEVEL" ] ; then
+{% set devel_repo_count = upgrade_devel_repos|length %}
+{% for _repo in upgrade_devel_repos %}
+{% set devel_repo_name = "devel-repo-" ~ loop.index %}
+    zypper addrepo --refresh {{ _repo }} {{ devel_repo_name }}
+{% endfor %}
+fi
+echo "=> refresh local metadata cache" > /dev/null
+zypper --non-interactive --no-gpg-checks refresh
+echo "=> dist-upgrade" > /dev/null
+zypper dist-upgrade \
+    --allow-vendor-change \
+    --auto-agree-with-licenses \
+    --no-confirm
+EOF
+chmod 755 {{ upgrade_script }}
+cat {{ upgrade_script }}
 
 # SUSE:CA repo on SLE
 {% if os.startswith("sle") %}


### PR DESCRIPTION
In its current form, this command only supports the following configurations:

* nautilus -> octopus
* ses6 -> ses7

The command takes both a DEP_ID and a NODE. It upgrades only one node, not an
entire cluster!

What will happen when I issue this command?

* old repositories will be wiped out
* new repositories will be added
* zypper dup

Fixes: https://github.com/SUSE/sesdev/issues/527
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

TO DO:

- [x] https://github.com/SUSE/sesdev/pull/530 merged
- [x] this PR rebased
