### PR TITLE
sesdev --devel flag: let click deduct type

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -1490,7 +1490,7 @@ def tunnel(deployment_id, service=None, node=None, remote_port=None, local_port=
 @cli.command()
 @click.argument('deployment_id')
 @click.argument('node')
-@click.option('--devel/--product', 'devel_repos', default=True, type=bool, is_flag=True,
+@click.option('--devel/--product', 'devel_repos', default=True, is_flag=True,
               help="Upgrade to devel or product repos (default: devel)")
 @click.option('--to', 'to_version', default='octopus', type=str, show_default=True,
               help='The local address to bind the tunnel')


### PR DESCRIPTION
If one uses type=bool on a switch style flag (like --error/--no-error)
click6 only considers this a bool flag if type is None. Flags like that
default to type bool though, so just let click find out on its own.
Click7 can handle explicit type=bool but also deducts it just fine.

Fixes: #549

Signed-off-by: Jan Fajerski <jfajerski@suse.com>