### PR TITLE
templates: disallow global ID reclaim

### DIFF
--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -369,3 +369,5 @@ ceph orch apply -i {{ service_spec_gw }}
 {% endif %}{# rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring #}
 
 {% endif %}{# storage_nodes > 0 #}
+
+ceph config set mon auth_allow_insecure_global_id_reclaim false || true

--- a/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
+++ b/seslib/templates/salt/deepsea/deepsea_deployment.sh.j2
@@ -180,4 +180,6 @@ deepsea stage run --simple-output ceph.stage.4
 sleep 5
 {% endif %} {# deepsea_need_stage_4 #}
 
+ceph config set mon auth_allow_insecure_global_id_reclaim false || true
+
 echo "deployment complete!"


### PR DESCRIPTION
As of Nautilus v14.2.20 and Octopus v15.2.11, clusters intentionally come up in
HEALTH_WARN (AUTH_INSECURE_GLOBAL_ID_RECLAIM) and to achieve HEALTH_OK we have
to disallow this insecure feature.

Signed-off-by: Nathan Cutler <ncutler@suse.com>