### PR TITLE
provision.sh: persist systemd journal in SES7 only

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -50,9 +50,11 @@ hostnamectl set-hostname {{ node.fqdn }}
 hostnamectl set-hostname {{ node.name }}
 {% endif %}
 
+{% if version in ['octopus', 'ses7', 'pacific'] %}
 # persist the journal
 sed -i -e 's/#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf
 systemctl restart systemd-journald
+{% endif %}{# version in ['octopus', 'ses7', 'pacific'] #}
 
 {% if not provision %}
 set +x


### PR DESCRIPTION
Only SES7 -- {octopus, ses7, pacific} to be precise -- uses systemd-journald for
logging. So make the related adjustments only on those deployment versions.

Signed-off-by: Nathan Cutler <ncutler@suse.com>