### PR TITLE
ceph-salt: no cephadm for nodes with no sesdev roles

### DIFF
--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -49,7 +49,7 @@ type ceph-salt
 ceph-salt --version
 
 {% for node in nodes %}
-{% if not node.has_exclusive_role('client') %}
+{% if node.has_roles() and not node.has_exclusive_role('client') %}
 ceph-salt config /ceph_cluster/minions add {{ node.fqdn }}
 ceph-salt config /ceph_cluster/roles/cephadm add {{ node.fqdn }}
 {% endif %}


### PR DESCRIPTION
In order to be able to simulate administration tasks like adding nodes to
a cluster, we need to make it easy for sesdev users to create deployments that
have "extra" nodes.

Before this change, we had to specify the "extra" node's roles like this:

    [client]

Now nodes with no roles at all will be treated the same way when it comes to
assigning the "cephadm" ceph-salt role.

Signed-off-by: Nathan Cutler <ncutler@suse.com>