### PR TITLE
provision.sh: add helper_scripts Jinja template

### DIFF
--- a/seslib/templates/helper_scripts.j2
+++ b/seslib/templates/helper_scripts.j2
@@ -1,0 +1,31 @@
+
+# populate helper scripts
+{% set is_os_script = "/home/vagrant/is_os.sh" %}
+cat > {{ is_os_script }} << 'EOF'
+#!/bin/bash -e
+[[ "$*" =~ "sles-15.2" ]] && OS="sles-15.2"
+[[ "$*" =~ "sles-15.1" ]] && OS="sles-15.1"
+[[ "$*" =~ "leap-15.2" ]] && OS="leap-15.2"
+[[ "$*" =~ "leap-15.1" ]] && OS="leap-15.1"
+if [ -z "$OS" ] ; then
+    echo "is_os.sh: ERROR: unsupported OS"
+    exit 1
+fi
+
+function check_os {
+    local id_should_be="$1"
+    local version_id_should_be="$2"
+    source /etc/os-release
+    if [ "$ID" = "$id_should_be" ] && [ "$VERSION_ID" = "$version_id_should_be" ] ; then
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+[ "$OS" = "sles-15.2" ] && check_os sles 15.2
+[ "$OS" = "sles-15.1" ] && check_os sles 15.1
+[ "$OS" = "leap-15.1" ] && check_os opensuse-leap 15.1
+[ "$OS" = "leap-15.1" ] && check_os opensuse-leap 15.1
+EOF
+chmod 755 {{ is_os_script }}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -55,14 +55,14 @@ systemctl restart systemd-journald
 set +x
 echo "Stopping the deployment now because the --no-provision option was given"
 exit 0
-{% endif %} {# not provision #}
+{% endif %}{# not provision #}
 
 # if --ssd option was given, set rotational flag on first additional disk
 {% if ssd %}
 if [ -f /sys/block/vdb/queue/rotational ] ; then
     echo "0" > /sys/block/vdb/queue/rotational
 fi
-{% endif %} {# ssd #}
+{% endif %}{# ssd #}
 
 {% if package_manager == 'zypper' %}
 {% include "zypper.j2" ignore missing %}
@@ -72,7 +72,10 @@ fi
 {% include "yum.j2" ignore missing %}
 {% elif package_manager == 'dnf' %}
 {% include "dnf.j2" ignore missing %}
-{% endif %} {# package_manager == 'zypper' #}
+{% endif %}{# package_manager == 'zypper' #}
+
+# include helper scripts
+{% include "helper_scripts.j2" %}
 
 # sync clocks if needed
 {% include "sync_clocks.j2" %}
@@ -85,7 +88,7 @@ fi
 {% if node == master %}
 {% include "salt/deepsea/deepsea_deployment.sh.j2" %}
 {% include "salt/qa_test.j2" %}
-{% endif %} {# node == master #}
+{% endif %}{# node == master #}
 
 # SUMA
 {% elif suma and node == suma %}
@@ -99,7 +102,7 @@ fi
 {% include "salt/ceph-salt/deployment_day_1.sh.j2" %}
 {% include "cephadm/deployment_day_2.sh.j2" %}
 {% include "salt/qa_test.j2" %}
-{% endif %} {# node == master #}
+{% endif %}{# node == master #}
 
 # caasp4
 {% elif version == 'caasp4' %}
@@ -113,4 +116,4 @@ fi
 {% elif os.startswith('ubuntu') %}
 {% include "ubuntu/provision.sh.j2" %}
 
-{% endif %} {# end of deploy state machine #}
+{% endif %}{# end of deploy state machine #}


### PR DESCRIPTION
For upgrade testing, we need to be able to easily determine (via "sesdev ssh")
whether a node is running a particular OS.

Signed-off-by: Nathan Cutler <ncutler@suse.com>