### PR TITLE
deployment_day_2.sh: create CephFS using documented procedure

### DIFF
--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -130,11 +130,18 @@ NFS_NODES_COMMA_SEPARATED_LIST="${NFS_NODES_COMMA_SEPARATED_LIST%,*}"
 {% if mds_nodes > 0 %}
 
 {% set service_spec_mds = "/root/service_spec_mds.yml" %}
-{% set fs_volume = "sesdev_fs" %}
+{% set fs_name = "sesdev_fs" %}
+{% set fs_pool_prefix = "cephfs." %}
+{% set fs_meta_pool = fs_pool_prefix + fs_name + ".meta" %}
+{% set fs_data_pool = fs_pool_prefix + fs_name + ".data" %}
+
+ceph osd pool create {{ fs_meta_pool }}
+ceph osd pool create {{ fs_data_pool }}
+
 cat >> {{ service_spec_mds }} << 'EOF'
 ---
 service_type: mds
-service_id: {{ fs_volume }}
+service_id: {{ fs_name }}
 placement:
     hosts:
 {% for node in nodes %}
@@ -187,8 +194,7 @@ while true ; do
 done
 set -x
 
-# create the volume
-ceph fs volume create {{ fs_volume }}
+ceph fs new {{ fs_name }} {{ fs_meta_pool }} {{ fs_data_pool }}
 sleep 10
 ceph fs status
 sleep 5


### PR DESCRIPTION
It came to my attention that sesdev was using an unsupported
and undocumented procedure ("ceph fs volume create") to create
the CephFS.

Signed-off-by: Nathan Cutler <ncutler@suse.com>