### PR TITLE
cephadm: add 'period update' in radosgw deployment

### DIFF
--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -230,6 +230,7 @@ touch {{ service_spec_gw }}
 radosgw-admin realm create --rgw-realm=default --default
 radosgw-admin zonegroup create --rgw-zonegroup=default --master --default
 radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=default --master --default
+radosgw-admin period update --rgw-realm=default --commit
 cat >> {{ service_spec_gw }} << 'EOF'
 ---
 service_type: rgw


### PR DESCRIPTION
This command was added to the upstream doc in this PR [1],
and it fixes the issue with creating a rgw bucket via dashboard
(InvalidLocationConstraint error).

[1] https://github.com/ceph/ceph/pull/36496

Signed-off-by: Mykola Golub <mgolub@suse.com>