### PR TITLE
Implement --rgw-ssl option for deploying RGWs with SSL enabled

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -167,6 +167,8 @@ def common_create_options(func):
                      help='Make \'hostname\' command return FQDN'),
         click.option('--apparmor/--no-apparmor', is_flag=True, default=True,
                      help='Enable/disable AppArmor'),
+        click.option('--rgw-ssl/--no-rgw-ssl', is_flag=True, default=False,
+                     help='Deploy RGW with SSL'),
     ]
     return _decorator_composer(click_options, func)
 
@@ -371,6 +373,7 @@ def _gen_settings_dict(
         ram=None,
         repo=None,
         repo_priority=None,
+        rgw_ssl=None,
         roles=None,
         salt=None,
         scc_pass=None,
@@ -620,6 +623,11 @@ def _gen_settings_dict(
 
     if apparmor is not None:
         settings_dict['apparmor'] = apparmor
+
+    if rgw_ssl is not None:
+        if rgw_ssl and version not in ['nautilus', 'ses6']:
+            raise OptionNotSupportedInVersion('--rgw-ssl', version)
+        settings_dict['rgw_ssl'] = rgw_ssl
 
     return settings_dict
 

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -590,6 +590,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'upgrade_devel_repos': self.upgrade_devel_repos,
             'os_upgrade_repos': self.os_upgrade_repos,
             'apparmor': self.settings.apparmor,
+            'rgw_ssl': self.settings.rgw_ssl,
         }
 
         scripts = {}

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -923,6 +923,10 @@ deployment might not be completely destroyed.
                     result += "  - {}\n".format(repo_obj.url)
             if self.settings.version in Constant.CORE_VERSIONS:
                 result += "- qa_test:          {}\n".format(self.settings.qa_test)
+            if self.settings.fqdn:
+                result += "- FQDN:             {}\n".format(self.settings.fqdn)
+            if self.settings.rgw_ssl:
+                result += "- RGW with SSL:     {}\n".format(self.settings.rgw_ssl)
         if show_individual_vms:
             result += "\n"
             result += "Individual VM parameters:\n"

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -120,6 +120,15 @@ SETTINGS = {
         'help': 'paths to container images to be passed to "podman" and "cephadm bootstrap"',
         'default': Constant.IMAGE_PATHS,
     },
+    'ipv6': {
+        'type': bool,
+        'help': 'Configure IPv6 addresses. This option requires "Accept Router '
+                'Advertisements" to be set to 2. You can change it by running '
+                '"sysctl -w net.ipv6.conf.<if>.accept_ra=2" where '
+                '<if> is the network interface used by libvirt for network '
+                'forwarding, or "all" to apply to all interfaces.',
+        'default': False
+    },
     'libvirt_host': {
         'type': str,
         'help': 'Hostname/IP address of the libvirt host',
@@ -220,15 +229,6 @@ SETTINGS = {
         'help': 'Automatically run integration tests on the deployed cluster',
         'default': False,
     },
-    'ipv6': {
-        'type': bool,
-        'help': 'Configure IPv6 addresses. This option requires "Accept Router '
-                'Advertisements" to be set to 2. You can change it by running '
-                '"sysctl -w net.ipv6.conf.<if>.accept_ra=2" where '
-                '<if> is the network interface used by libvirt for network '
-                'forwarding, or "all" to apply to all interfaces.',
-        'default': False
-    },
     'ram': {
         'type': int,
         'help': 'RAM size in gigabytes for each node',
@@ -243,6 +243,11 @@ SETTINGS = {
         'type': list,
         'help': 'DEPRECATED: use custom_repos instead',
         'default': [],
+    },
+    'rgw_ssl': {
+        'type': bool,
+        'help': 'Whether to deploy RGW with SSL enabled',
+        'default': False,
     },
     'roles': {
         'type': list,

--- a/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
@@ -1,3 +1,4 @@
+
 {% if deepsea_git_repo %}
 cd /root
 git clone {{ deepsea_git_repo }}

--- a/seslib/templates/salt/deepsea/nautilus_policy.cfg.j2
+++ b/seslib/templates/salt/deepsea/nautilus_policy.cfg.j2
@@ -35,3 +35,4 @@ role-prometheus/cluster/{{ node.name }}*.sls
 role-grafana/cluster/{{ node.name }}*.sls
 {% endif %}
 {% endfor %}
+

--- a/seslib/templates/salt/deepsea/nautilus_pre_stage_1.sh.j2
+++ b/seslib/templates/salt/deepsea/nautilus_pre_stage_1.sh.j2
@@ -1,0 +1,23 @@
+
+{% if rgw_ssl %}
+# Set up RGW-over-SSL
+CERTDIR=/srv/salt/ceph/rgw/cert
+mkdir -p $CERTDIR
+pushd $CERTDIR
+openssl req -x509 \
+        -nodes \
+        -days 1095 \
+        -newkey rsa:4096 \
+        -keyout rgw.key \
+        -out rgw.crt \
+        -subj "/C=DE"
+cat rgw.key > rgw.pem && cat rgw.crt >> rgw.pem
+popd
+GLOBALYML=/srv/pillar/ceph/stack/global.yml
+cat <<EOF >> $GLOBALYML
+rgw_init: default-ssl
+EOF
+cat $GLOBALYML
+cp /srv/salt/ceph/configuration/files/rgw-ssl.conf \
+    /srv/salt/ceph/configuration/files/ceph.conf.d/rgw.conf
+{% endif %}

--- a/seslib/templates/salt/deepsea/ses6_pre_stage_1.sh.j2
+++ b/seslib/templates/salt/deepsea/ses6_pre_stage_1.sh.j2
@@ -1,0 +1,1 @@
+{% include "salt/deepsea/nautilus_pre_stage_1.sh.j2" %}


### PR DESCRIPTION
Currently this only works with 'nautilus' and 'ses6' deployments.

Signed-off-by: Nathan Cutler <ncutler@suse.com>