### PR TITLE
constant.py: drop nfs from octopus default roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ The following roles can be assigned:
 * `admin` - signifying that the node should get ceph.conf and keyring [1]
 * `bootstrap` - The node where `cephadm bootstrap` will be run
 * `client` - Various Ceph client utilities
-* `nfs` - NFS (Ganesha) gateway [2]
+* `nfs` - NFS (Ganesha) gateway [2] [5]
 * `grafana` - Grafana metrics visualization (requires Prometheus) [3]
 * `igw` - iSCSI target gateway
 * `mds` - CephFS MDS
@@ -400,6 +400,8 @@ roles in `policy.cfg`.
 [4] Do not use the `storage` role when deploying Rook/Ceph over CaaSP. See
 [Rook and CaaSP based Ceph cluster](#rook-and-caasp-based-ceph-cluster) for more
 information.
+
+[5] Not currently supported by the `octopus`, `pacific`, or `master` roles.
 
 The following example will generate a cluster with four nodes: the master (Salt
 Master) node that is also running a MON daemon; a storage (OSD) node that

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -412,7 +412,9 @@ def _gen_settings_dict(
         raise NoExplicitRolesWithSingleNode()
     elif single_node:
         roles_string = ""
-        if version in ['ses7', 'octopus', 'pacific']:
+        if version in ['ses7']:
+            roles_string = Constant.ROLES_SINGLE_NODE['ses7']
+        elif version in ['octopus', 'pacific']:
             roles_string = Constant.ROLES_SINGLE_NODE['octopus']
         elif version in ['ses6', 'nautilus']:
             roles_string = Constant.ROLES_SINGLE_NODE['nautilus']

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -237,7 +237,12 @@ class Constant():
         "octopus": [["admin", "master", "client", "prometheus", "grafana", "alertmanager",
                      "node-exporter"],
                     ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
-                    ["storage", "mon", "mgr", "mds", "igw", "nfs", "node-exporter"],
+                    ["storage", "mon", "mgr", "mds", "igw", "node-exporter"],
+                    ["storage", "mon", "mgr", "mds", "rgw", "node-exporter"]],
+        "ses7": [["admin", "master", "client", "prometheus", "grafana", "alertmanager",
+                     "node-exporter"],
+                    ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
+                    ["storage", "mon", "mgr", "mds", "igw", "node-exporter"],
                     ["storage", "mon", "mgr", "mds", "rgw", "nfs", "node-exporter"]]
     }
 
@@ -249,7 +254,7 @@ class Constant():
         'pacific': ROLES_DEFAULT["octopus"],
         'ses5': ROLES_DEFAULT["luminous"],
         'ses6': ROLES_DEFAULT["nautilus"],
-        'ses7': ROLES_DEFAULT["octopus"],
+        'ses7': ROLES_DEFAULT["ses7"],
     }
 
     ROLES_KNOWN = [
@@ -282,7 +287,9 @@ class Constant():
         "nautilus": "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
                     "nfs ]",
         "octopus": "[ master, admin, bootstrap, storage, mon, mgr, mds, igw, rgw, "
-                   "nfs, prometheus, grafana, alertmanager, node-exporter ]",
+                   "prometheus, grafana, alertmanager, node-exporter ]",
+        "ses7": "[ master, admin, bootstrap, storage, mon, mgr, mds, igw, rgw, "
+                   "prometheus, grafana, alertmanager, node-exporter ]",
     }
 
     SSH_KEY_NAME = 'sesdev'  # do NOT use 'id_rsa'


### PR DESCRIPTION
Attempt to workaround:
Bug 1183740 - ceph octopus 15.2.9 fails to deploy rgw and nfs

Works-around: https://bugzilla.opensuse.org/show_bug.cgi?id=1183740
Signed-off-by: Nathan Cutler <ncutler@suse.com>