### PR TITLE
spec: pin sesdev-qa version to sesdev version

### DIFF
--- a/sesdev.spec
+++ b/sesdev.spec
@@ -50,7 +50,7 @@ Requires:       python3-pycryptodomex >= 3.4.6
 Requires:       python3-setuptools
 Requires:       vagrant > 2.2.2
 Requires:       vagrant-libvirt
-Requires:       sesdev-qa
+Requires:       sesdev-qa = %{version}-%{release}
 
 %if 0%{?el8} || 0%{?fedora}
 %{?python_disable_dependency_generator}


### PR DESCRIPTION
Without this, the installed sesdev-qa version lags behind the sesdev
version because the user will typically do

    zypper update sesdev

instead of

    zypper update sesdev sesdev-qa

(And it's unreasonable to expect users to remember that they should do
the latter and not the former!)

Signed-off-by: Nathan Cutler <ncutler@suse.com>