### PR TITLE
setup.cfg: include seslib/templates/cephadm/ directory in packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ seslib =
     templates/salt/ceph-salt/*.j2
     templates/salt/deepsea/*.j2
     templates/salt/suma/*.j2
+    templates/cephadm/*.j2
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Overlooked this when I moved deployment_day_2.sh.j2 :-(

Fixes: b62836e53bdfe98367e92387d374beb42e7b1c2b
Signed-off-by: Nathan Cutler <ncutler@suse.com>