### PR TITLE
provision: enable coredumps

### DIFF
--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -198,6 +198,9 @@ ceph_health_test
 # check that OSDs have the expected objectstore
 osd_objectstore_test
 
+# core dump test
+core_dump_test
+
 # check numbers of daemons and whether they are running on the expected nodes
 number_of_daemons_expected_vs_metadata_test
 number_of_services_expected_vs_orch_ls_test

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -514,6 +514,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'sesdev_path_to_qa': Constant.PATH_TO_QA,
             'dep_id': self.dep_id,
             'os': self.settings.os,
+            'ram': self.settings.ram,
             'package_manager': Constant.OS_PACKAGE_MANAGER_MAPPING[self.settings.os],
             'vm_engine': self.settings.vm_engine,
             'libvirt_host': self.settings.libvirt_host,

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -16,6 +16,9 @@ function err_report {
 # ensure Vagrant doesn't destroy the master node when the script fails
 trap 'err_report $LINENO' ERR
 
+# do not limit coredump size
+ulimit -c unlimited
+
 ls -lR /home/vagrant
 
 # populate /etc/hosts
@@ -96,6 +99,23 @@ else
 fi
 aa-status || true
 {% endif %}{# apparmor #}
+
+{% if os != 'sles-12-sp3' %}
+source /etc/os-release
+if [[ "$ID_LIKE" =~ "suse" ]] ; then
+    # enable coredump capturing
+    sysctl -w kernel.core_pattern="|/usr/lib/systemd/systemd-coredump %P %u %g s %t %c %e"
+    sysctl kernel.core_pattern
+    cat <<EOF >>/etc/systemd/coredump.conf
+ProcessSizeMax={{ ram }}G
+ExternalSizeMax={{ ram }}G
+JournalSizeMax={{ ram }}G
+EOF
+    cat /etc/systemd/coredump.conf
+    systemctl enable systemd-coredump.socket
+    systemctl start systemd-coredump.socket
+fi
+{% endif %}{# os != 'sles-12-sp3' #}
 
 # deployment state machine
 

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -220,7 +220,7 @@ zypper --non-interactive install --from update --force libncurses5 libncurses6
 {% if os == 'sles-12-sp3' %}
 zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} ntp
 {% else %}
-zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} chrony hostname
+zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} chrony hostname systemd-coredump
 {% endif %}{# os == 'sles-12-sp3' #}
 
 {% if os.startswith("sle") %}


### PR DESCRIPTION
It came to my attention that coredump capturing might not be enabled by default
in sesdev clusters.

Signed-off-by: Nathan Cutler <ncutler@suse.com>