### PR TITLE
zypper.j2: remove Python 2 even on SLE-12-SP3

### DIFF
--- a/contrib/standalone.sh
+++ b/contrib/standalone.sh
@@ -255,7 +255,7 @@ if [ "$SES5" ] ; then
     # deploy ses5 without igw, so as not to hit https://github.com/SUSE/sesdev/issues/239
     run_cmd sesdev --verbose create ses5 --product --non-interactive --roles "[master,storage,mon,mgr,mds,rgw,nfs]" ses5-1node
     run_cmd sesdev --verbose qa-test ses5-1node
-    run_cmd sesdev --verbose add-repo --update ses5-1node
+    # run_cmd sesdev --verbose add-repo --update ses5-1node
     run_cmd sesdev --verbose destroy --non-interactive ses5-1node
     run_cmd sesdev --verbose create ses5 --non-interactive --roles "[master,client,openattic],[storage,mon,mgr,rgw],[storage,mon,mgr,mds,nfs],[storage,mon,mgr,mds,rgw,nfs]" ses5-4node
     run_cmd sesdev --verbose qa-test ses5-4node

--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -19,9 +19,8 @@ zypper --non-interactive remove rsync || true
 zypper --non-interactive remove which || true
 
 # remove Python 2 so it doesn't pollute the environment
-{% if os != 'sles-12-sp3' %}
 zypper --non-interactive remove python-base || true
-{% endif %}{# os != 'sles-12-sp3' #}
+zypper --non-interactive remove libpython2_7-1_0 || true
 
 # remove Non-OSS repos in openSUSE
 {% if os.startswith('leap') or os == "tumbleweed" %}


### PR DESCRIPTION
The SLE-12-SP3 images are now being built with a python package that is even
newer than what is in the SLE-12-SP3 LTSS channel.

Work around this by deleting python and then reinstalling it from the LTSS
channel repo.

Signed-off-by: Nathan Cutler <ncutler@suse.com>