### PR TITLE
Fix --stop-before-cephadm-bootstrap

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -610,6 +610,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'stop_before_ceph_salt_config': self.settings.stop_before_ceph_salt_config,
             'stop_before_ceph_salt_apply': self.settings.stop_before_ceph_salt_apply,
             'stop_before_ceph_orch_apply': self.settings.stop_before_ceph_orch_apply,
+            'stop_before_cephadm_bootstrap': self.settings.stop_before_cephadm_bootstrap,
             'reg': self.settings.reg,
             'image_path': self.settings.image_path,
             'use_salt': self.settings.use_salt,

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -420,7 +420,7 @@ class Settings():
 
         config_tree = {}
 
-        def __fill_in_config_tree(config_param, global_param):
+        def _fill_in_config_tree(config_param, global_param):
             """
             fill in missing parts of config_tree[config_param]
             from global_param
@@ -444,11 +444,11 @@ class Settings():
             config_tree = {}
         Log.debug("_load_config_file: config_tree: {}".format(config_tree))
         assert isinstance(config_tree, dict), "yaml.load() of config file misbehaved!"
-        __fill_in_config_tree('os_repos', Constant.OS_REPOS)
-        __fill_in_config_tree('version_devel_repos', Constant.VERSION_DEVEL_REPOS)
-        __fill_in_config_tree('image_paths_devel', Constant.IMAGE_PATHS_DEVEL)
-        __fill_in_config_tree('image_paths_product', Constant.IMAGE_PATHS_PRODUCT)
-        __fill_in_config_tree('version_default_roles', Constant.ROLES_DEFAULT_BY_VERSION)
+        _fill_in_config_tree('os_repos', Constant.OS_REPOS)
+        _fill_in_config_tree('version_devel_repos', Constant.VERSION_DEVEL_REPOS)
+        _fill_in_config_tree('image_paths_devel', Constant.IMAGE_PATHS_DEVEL)
+        _fill_in_config_tree('image_paths_product', Constant.IMAGE_PATHS_PRODUCT)
+        _fill_in_config_tree('version_default_roles', Constant.ROLES_DEFAULT_BY_VERSION)
         return config_tree
 
 


### PR DESCRIPTION
`--stop-before-cephadm-boostrap` didn't work because the argument wasn't part of the code that reads the arguments and creates the context out of that. The context is then used to generate the templates (Vagrantfile and deployment scripts). This means that the switch never reached the conditions in the Jinja templates and was therefore technically ignored.