### PR TITLE
ses7: use product container image when --product given

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -328,9 +328,12 @@ if [ "$SES7" ] ; then
     run_cmd test "$(sesdev show ses7-mini --format json --nodes-with-role bootstrap | jq -r '.[0]')" = "master"
     run_cmd sesdev --verbose qa-test ses7-mini
     run_cmd sesdev --verbose destroy --non-interactive ses7-mini
-    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --fqdn ses7-1node
-    run_cmd sesdev --verbose qa-test ses7-1node
-    run_cmd sesdev --verbose destroy --non-interactive ses7-1node
+    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --fqdn ses7-1node-fqdn
+    run_cmd sesdev --verbose qa-test ses7-1node-fqdn
+    run_cmd sesdev --verbose destroy --non-interactive ses7-1node-fqdn
+    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --product ses7-1node-product
+    run_cmd sesdev --verbose qa-test ses7-1node-product
+    run_cmd sesdev --verbose destroy --non-interactive ses7-1node-product
     run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" ses7-4node
     run_cmd sesdev --verbose qa-test ses7-4node
     run_cmd sesdev --verbose supportconfig ses7-4node node1

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -33,10 +33,14 @@ class Constant():
         },
     }
 
-    IMAGE_PATHS = {
+    IMAGE_PATHS_DEVEL = {
         'ses7': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
         'octopus': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph',
         'pacific': 'registry.opensuse.org/filesystems/ceph/pacific/images/ceph/ceph',
+    }
+
+    IMAGE_PATHS_PRODUCT = {
+        'ses7': 'registry.suse.com/ses/7/ceph/ceph',
     }
 
     INTERNAL_MEDIA_REPOS = {

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -152,9 +152,14 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                 Constant.VERSION_PREFERRED_DEPLOYMENT_TOOL[self.settings.version]
 
     def __populate_image_path(self):
-        if self.settings.deployment_tool == 'cephadm':
-            if not self.settings.image_path:
-                self.settings.image_path = self.settings.image_paths[self.settings.version]
+        if self.settings.deployment_tool == 'cephadm' and not self.settings.image_path:
+            if not self.settings.devel_repo:
+                if self.settings.version in self.settings.image_paths_product:
+                    self.settings.image_path = \
+                        self.settings.image_paths_product[self.settings.version]
+                    return
+            self.settings.image_path = \
+                self.settings.image_paths_devel[self.settings.version]
 
     def __set_up_make_check(self):
         self.settings.override('single_node', True)

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -120,10 +120,15 @@ SETTINGS = {
         'help': 'Container image path for Ceph daemons',
         'default': '',
     },
-    'image_paths': {
+    'image_paths_devel': {
         'type': dict,
-        'help': 'paths to container images to be passed to "podman" and "cephadm bootstrap"',
-        'default': Constant.IMAGE_PATHS,
+        'help': 'paths to devel container images',
+        'default': Constant.IMAGE_PATHS_DEVEL,
+    },
+    'image_paths_product': {
+        'type': dict,
+        'help': 'paths to product container images',
+        'default': Constant.IMAGE_PATHS_PRODUCT,
     },
     'internal_media_repos': {
         'type': dict,


### PR DESCRIPTION
Before this commit, "sesdev create ses7 --product" would use registry.suse.de,
which only has the devel container image. That was wrong.

Fixes: https://github.com/SUSE/sesdev/issues/560
Signed-off-by: Nathan Cutler <ncutler@suse.com>