### PR TITLE
pycodestyle: Fix issue with yaml.load (use safe_load)

### DIFF
--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -435,13 +435,9 @@ class Settings():
         if not os.path.exists(Constant.CONFIG_FILE) \
                 or not os.path.isfile(Constant.CONFIG_FILE):
             return config_tree
+
         with open(Constant.CONFIG_FILE, 'r', encoding='utf-8') as file:
-            try:
-                config_tree = yaml.load(file, Loader=yaml.FullLoader)
-            except AttributeError:  # older versions of pyyaml does not have FullLoader
-                config_tree = yaml.load(file)
-        if not config_tree:
-            config_tree = {}
+            config_tree = yaml.safe_load(file) or {}
         Log.debug("_load_config_file: config_tree: {}".format(config_tree))
         assert isinstance(config_tree, dict), "yaml.load() of config file misbehaved!"
         _fill_in_config_tree('os_repos', Constant.OS_REPOS)

--- a/tests/test_parse_config_yaml.py
+++ b/tests/test_parse_config_yaml.py
@@ -1,0 +1,52 @@
+from seslib.settings import Settings
+from seslib.constant import Constant
+
+
+from unittest.mock import patch, mock_open
+from tempfile import mktemp
+
+
+def test_parse_config_yaml__return_empty_dict():
+    Constant.CONFIG_FILE = mktemp()
+    config_tree = Settings._load_config_file()
+    assert config_tree == {}, 'reading non-existent file does not return empty dict'
+
+
+# Examples from the documentation of how config.yaml can be used.
+# Excluding the ability to use references in YAML, that is not from the docs but made up.
+config_yaml = '''
+libvirt_use_ssh: true
+libvirt_user: root
+libvirt_private_key_file: $HOME/.ssh/id_rsa
+libvirt_host: foo
+version_devel_repos:
+  octopus:
+      leap-15.2:
+          - 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/openSUSE_Leap_15.2'
+image_paths_devel:
+    octopus: 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'
+container_registry:
+    prefix: 'registry.suse.de'
+    location: '1.2.3.4:5000'
+    insecure: True
+version_default_roles: &default
+    octopus:
+        - [master, mon, mgr, storage]
+        - [mon, mgr, storage]
+        - [mon, mgr, storage]
+other_roles: *default
+    '''  # noqa
+
+
+@patch('os.path.exists', return_value=True)
+@patch('os.path.isfile', return_value=True)
+@patch('builtins.open', mock_open(read_data=config_yaml))
+def test_parse_config_yaml(isfile, exists):
+    settings = Settings._load_config_file()
+    assert settings['libvirt_host'] == 'foo'
+    assert settings['other_roles']['octopus'] == [
+        ['master', 'mon', 'mgr', 'storage'],
+        ['mon', 'mgr', 'storage'],
+        ['mon', 'mgr', 'storage'],
+    ]
+    assert len(settings['other_roles'].keys()) == 9


### PR DESCRIPTION
Replace `yaml.load` with `safe_load` to fix pycodestyle issue and ensure
using tests that `safe_load` is capable of loading the `config.yaml`
file correctly, including the ability to use the YAML reference (which
is not explicitly documented in the sesdev docs but part of YAML).

`yaml.load` has been to be used without a Loader. However it is unsafe and
has been used way too frequently, although the documentation of PyYAML
has always stated that it is unsafe.

Fixes: #618 

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>