### PR TITLE
sesdev.spec: fix missing qa/common/rgw.sh

### DIFF
--- a/sesdev.spec
+++ b/sesdev.spec
@@ -88,6 +88,7 @@ install -m 0755 qa/health-ok.sh %{buildroot}/%{_datadir}/%{name}/qa/health-ok.sh
 install -m 0644 qa/common/common.sh %{buildroot}/%{_datadir}/%{name}/qa/common/common.sh
 install -m 0644 qa/common/helper.sh %{buildroot}/%{_datadir}/%{name}/qa/common/helper.sh
 install -m 0644 qa/common/json.sh %{buildroot}/%{_datadir}/%{name}/qa/common/json.sh
+install -m 0644 qa/common/rgw.sh %{buildroot}/%{_datadir}/%{name}/qa/common/rgw.sh
 install -m 0644 qa/common/zypper.sh %{buildroot}/%{_datadir}/%{name}/qa/common/zypper.sh
 
 %files


### PR DESCRIPTION
Commit e1fcf95dd7bc43f7b0881288228b74ca10a0b440 added a new file qa/common/rgw.sh
but neglected to include it in the sesdev-qa RPM. This patch rectifies that
oversight.

NOTE: this only happens when sesdev is installed from the RPM package