### PR TITLE
zypper: add repos when needed

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -18,10 +18,40 @@ class Constant():
 
     DEBUG = False
 
+    DEVELOPER_TOOLS_REPOS = {
+        'sles-15-sp1': {
+            'dev-tools': 'http://dist.suse.de/ibs/SUSE/Products/'
+                         'SLE-Module-Development-Tools/15-SP1/x86_64/product/',
+            'dev-tools-update': 'http://dist.suse.de/ibs/SUSE/Products/'
+                                'SLE-Module-Development-Tools/15-SP1/x86_64/product/',
+        },
+        'sles-15-sp2': {
+            'dev-tools': 'http://download.nue.suse.com/ibs/SUSE/Products/'
+                         'SLE-Module-Development-Tools/15-SP2/x86_64/product/',
+            'dev-tools-update': 'http://download.nue.suse.com/ibs/SUSE/Updates/'
+                                'SLE-Module-Development-Tools/15-SP2/x86_64/update/',
+        },
+    }
+
     IMAGE_PATHS = {
         'ses7': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
         'octopus': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph',
         'pacific': 'registry.opensuse.org/filesystems/ceph/pacific/images/ceph/ceph',
+    }
+
+    INTERNAL_MEDIA_REPOS = {
+        'ses5': {
+            'ses5-internal-media': 'http://download.suse.de/ibs/Devel:/Storage:/5.0/images/repo/'
+                                   'SUSE-Enterprise-Storage-5-POOL-Internal-x86_64-Media/',
+        },
+        'ses6': {
+            'ses6-internal-media': 'http://download.suse.de/ibs/Devel:/Storage:/6.0/images/repo/'
+                                   'SUSE-Enterprise-Storage-6-POOL-Internal-x86_64-Media/',
+        },
+        'ses7': {
+            'ses7-internal-media': 'http://download.suse.de/ibs/Devel:/Storage:/7.0/images/repo/'
+                                   'SUSE-Enterprise-Storage-7-POOL-Internal-x86_64-Media/',
+        },
     }
 
     JINJA_ENV = Environment(loader=PackageLoader('seslib', 'templates'), trim_blocks=True)
@@ -99,16 +129,6 @@ class Constant():
         'generic/ubuntu1804': 'generic/ubuntu1804',
     }
 
-    OS_PACKAGE_MANAGER_MAPPING = {
-        'sles-12-sp3': 'zypper',
-        'sles-15-sp1': 'zypper',
-        'sles-15-sp2': 'zypper',
-        'leap-15.1': 'zypper',
-        'leap-15.2': 'zypper',
-        'tumbleweed': 'zypper',
-        'ubuntu-bionic': 'apt',
-    }
-
     OS_MAKECHECK_REPOS = {
         'sles-12-sp3': {
             'sdk': 'http://dist.suse.de/ibs/SUSE/Products/SLE-SDK/12-SP3/x86_64/product/',
@@ -142,6 +162,16 @@ class Constant():
             'workstation-update': 'http://download.nue.suse.com/ibs/SUSE/Updates/SLE-Product-WE/'
                                   '15-SP2/x86_64/update/',
         },
+    }
+
+    OS_PACKAGE_MANAGER_MAPPING = {
+        'sles-12-sp3': 'zypper',
+        'sles-15-sp1': 'zypper',
+        'sles-15-sp2': 'zypper',
+        'leap-15.1': 'zypper',
+        'leap-15.2': 'zypper',
+        'tumbleweed': 'zypper',
+        'ubuntu-bionic': 'apt',
     }
 
     OS_REPOS = {

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -102,6 +102,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.bootstrap_mon_ip = None
         self.version_devel_repos = None
         self.os_base_repos = None
+        self.internal_media_repo = None
+        self.developer_tools_repos = None
         self.os_makecheck_repos = None
         self.os_upgrade_repos = None
         self.upgrade_devel_repos = None
@@ -445,6 +447,18 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         else:
             self.os_upgrade_repos = []
 
+    def __set_internal_media_repo(self):
+        if self.settings.version in self.settings.internal_media_repos:
+            self.internal_media_repo = \
+                self.settings.internal_media_repos[self.settings.version].items()
+
+    def __set_developer_tools_repos(self):
+        if self.settings.os in self.settings.developer_tools_repos:
+            self.developer_tools_repos = \
+                list(
+                    self.settings.developer_tools_repos[self.settings.os].items()
+                )
+
     def __set_os_makecheck_repos(self):
         if self.settings.os in self.settings.os_makecheck_repos:
             self.os_makecheck_repos = \
@@ -481,6 +495,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         """
         self.__set_version_devel_repos()
         self.__set_os_base_repos()
+        self.__set_internal_media_repo()
+        self.__set_developer_tools_repos()
         self.__set_os_makecheck_repos()
         self.__analyze_ceph_salt_github_pr_fetching()
         self.__set_cephadm_bootstrap_node()
@@ -591,6 +607,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'os_upgrade_repos': self.os_upgrade_repos,
             'apparmor': self.settings.apparmor,
             'rgw_ssl': self.settings.rgw_ssl,
+            'internal_media_repo': self.internal_media_repo,
+            'developer_tools_repos': self.developer_tools_repos,
         }
 
         scripts = {}

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -65,6 +65,11 @@ SETTINGS = {
         'help': 'Include "devel" zypper repo, if applicable',
         'default': True,
     },
+    'developer_tools_repos': {
+        'type': dict,
+        'help': 'Developer Tools Module repos for various versions of SLE',
+        'default': Constant.DEVELOPER_TOOLS_REPOS,
+    },
     'disk_size': {
         'type': int,
         'help': 'Storage disk size in gigabytes',
@@ -119,6 +124,11 @@ SETTINGS = {
         'type': dict,
         'help': 'paths to container images to be passed to "podman" and "cephadm bootstrap"',
         'default': Constant.IMAGE_PATHS,
+    },
+    'internal_media_repos': {
+        'type': dict,
+        'help': 'Internal Media repos for various versions of SES',
+        'default': Constant.INTERNAL_MEDIA_REPOS,
     },
     'ipv6': {
         'type': bool,

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -37,6 +37,18 @@ zypper --non-interactive removerepo repo-source-non-oss || true
 zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}
 
+# ses6 deepsea install from source requires:
+# - SES6 Internal Media repo
+# - SLE-15-SP1 Developer Tools Module repos
+{% if version == 'ses6' and deepsea_git_repo and node == master %}
+{% for internal_media_repo_name, internal_media_repo_url in internal_media_repo %}
+zypper addrepo --refresh {{ internal_media_repo_url }} {{ internal_media_repo_name }}
+{% endfor %}
+{% for dev_tools_repo_name, dev_tools_repo_url in developer_tools_repos %}
+zypper addrepo --refresh {{ dev_tools_repo_url }} {{ dev_tools_repo_name }}
+{% endfor %}
+{% endif %}{# version == 'ses6' and deepsea_git_repo #}
+
 # make check repos
 {% if version == 'makecheck' %}
 {% for os_repo_name, os_repo_url in os_makecheck_repos %}


### PR DESCRIPTION
In certain cases, e.g. when installing DeepSea from source on SES6, additional
repos ("SES6 Internal Media", "Developer Tools Module", etc.) are needed to
satisfy dependencies.

We are already carrying code for "sesdev create makecheck" which adds several
additional repos, but this code can not be easily reused to address the issue.

Fixes: https://github.com/SUSE/sesdev/issues/559
Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

To Do:

- [x] create an issue that describes the problem in more detail
- [x] create a "dev_tools_repos" dict along the lines of "internal_media_repo"