### PR TITLE
DNM TEMPORARY HACK: contrib/standalone.sh: work around SES7 packaging issue

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -322,19 +322,19 @@ if [ "$SES7" ] ; then
     sesdev --verbose box remove --non-interactive sles-15-sp2
     # dry run
     run_cmd sesdev create ses7 --dry-run
-    run_cmd sesdev --verbose create ses7 --non-interactive --roles "[admin,master,bootstrap,storage,mon,mgr]" ses7-mini
+    run_cmd sesdev --verbose create ses7 --non-interactive --roles "[admin,master,bootstrap,storage,mon,mgr]" --repo "http://download.suse.de/ibs/Devel:/Storage:/7.0/SLE_15_SP2/Devel:Storage:7.0.repo" ses7-mini
     run_cmd sesdev --verbose show ses7-mini
     run_cmd sesdev --verbose show --detail ses7-mini
     run_cmd test "$(sesdev show ses7-mini --format json --nodes-with-role bootstrap | jq -r '.[0]')" = "master"
     run_cmd sesdev --verbose qa-test ses7-mini
     run_cmd sesdev --verbose destroy --non-interactive ses7-mini
-    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --fqdn ses7-1node-fqdn
+    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --fqdn --repo "http://download.suse.de/ibs/Devel:/Storage:/7.0/SLE_15_SP2/Devel:Storage:7.0.repo" ses7-1node-fqdn
     run_cmd sesdev --verbose qa-test ses7-1node-fqdn
     run_cmd sesdev --verbose destroy --non-interactive ses7-1node-fqdn
-    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --product ses7-1node-product
+    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --single-node --product --repo "http://download.suse.de/ibs/Devel:/Storage:/7.0/SLE_15_SP2/Devel:Storage:7.0.repo" ses7-1node-product
     run_cmd sesdev --verbose qa-test ses7-1node-product
     run_cmd sesdev --verbose destroy --non-interactive ses7-1node-product
-    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" ses7-4node
+    run_cmd sesdev --verbose create ses7 --non-interactive "${CEPH_SALT_OPTIONS[@]}" --repo "http://download.suse.de/ibs/Devel:/Storage:/7.0/SLE_15_SP2/Devel:Storage:7.0.repo" ses7-4node
     run_cmd sesdev --verbose qa-test ses7-4node
     run_cmd sesdev --verbose supportconfig ses7-4node node1
     rm -f scc*


### PR DESCRIPTION
python3-distro 1.5.0 is needed, and -- at the moment -- this can only be
provided by hacking the repos :-(

Signed-off-by: Nathan Cutler <ncutler@suse.com>