### PR TITLE
templates/cephadm/deployment_day_2: fix NFS cluster create command

### DIFF
--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -202,7 +202,11 @@ ceph fs status --format json-pretty
 
 {% if nfs_nodes > 0 %}
 {% set nfs_cluster = "sesdev_nfs" %}
+{% if version in ['octopus', 'ses7'] %}
+ceph nfs cluster create cephfs {{ nfs_cluster }} "$NFS_NODES_COMMA_SEPARATED_LIST"
+{% else %}
 ceph nfs cluster create {{ nfs_cluster }} "$NFS_NODES_COMMA_SEPARATED_LIST"
+{% endif %}{# if version in ['octopus', 'ses7'] #}
 sleep 10
 ceph nfs cluster ls
 {% endif %}{# nfs_nodes > 0 #}


### PR DESCRIPTION
At some point, upstream obviously changed the syntax of the "ceph nfs cluster
create" command in octopus, thereby breaking "sesdev create pacific" and "sesdev
create ses7".

Later, this syntax change got reverted [1], but since this revert was made
possible by a big feature [2], so far it has been backported only to pacific [3]

[1] https://github.com/ceph/ceph/pull/40411
[2] https://github.com/ceph/ceph/pull/37600
[3] https://github.com/ceph/ceph/pull/41005

Fixes: https://github.com/SUSE/sesdev/issues/611

Signed-off-by: Nathan Cutler <ncutler@suse.com>