### PR TITLE
deployment: saner processing of --deepsea-repo, --deepsea-branch

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -489,6 +489,8 @@ def _gen_settings_dict(
 
     if deepsea_branch is not None:
         settings_dict['deepsea_git_branch'] = deepsea_branch
+        if not deepsea_repo:
+            settings_dict['deepsea_git_repo'] = Constant.DEEPSEA_REPO
 
     if version is not None:
         settings_dict['version'] = version

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -18,6 +18,8 @@ class Constant():
 
     DEBUG = False
 
+    DEEPSEA_REPO = "https://github.com/SUSE/DeepSea"
+
     DEVELOPER_TOOLS_REPOS = {
         'sles-15-sp1': {
             'dev-tools': 'http://dist.suse.de/ibs/SUSE/Products/'

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -951,6 +951,9 @@ deployment might not be completely destroyed.
                 result += "- FQDN:             {}\n".format(self.settings.fqdn)
             if self.settings.rgw_ssl:
                 result += "- RGW with SSL:     {}\n".format(self.settings.rgw_ssl)
+            if self.settings.deepsea_git_repo and self.settings.deepsea_git_branch:
+                result += "- DeepSea repo:     {}\n".format(self.settings.deepsea_git_repo)
+                result += "- DeepSea branch:   {}\n".format(self.settings.deepsea_git_branch)
         if show_individual_vms:
             result += "\n"
             result += "Individual VM parameters:\n"


### PR DESCRIPTION
Before this patch, the user needed to give both --deepsea-repo
and --deepsea-branch options. If only one was given, sesdev was
silently ignoring it.

Fixes: https://github.com/SUSE/sesdev/issues/583
Signed-off-by: Nathan Cutler <ncutler@suse.com>