### PR TITLE
templates/zypper: install basic packages with --no-recommends

### DIFF
--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -217,9 +217,9 @@ zypper --non-interactive install --from update --force libncurses5 libncurses6
        'lsof',
    ] %}
 {% if os == 'sles-12-sp3' %}
-zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} ntp
+zypper --non-interactive install --no-recommends {{ basic_pkgs_to_install | join(' ') }} ntp
 {% else %}
-zypper --non-interactive install {{ basic_pkgs_to_install | join(' ') }} chrony hostname
+zypper --non-interactive install --no-recommends {{ basic_pkgs_to_install | join(' ') }} chrony hostname
 {% endif %}{# os == 'sles-12-sp3' #}
 
 {% if os != 'sles-12-sp3' %}


### PR DESCRIPTION
When we install basic packages, we want just those packages and their hard
dependencies. We do not need or want any soft dependencies of those packages or
of their dependencies.

Signed-off-by: Nathan Cutler <ncutler@suse.com>