### PR TITLE
qa/common/json.sh: adapt to change in ceph status json format

### DIFF
--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -90,8 +90,12 @@ function json_total_mons {
     local ceph_status_json
     if [ "$VERSION_ID" = "15.2" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
         json_ses7_orch_ls mon
-    elif [ "$VERSION_ID" = "15.1" ] || [ "$VERSION_ID" = "12.3" ] ; then
-        # SES6, SES5
+    elif [ "$VERSION_ID" = "15.1" ] ; then
+        # SES6
+        ceph_status_json="$(ceph status --format json)"
+        echo "$ceph_status_json" | jq -r ".monmap.num_mons"
+    elif [ "$VERSION_ID" = "12.3" ] ; then
+        # SES5
         ceph_status_json="$(ceph status --format json)"
         echo "$ceph_status_json" | jq -r ".monmap.mons | length"
     else


### PR DESCRIPTION
As of Nautilus 14.2.17, the JSON data structure produced by

    ceph status --format json

changed in a way that broke sesdev's number_of_nodes_actual_vs_expected_test for
nautilus clusters.

The new format is:

    master:~ # ceph status --format json | jq -r '.monmap'
    {
      "epoch": 1,
      "min_mon_release_name": "14",
      "num_mons": 1
    }

This commit fixes the issue by adapting the json_total_mons function to this 
change in Ceph's behavior.

Signed-off-by: Nathan Cutler <ncutler@suse.com>