### PR TITLE
tunnel: improve finding dashboard node

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -1406,6 +1406,12 @@ deployment might not be completely destroyed.
         nodes = [name for name, node in self.nodes.items() if service in node.roles]
         return nodes[0] if nodes else None
 
+    def _find_node_by_address(self, address):
+        for name, node in self.nodes.items():
+            if node.has_address(address):
+                return name
+        return None
+
     def start_port_forwarding(self, service=None, node=None, remote_port=None, local_port=None,
                               local_address=None):
         if local_address is None:
@@ -1448,7 +1454,11 @@ deployment might not be completely destroyed.
                     Log.debug("Decoded json: {}".format(decoded_json))
                     dashboard_url = decoded_json['dashboard']
                     Log.debug("Dashboard URL: {}".format(dashboard_url))
-                    node = re.match(r"https://([^.]*).*", dashboard_url).group(1)
+                    dashboard_address = re.match(
+                        r"https://([^:]+)", dashboard_url).group(1)
+                    node = self._find_node_by_address(dashboard_address)
+                    if not node and dashboard_address:
+                        node = re.match(r"^([^.]+)", dashboard_address).group(1)
                     Log.debug("Extracted node: {}".format(node))
                 except (CmdException, AttributeError, KeyError):
                     node = 'null'

--- a/seslib/node.py
+++ b/seslib/node.py
@@ -47,6 +47,10 @@ class Node():
             raise RoleNotKnown(role)
         return self.roles == [role]
 
+    def has_address(self, address):
+        return address in \
+            (self.fqdn, self.public_address, self.cluster_address)
+
     def add_custom_repo(self, zypper_repo):
         """
         Takes a ZypperRepo object


### PR DESCRIPTION
In ses7p `ceph mgr services` returns:

{
    "dashboard": "https://10.20.161.201:8443/",
    "prometheus": "http://10.20.161.201:9283/"
}

While in older releases it was:

{
    "dashboard": "https://node3.ses7.test:8443/",
    "prometheus": "http://node3.ses7.test:9283/"
}

This change makes it work for the both cases.

Fixes: https://github.com/SUSE/sesdev/issues/622
Signed-off-by: Mykola Golub <mgolub@suse.com>