### PR TITLE
exceptions: have SesDevException return optional exit code

### DIFF
--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -1,5 +1,14 @@
 class SesDevException(Exception):
-    pass
+
+    def __init__(self, message, code=None):
+        self.message = message
+        self.code = code
+        super().__init__(self.code)
+
+    def __str__(self):
+        if self.code is None:
+            return self.message
+        return "{} (code: {})".format(self.message, self.code)
 
 
 class AddRepoNoUpdateWithExplicitRepo(SesDevException):
@@ -295,6 +304,14 @@ class SettingTypeError(SesDevException):
         super().__init__(
             "Wrong value type for setting '{}': expected type: '{}', actual value='{}' ('{}')"
             .format(setting, expected_type, value, type(value))
+        )
+
+
+class SSHCommandReturnedNonZero(SesDevException):
+    def __init__(self, exitcode):
+        super().__init__(
+            "SSH command returned non-zero exit code",
+            code=exitcode
         )
 
 


### PR DESCRIPTION
The exit code is optional, but we guarantee it is always there
in the args list of the Exception object.

When the code is present, have the sesdev entrypoint return it
to the calling shell.

Fixes: https://github.com/SUSE/sesdev/issues/537
Signed-off-by: Nathan Cutler <ncutler@suse.com>