### PR TITLE
nautilus_pre_stage_4.sh.j2: adapt to syntax change

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -242,10 +242,10 @@ class Constant():
                     ["storage", "mon", "mgr", "mds", "igw", "node-exporter"],
                     ["storage", "mon", "mgr", "mds", "rgw", "node-exporter"]],
         "ses7": [["admin", "master", "client", "prometheus", "grafana", "alertmanager",
-                     "node-exporter"],
-                    ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
-                    ["storage", "mon", "mgr", "mds", "igw", "node-exporter"],
-                    ["storage", "mon", "mgr", "mds", "rgw", "nfs", "node-exporter"]]
+                  "node-exporter"],
+                 ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
+                 ["storage", "mon", "mgr", "mds", "igw", "node-exporter"],
+                 ["storage", "mon", "mgr", "mds", "rgw", "nfs", "node-exporter"]]
     }
 
     ROLES_DEFAULT_BY_VERSION = {

--- a/seslib/templates/salt/deepsea/nautilus_pre_stage_4.sh.j2
+++ b/seslib/templates/salt/deepsea/nautilus_pre_stage_4.sh.j2
@@ -1,2 +1,2 @@
- # set dashboard password to 'admin'
-  ceph dashboard ac-user-set-password admin admin
+# set password of dashboard user 'admin' to 'admin'
+echo -n admin | ceph dashboard ac-user-set-password admin -i -


### PR DESCRIPTION
In Nautilus release 14.2.17, upstream changed the syntax of the command for
changing the dashboard password.

This commit adapts sesdev to this change.

Fixes: https://github.com/SUSE/sesdev/issues/588
Signed-off-by: Nathan Cutler <ncutler@suse.com>