### PR TITLE
Implement --no-apparmor option

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -164,7 +164,9 @@ def common_create_options(func):
         click.option('--ssd', is_flag=True, default=False,
                      help='On VMS with additional disks, make one disk non-rotational'),
         click.option('--fqdn', is_flag=True, default=False,
-                     help='Make \'hostname\' command return FQDN')
+                     help='Make \'hostname\' command return FQDN'),
+        click.option('--apparmor/--no-apparmor', is_flag=True, default=True,
+                     help='Enable/disable AppArmor'),
     ]
     return _decorator_composer(click_options, func)
 
@@ -337,6 +339,7 @@ def create():
 
 def _gen_settings_dict(
         version,
+        apparmor=None,
         bluestore=None,
         ceph_branch=None,
         ceph_repo=None,
@@ -612,6 +615,9 @@ def _gen_settings_dict(
         settings_dict['msgr2_secure_mode'] = True
     if msgr2_prefer_secure:
         settings_dict['msgr2_prefer_secure'] = True
+
+    if apparmor is not None:
+        settings_dict['apparmor'] = apparmor
 
     return settings_dict
 

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -589,6 +589,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'msgr2_prefer_secure': self.settings.msgr2_prefer_secure,
             'upgrade_devel_repos': self.upgrade_devel_repos,
             'os_upgrade_repos': self.os_upgrade_repos,
+            'apparmor': self.settings.apparmor,
         }
 
         scripts = {}

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -10,6 +10,11 @@ from .log import Log
 
 SETTINGS = {
     # RESERVED KEY, DO NOT USE: 'strict'
+    'apparmor': {
+        'type': bool,
+        'help': 'Enable/disable AppArmor',
+        'default': True,
+    },
     'caasp_deploy_ses': {
         'type': bool,
         'help': 'Deploy SES using rook in CaasP',

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -80,7 +80,24 @@ fi
 # sync clocks if needed
 {% include "sync_clocks.j2" %}
 
-# deploy state machine
+# apparmor
+{% if apparmor %}
+aa-status || true
+{% else %}
+aa-teardown
+echo "Possibly changing GRUB configuration to disable apparmor persistently"
+GRUB_APPARMOR_BEFORE="$(grep ^GRUB_CMDLINE_LINUX_DEFAULT /etc/default/grub)"
+sed -i -e 's/^GRUB_CMDLINE_LINUX_DEFAULT=""$/GRUB_CMDLINE_LINUX_DEFAULT="apparmor=0"/' /etc/default/grub
+GRUB_APPARMOR_AFTER="$(grep ^GRUB_CMDLINE_LINUX_DEFAULT /etc/default/grub)"
+if [ "$GRUB_APPARMOR_AFTER" ] && [ "$GRUB_APPARMOR_BEFORE" != "$GRUB_APPARMOR_AFTER" ] ; then
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+else
+    echo "GRUB configuration did not change; not persisting it"
+fi
+aa-status || true
+{% endif %}{# apparmor #}
+
+# deployment state machine
 
 # DeepSea
 {% if deploy_salt and deployment_tool == "deepsea" %}

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -202,6 +202,8 @@ zypper --non-interactive install --from update --force libncurses5 libncurses6
        'man',
        'command-not-found',
        'bc',
+       'apparmor-utils',
+       'apparmor-parser',
    ] %}
 {% if os == 'sles-12-sp3' %}
 zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} ntp


### PR DESCRIPTION
Until now, if AppArmor was active in the VM image, sesdev gave you no
way of deactivating it.

Fixes: https://github.com/SUSE/sesdev/issues/136
Signed-off-by: Nathan Cutler <ncutler@suse.com>
