### PR TITLE
sesdev: increase timeout in seconds

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -286,7 +286,7 @@ class Constant():
         },
     }
 
-    REASONABLE_TIMEOUT_IN_SECONDS = 1800
+    REASONABLE_TIMEOUT_IN_SECONDS = 3200
 
     ROLES_DEFAULT = {
         "caasp4": [["master"], ["worker"], ["worker"], ["loadbalancer"]],


### PR DESCRIPTION
avoid failures on less reasonable (slow) hardware

Signed-off-by: Michael Fritch <mfritch@suse.com>