### PR TITLE
zypper: remove python3-base if it's installed

### DIFF
--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -22,6 +22,10 @@ zypper --non-interactive remove which || true
 zypper --non-interactive remove python-base || true
 zypper --non-interactive remove libpython2_7-1_0 || true
 
+# remove Python 3 (large portions of which are preinstalled on the image) so we
+# get the Python 3 that is actually shipping
+zypper --non-interactive remove python3-base || true
+
 # remove Non-OSS repos in openSUSE
 {% if os.startswith('leap') or os == "tumbleweed" %}
 zypper --non-interactive removerepo repo-non-oss || true


### PR DESCRIPTION
Large swathes of Python 3 may come preinstalled in the Vagrant Box.
There is no guarantee that the version number of these preinstalled RPMs
will match the version number of other Python 3 RPMs that we get from
the repos.

This is a known design flaw (bug) in how OBS/Kiwi builds images: i.e., it
takes RPMs from the codestreams and not from the distribution channels.
(That's just a very brief -- even cryptic -- statement of the problem,
but it will have to do for this commit message.)

Work around this issue by prophylactically removing the Python 3 that is
preinstalled in the Vagrant Box. Later, the Python 3 from the
distribution channels will be pulled in via the dependency chains of the
various RPMs we install.

Signed-off-by: Nathan Cutler <ncutler@suse.com>