### PR TITLE
tox.ini: add "allowexternals = pylint"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
   pytest --pycodestyle {posargs: -vv}
 
 [testenv:lint]
+allowlist_externals = pylint
 commands =
   pylint sesdev
   pylint seslib


### PR DESCRIPTION
When running "tox", we recently started to see:

    lint run-test: commands[0] | pylint sesdev
    WARNING: test command found but not installed in testenv
      cmd: /home/smithfarm/src/ceph/smithfarm/sesdev/venv/bin/pylint
      env: /home/smithfarm/src/ceph/smithfarm/sesdev/.tox/lint
    Maybe you forgot to specify a dependency? See also the allowlist_externals envconfig setting.

    DEPRECATION WARNING: this will be an error in tox 4 and above!

To make matters worse, part of the message was displayed in RED LETTERS, which
ruined my day, so I decided to push this fix.

Signed-off-by: Nathan Cutler <ncutler@suse.com>