### PR TITLE
zypper: be more careful when installing systemd-coredump

### DIFF
--- a/qa/health-ok.sh
+++ b/qa/health-ok.sh
@@ -178,6 +178,7 @@ test "$DEPLOYMENT_VERSION"
 set -e
 
 # tests that verify basic assumptions
+assert_reboot_not_needed
 support_cop_out_test
 no_non_oss_repos_test
 make_salt_master_an_admin_node_test

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -156,3 +156,6 @@ fi
 {% include "ubuntu/provision.sh.j2" %}
 
 {% endif %}{# end of deploy state machine #}
+
+# inform user if reboot is needed (should be the very last thing the provisioner does)
+zypper ps -s || true

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -56,12 +56,6 @@ sed -i -e 's/#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf
 systemctl restart systemd-journald
 {% endif %}{# version in ['octopus', 'ses7', 'pacific'] #}
 
-{% if not provision %}
-set +x
-echo "Stopping the deployment now because the --no-provision option was given"
-exit 0
-{% endif %}{# not provision #}
-
 # if --ssd option was given, set rotational flag on first additional disk
 {% if ssd %}
 if [ -f /sys/block/vdb/queue/rotational ] ; then
@@ -78,6 +72,12 @@ fi
 {% elif package_manager == 'dnf' %}
 {% include "dnf.j2" ignore missing %}
 {% endif %}{# package_manager == 'zypper' #}
+
+{% if not provision %}
+set +x
+echo "Stopping the deployment now because the --no-provision option was given"
+exit 0
+{% endif %}{# not provision #}
 
 # include helper scripts
 {% include "helper_scripts.j2" %}

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -216,6 +216,7 @@ zypper --non-interactive install --from update --force libncurses5 libncurses6
        'bc',
        'apparmor-utils',
        'apparmor-parser',
+       'lsof',
    ] %}
 {% if os == 'sles-12-sp3' %}
 zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} ntp

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -220,8 +220,15 @@ zypper --non-interactive install --from update --force libncurses5 libncurses6
 {% if os == 'sles-12-sp3' %}
 zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} ntp
 {% else %}
-zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} chrony hostname systemd-coredump
+zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} chrony hostname
 {% endif %}{# os == 'sles-12-sp3' #}
+
+{% if os != 'sles-12-sp3' %}
+# install systemd-coredump, ensuring that it has the same exact version as systemd
+# (avoid newer systemd possibly pre-installed by Kiwi in the Vagrant Box)
+zypper --non-interactive install --force systemd systemd-sysvinit udev libudev1
+zypper --non-interactive install systemd-coredump
+{% endif %}{# os != 'sles-12-sp3' #}
 
 {% if os.startswith("sle") %}
 {% set sle_pkgs_to_install = [


### PR DESCRIPTION
    provision.sh: include zypper repo setup in --no-provision
    
    Recently a --no-provision feature was added to provide a way to quickly
    bring up a VM. But in order for that feature to be useful, the VM should
    have the same repos as in a full deployment.
    
    Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

    zypper: be more careful when installing systemd-coredump
    
    Due to the way Kiwi builds SLE Vagrant Boxes, the versions of packages
    pre-installed in the Vagrant Box may be newer than the versions of the same
    packages in the "channels" (i.e., in the zypper repos that are added after the
    VMs start).
    
    Work around this by force-installing systemd, udev, etc. from the repos.
    
    This has the drawback of putting the system into a state where "zypper ps -s"
    reports that it needs a reboot.
    
    Fixes: https://github.com/SUSE/sesdev/issues/575
    Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

    zypper: add "lsof" to basic set of packages to install
    
    The "lsof" package is required for "zypper ps -s" to work.
    Apparently, it is not pre-installed in at least one of the Vagrant Boxes that
    we use.
    
    Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

    provision.sh: inform user if reboot is needed
    
    Run "zypper ps -s" at the very end of the provisioning script.
    
    Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

    qa: add assert_reboot_not_needed test
    
    As part of qa-test, run "zypper ps -s" on all nodes and evaluate the output.
    
    If any node is in need of reboot, abort the test and instruct the user that
    it would be better if the cluster were rebooted before running qa-test.
    
    Since rebooting the cluster before running qa-test would have to be done
    manually, failure of this test currently only results in a "soft failure"
    (warning), not a hard failure.

        Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

Fixes: https://github.com/SUSE/sesdev/issues/575