### PR TITLE
deepsea/nautilus_pre_stage_0.sh: refrain from patching DeepSea

### DIFF
--- a/seslib/templates/salt/deepsea/nautilus_pre_stage_0.sh.j2
+++ b/seslib/templates/salt/deepsea/nautilus_pre_stage_0.sh.j2
@@ -10,20 +10,3 @@ echo "updates_restart: nop" >> /srv/pillar/ceph/stack/global.yml
 
 # cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/time
 # sed -i 's/default/default_my/g' /srv/salt/ceph/time/init.sls
-
-cat > /root/mds-get-name.patch <<EOF
---- /srv/salt/_modules/mds.py
-+++ /srv/salt/_modules/mds.py
-@@ -17,6 +17,6 @@ def get_name(host):
-     MDS names must not start with a digit, so filter those out and prefix them
-     with "mds.".
-     """
--    if host[0].isdigit():
-+    if host[0].isdigit() or host == 'master':
-         return 'mds.{}'.format(host)
-     return host
-EOF
-
-pushd /
-patch -p0 < /root/mds-get-name.patch
-popd

--- a/seslib/templates/salt/deepsea/nautilus_pre_stage_0.sh.j2
+++ b/seslib/templates/salt/deepsea/nautilus_pre_stage_0.sh.j2
@@ -7,6 +7,3 @@ cp /srv/salt/ceph/updates/nop.sls /srv/salt/ceph/updates/restart
 echo "updates_init: nop" >> /srv/pillar/ceph/stack/global.yml
 
 echo "updates_restart: nop" >> /srv/pillar/ceph/stack/global.yml
-
-# cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/time
-# sed -i 's/default/default_my/g' /srv/salt/ceph/time/init.sls


### PR DESCRIPTION
For a long time, sesdev was patching the DeepSea code. This was needed
because, in sesdev clusters, one of the hosts was called "admin" and the
MDS doesn't like this.

Now that sesdev is no longer calling hosts "admin", the patch can be
dropped.