### PR TITLE
Prevent Vagrant from setting the hostname in /etc/hosts

### DIFF
--- a/seslib/templates/engine/libvirt/vagrant.node.j2
+++ b/seslib/templates/engine/libvirt/vagrant.node.j2
@@ -1,7 +1,5 @@
     {{ node.networks }}
 
-    node.vm.hostname = "{{ node.fqdn }}"
-
     node.vm.provider "libvirt" do |lv|
       lv.memory = {{ node.ram }}
       lv.cpus = {{ node.cpus }}


### PR DESCRIPTION
Having the hostname pointing to a local address can be
problematic, as was the case with skuba failing to
properly bootstrap the Master node.

See https://github.com/SUSE/sesdev/issues/567 for more.