### PR TITLE
deployment: wait for rebooted node to complete boot sequence

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -30,6 +30,7 @@ from .exceptions import \
                         NoStorageRolesCephadm, \
                         NoSupportConfigTarballFound, \
                         ProductOptionOnlyOnSES, \
+                        RebootDidNotSucceed, \
                         RoleNotKnown, \
                         RoleNotSupported, \
                         ScpInvalidSourceOrDestination, \
@@ -722,13 +723,12 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             seconds_to_wait -= interval_seconds
             if seconds_to_wait <= 0:
                 log_handler("ERROR: node '{}' did not come back from reboot!\n".format(node))
-                return False
+                raise RebootDidNotSucceed(node, self.dep_id)
             log_handler("=> waiting up to {} more seconds for node '{}' to come back from reboot\n"
                         .format(seconds_to_wait, node)
                        )
             time.sleep(interval_seconds)
         log_handler("=> node '{}' is back from reboot!\n".format(node))
-        return True
 
     def destroy(self, log_handler, destroy_networks=False):
 

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -709,7 +709,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         ssh_cmd = ("bash -x -c 'reboot'",)
         retval = self.ssh(node, ssh_cmd)
         log_handler("=> interactive SSH command returned {}\n".format(retval))
-        seconds_to_wait = 300
+        seconds_to_wait = 600
         log_handler("=> waiting up to {} seconds for node '{}' to come back from reboot\n"
                     .format(seconds_to_wait, node)
                    )
@@ -729,6 +729,25 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                        )
             time.sleep(interval_seconds)
         log_handler("=> node '{}' is back from reboot!\n".format(node))
+        seconds_to_wait = 600
+        log_handler("=> waiting up to {} seconds for node '{}' to finish booting\n"
+                    .format(seconds_to_wait, node)
+                   )
+        while True:
+            ssh_cmd = ("bash -x -c 'systemctl is-system-running'",)
+            retval = self.ssh(node, ssh_cmd)
+            if retval == 0:
+                break
+            log_handler("=> interactive SSH command returned {}\n".format(retval))
+            seconds_to_wait -= interval_seconds
+            if seconds_to_wait <= 0:
+                log_handler("ERROR: node '{}' did not complete boot sequence!\n".format(node))
+                raise RebootDidNotSucceed(node, self.dep_id)
+            log_handler("=> waiting up to {} more seconds for node '{}' to finish booting\n"
+                        .format(seconds_to_wait, node)
+                       )
+            time.sleep(interval_seconds)
+        log_handler("=> node '{}' completed boot sequence!\n".format(node))
 
     def destroy(self, log_handler, destroy_networks=False):
 

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -239,6 +239,14 @@ class ProductOptionOnlyOnSES(SesDevException):
         )
 
 
+class RebootDidNotSucceed(SesDevException):
+    def __init__(self, node, deployment_id):
+        super().__init__(
+            "Attempted to reboot node '{}' of deployment '{}', but ran into problems"
+            .format(node, deployment_id)
+        )
+
+
 class RoleNotKnown(SesDevException):
     def __init__(self, role):
         super().__init__(


### PR DESCRIPTION
deployment: raise exception when node does not come back from reboot

This part was overlooked in the rush to merge
0b2feb96c07428d28b54dd1ff471d3424ddb7181

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

deployment: wait for rebooted node to complete boot sequence

Once we regain SSH access, poll "systemctl is-system-running" until it
starts to succeed. This makes it more likely that the "sesdev reboot"
command won't return until the VM has really finished booting up.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
