### PR TITLE
provision.sh: try harder to ensure hostname is installed

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -741,7 +741,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             tools.run_async(cmd, log_handler)
 
     def _vagrant_up(self, node, log_handler):
-        cmd = ["vagrant", "up"]
+        cmd = ["vagrant", "up", "--no-destroy-on-error"]
         if self.existing:
             cmd.extend(["--no-provision"])
         else:

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -1,19 +1,39 @@
-set -ex
+set -e
 
 DEPLOYMENT_SCRIPT="$0"
 
 function err_report {
+    local hn
     set +x
+    if hostname >/dev/null 2>&1 ; then
+        hn="$(hostname)"
+    else
+        hn="(cannot determine: hostname binary appears to be missing)"
+    fi
     local line_number="$1"
-    echo "Error in sesdev deployment script trapped!"
-    echo "=> hostname: $(hostname)"
+    echo "Error in provisioner script trapped!"
+    echo "=> hostname: $hn"
     echo "=> script: $DEPLOYMENT_SCRIPT"
     echo "=> line number: $line_number"
     echo "Bailing out!"
-    exit 0
+    exit 1
 }
 
-# ensure Vagrant doesn't destroy the master node when the script fails
+# We run hostname in err_report. Blindly try to make sure it's installed.
+if hostname >/dev/null 2>&1 ; then
+    echo "hostname binary is present. Good."
+else
+    if zypper >/dev/null 2>&1 ; then
+        echo "hostname binary is not present. Attempting to install it using \"zypper\"..."
+        set -x
+        zypper --non-interactive install hostname || true
+        set +x
+    fi
+fi
+
+set -x
+
+# display error report when this provisioner script fails
 trap 'err_report $LINENO' ERR
 
 # do not limit coredump size


### PR DESCRIPTION
77506e5e7211e998737b4ce0e058c148cbb771bf
deployment: run "vagrant up" with --no-destroy-on-error

Up to Vagrant 2.2.9, --no-destroy-on-error was the default and everything was
fine.

Then Vangrant 2.2.10 changed the default to --destroy-on-error. Since I was
ignorant of this option, I worked around it by merging
55314a49fb94c08a7681b72398eee33aaf9edef0 which ensured that the provisioner
script exits with status code 0 even when there is an error (that tricked
Vagrant into thinking the script succeeded, so it did not destroy the VMs when
the script failed).

Now that I know about this option, it makes sense to run with
--no-destroy-on-error since we don't want Vagrant to destroy VMs during
provisioning in any case (since it is assumed that we want to go in and debug to
determine why the provisioner failed).

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

47dc6592a9e112cbce490c761243a885d2bdc99d
provision.sh: try harder to ensure hostname is installed

When the provisioner fails before the hostname package is installed, we were
getting bogus error messages which sowed confusion.

Fixes: https://github.com/SUSE/sesdev/issues/601

Signed-off-by: Nathan Cutler <ncutler@suse.com>
