### PR TITLE
provision.sh: zealously remove bogus loopback assignments from /etc/hosts

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -48,11 +48,11 @@ echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/host
 {% endif %}
 {% endfor %}
 
-# Vagrant sometimes adds a bogus 127.0.0.1 line at the beginning of /etc/hosts:
+# Vagrant sometimes adds a bogus 127.0.0.1 to /etc/hosts:
 # If it's there, delete it!
 echo "State of /etc/hosts loopback assignments (BEFORE sed)" >/dev/null
 grep -E '^127\.[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+' /etc/hosts
-sed -i -e '1,1 {/^127\.[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\t{{ node.fqdn }}\t{{ node.name }}/ d}' /etc/hosts
+sed -i -e '/^127\.[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\s\+{{ node.fqdn }}\s\+{{ node.name }}/ d' /etc/hosts
 echo "State of /etc/hosts loopback assignments (AFTER sed)" >/dev/null
 grep -E '^127\.[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+' /etc/hosts
 


### PR DESCRIPTION
The previous implementation only removed bogus loopback assignments from the first line of /etc/hosts, and expected a single tab character between each field when doing the replacement.  I've since found with vagrant 2.2.19 deploying SES6 on SLE 15 SP1, that the loopback assignment is in the middle of the file, and uses spaces, not tabs.

This change makes provision.sh remove bogus loopback assignments wherever they are in the file, and it doesn't care about what kind of whitespace is used.

Signed-off-by: Tim Serong <tserong@suse.com>