### PR TITLE
Add downstream container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,8 @@ following to your `~/.sesdev/config.yaml`:
 
 ```
 image_paths_devel:
-    octopus: 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'
+    octopus:
+        ceph: 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'
 ```
 
 #### With custom registry
@@ -723,7 +724,8 @@ version_devel_repos:
             - 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/openSUSE_Leap_15.2'
             - '96!https://download.opensuse.org/repositories/filesystems:/ceph:/octopus:/upstream/openSUSE_Leap_15.2'
 image_paths_devel:
-    octopus: 'registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph'
+    octopus:
+        ceph: 'registry.opensuse.org/filesystems/ceph/octopus/upstream/images/ceph/ceph'
 ```
 
 Note: The elevated priority on the `filesystems:ceph:octopus:upstream`
@@ -779,7 +781,8 @@ version_devel_repos:
             - 'http://download.suse.de/ibs/Devel:/Storage:/7.0/images/repo/SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/'
             - '96!http://download.suse.de/ibs/Devel:/Storage:/7.0:/CR/SLE_15_SP2/'
 image_paths_devel:
-    ses7: 'registry.suse.de/devel/storage/7.0/cr/containers/ses/7/ceph/ceph'
+    ses7:
+        ceph: 'registry.suse.de/devel/storage/7.0/cr/containers/ses/7/ceph/ceph'
 ```
 
 Note: The elevated priority on the `Devel:Storage:7.0:CR` repo is needed to

--- a/README.md
+++ b/README.md
@@ -566,12 +566,12 @@ create`.
 
 #### Without the devel repo
 
-The "core" deployment targets (ses5, nautilus, ses6, octopus, ses7, pacific)
-all have a concept of a "devel" repo where updates to the Ceph/storage-related
-packages are staged. Since users frequently want to install the "latest,
-greatest" packages, the "devel" repo is added to all nodes by default. However,
-there are times when this is not desired: when using sesdev to simulate
-update/upgrade scenarios, for example.
+The "core" deployment targets (ses5, nautilus, ses6, octopus, ses7, ses7p,
+pacific) all have a concept of a "devel" repo where updates to the
+Ceph/storage-related packages are staged. Since users frequently want to install
+the "latest, greatest" packages, the "devel" repo is added to all nodes by
+default. However, there are times when this is not desired: when using sesdev to
+simulate update/upgrade scenarios, for example.
 
 To deploy a Ceph cluster without the "devel" repo, give the `--product` option
 on the `sesdev create` command line.

--- a/examples/sesdev-config.yaml
+++ b/examples/sesdev-config.yaml
@@ -24,7 +24,8 @@ version_devel_repos:
             - 'http://1.2.3.4/mirror/SUSE-Enterprise-Storage-7-POOL-x86_64-Build88.46'
 
 image_paths_devel:
-    ses7: 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph'
+    ses7:
+        ceph: 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph'
 
 container_registry:
     prefix: 'registry.suse.de'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jinja2
+requests

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -116,6 +116,10 @@ def ceph_salt_options(func):
                      help='registry path from which to download Node-Exporter container image'),
         click.option('--alertmanager-image-path', type=str, default=None,
                      help='registry path from which to download Alertmanager container image'),
+        click.option('--keepalived-image-path', type=str, default=None,
+                     help='registry path from which to download Keepalived container image'),
+        click.option('--haproxy-image-path', type=str, default=None,
+                     help='registry path from which to download HAProxy container image'),
 
         click.option('--salt/--ceph-salt', default=False,
                      help='Use "salt" (instead of "ceph-salt") to run ceph-salt formula'),
@@ -388,6 +392,8 @@ def _gen_settings_dict(
         prometheus_image_path=None,
         node_exporter_image_path=None,
         alertmanager_image_path=None,
+        haproxy_image_path=None,
+        keepalived_image_path=None,
         ipv6=None,
         libvirt_host=None,
         libvirt_networks=None,
@@ -614,6 +620,10 @@ def _gen_settings_dict(
         settings_dict['prometheus_image_path'] = prometheus_image_path
     if alertmanager_image_path is not None:
         settings_dict['alertmanager_image_path'] = alertmanager_image_path
+    if keepalived_image_path is not None:
+        settings_dict['keepalived_image_path'] = keepalived_image_path
+    if haproxy_image_path is not None:
+        settings_dict['haproxy_image_path'] = haproxy_image_path
 
     if ceph_repo is not None:
         match = re.search(r'github\.com', ceph_repo)

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -143,7 +143,8 @@ def common_create_options(func):
         click.option('--repo-priority/--no-repo-priority', default=False,
                      help="Automatically set priority on custom zypper repos"),
         click.option('--devel/--product', default=True,
-                     help="Include devel repo, if applicable"),
+                     help=("Include devel repo, if applicable. By default, the devel repos will be "
+                           "used.")),
         click.option('--qa-test/--no-qa-test', 'qa_test_opt', default=False,
                      help="Automatically run integration tests on the deployed cluster"),
         click.option('--scc-user', type=str, default=None,

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -97,12 +97,26 @@ def ceph_salt_options(func):
                      help='Stop deployment before running "cephadm bootstrap"'),
         click.option('--stop-before-ceph-orch-apply', is_flag=True, default=False,
                      help='Stop deployment before applying ceph orch service spec'),
+
         click.option('--ceph-salt-repo', type=str, default=None,
                      help='ceph-salt Git repo URL'),
         click.option('--ceph-salt-branch', type=str, default=None,
                      help='ceph-salt Git branch'),
+
         click.option('--image-path', type=str, default=None,
+                     help='registry path from which to download Ceph base container image '
+                          '(deprecated)'),
+        click.option('--ceph-image-path', type=str, default=None,
                      help='registry path from which to download Ceph base container image'),
+        click.option('--grafana-image-path', type=str, default=None,
+                     help='registry path from which to download Grafana container image'),
+        click.option('--prometheus-image-path', type=str, default=None,
+                     help='registry path from which to download Prometheus container image'),
+        click.option('--node-exporter-image-path', type=str, default=None,
+                     help='registry path from which to download Node-Exporter container image'),
+        click.option('--alertmanager-image-path', type=str, default=None,
+                     help='registry path from which to download Alertmanager container image'),
+
         click.option('--salt/--ceph-salt', default=False,
                      help='Use "salt" (instead of "ceph-salt") to run ceph-salt formula'),
         click.option('--msgr2-secure-mode', is_flag=True, default=False,
@@ -368,7 +382,12 @@ def _gen_settings_dict(
         encrypted_osds=None,
         force=None,
         fqdn=None,
-        image_path=None,
+        image_path=None,  # kept for backwards compatibility
+        ceph_image_path=None,
+        grafana_image_path=None,
+        prometheus_image_path=None,
+        node_exporter_image_path=None,
+        alertmanager_image_path=None,
         ipv6=None,
         libvirt_host=None,
         libvirt_networks=None,
@@ -585,8 +604,16 @@ def _gen_settings_dict(
     if stop_before_ceph_orch_apply is not None:
         settings_dict['stop_before_ceph_orch_apply'] = stop_before_ceph_orch_apply
 
-    if image_path is not None:
-        settings_dict['image_path'] = image_path
+    if image_path is not None or ceph_image_path is not None:
+        settings_dict['ceph_image_path'] = ceph_image_path or image_path
+    if grafana_image_path is not None:
+        settings_dict['grafana_image_path'] = grafana_image_path
+    if node_exporter_image_path is not None:
+        settings_dict['node_exporter_image_path'] = node_exporter_image_path
+    if prometheus_image_path is not None:
+        settings_dict['prometheus_image_path'] = prometheus_image_path
+    if alertmanager_image_path is not None:
+        settings_dict['alertmanager_image_path'] = alertmanager_image_path
 
     if ceph_repo is not None:
         match = re.search(r'github\.com', ceph_repo)

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -120,6 +120,8 @@ def ceph_salt_options(func):
                      help='registry path from which to download Keepalived container image'),
         click.option('--haproxy-image-path', type=str, default=None,
                      help='registry path from which to download HAProxy container image'),
+        click.option('--snmp-gateway-image-path', type=str, default=None,
+                     help='registry path from which to download SNMP-Gateway container image'),
 
         click.option('--salt/--ceph-salt', default=False,
                      help='Use "salt" (instead of "ceph-salt") to run ceph-salt formula'),
@@ -394,6 +396,7 @@ def _gen_settings_dict(
         alertmanager_image_path=None,
         haproxy_image_path=None,
         keepalived_image_path=None,
+        snmp_gateway_image_path=None,
         ipv6=None,
         libvirt_host=None,
         libvirt_networks=None,
@@ -624,6 +627,8 @@ def _gen_settings_dict(
         settings_dict['keepalived_image_path'] = keepalived_image_path
     if haproxy_image_path is not None:
         settings_dict['haproxy_image_path'] = haproxy_image_path
+    if snmp_gateway_image_path is not None:
+        settings_dict['snmp_gateway_image_path'] = snmp_gateway_image_path
 
     if ceph_repo is not None:
         match = re.search(r'github\.com', ceph_repo)

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -40,7 +40,15 @@ class Constant():
             'ceph': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
         },
         'ses7p': {
-            'ceph': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph'
+            'ceph': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph',
+            'grafana': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
+                       'ceph/grafana:7.5.12',
+            'prometheus': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
+                          'prometheus/prometheus-server:2.27.1',
+            'alertmanager': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
+                            'prometheus/prometheus-alertmanager:0.21.0',
+            'node-exporter': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
+                             'prometheus/prometheus-node-exporter:1.1.2',
         },
         'octopus': {
             'ceph': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -44,7 +44,7 @@ class Constant():
             'grafana': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
                        'ceph/grafana:7.5.12',
             'prometheus': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                          'prometheus/prometheus-server:2.27.1',
+                          'prometheus/prometheus-server:2.32.1',
             'alertmanager': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
                             'prometheus/prometheus-alertmanager:0.21.0',
             'node-exporter': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -38,27 +38,53 @@ class Constant():
     IMAGE_PATHS_DEVEL = {
         'ses7': {
             'ceph': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
+            'grafana': 'registry.suse.de/devel/storage/7.0/containers/ses/7/'
+                       'ceph/grafana:latest',
+            'prometheus': 'registry.suse.de/devel/storage/7.0/containers/ses/7/'
+                          'ceph/prometheus-server:latest',
+            'alertmanager': 'registry.suse.de/devel/storage/7.0/containers/ses/7/'
+                            'ceph/prometheus-alertmanager:latest',
+            'node-exporter': 'registry.suse.de/devel/storage/7.0/containers/ses/7/'
+                             'ceph/prometheus-node-exporter:latest',
         },
         'ses7p': {
             'ceph': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph',
             'grafana': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                       'ceph/grafana:7.5.12',
+                       'ceph/grafana:latest',
             'prometheus': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                          'ceph/prometheus-server:2.32.1',
+                          'ceph/prometheus-server:latest',
             'alertmanager': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                            'ceph/prometheus-alertmanager:0.21.0',
+                            'ceph/prometheus-alertmanager:latest',
             'node-exporter': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                             'ceph/prometheus-node-exporter:1.1.2',
+                             'ceph/prometheus-node-exporter:latest',
             'haproxy': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                       'ceph/haproxy:2.0.14',
+                       'ceph/haproxy:latest',
             'keepalived': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/'
-                          'keepalived:2.0.19',
+                          'keepalived:latest',
+            'snmp-gateway': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/'
+                            'prometheus-snmp_notifier:latest',
         },
         'octopus': {
-            'ceph': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'
+            'ceph': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph',
+            'grafana': 'registry.opensuse.org/filesystems/ceph/octopus/images/'
+                       'ceph/grafana:latest',
+            'prometheus': 'registry.opensuse.org/filesystems/ceph/octopus/images/'
+                          'ceph/prometheus-server:latest',
+            'alertmanager': 'registry.opensuse.org/filesystems/ceph/octopus/images/'
+                            'ceph/prometheus-alertmanager:latest',
+            'node-exporter': 'registry.opensuse.org/filesystems/ceph/octopus/images/'
+                             'ceph/prometheus-node-exporter:latest',
         },
         'pacific': {
-            'ceph': 'registry.opensuse.org/filesystems/ceph/pacific/images/ceph/ceph'
+            'ceph': 'registry.opensuse.org/filesystems/ceph/pacific/images/ceph/ceph',
+            'grafana': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
+                       'ceph/grafana:latest',
+            'prometheus': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
+                          'ceph/prometheus-server:latest',
+            'alertmanager': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
+                            'ceph/prometheus-alertmanager:latest',
+            'node-exporter': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
+                             'ceph/prometheus-node-exporter:latest',
         },
     }
 

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -36,14 +36,27 @@ class Constant():
     }
 
     IMAGE_PATHS_DEVEL = {
-        'ses7': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
-        'ses7p': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph',
-        'octopus': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph',
-        'pacific': 'registry.opensuse.org/filesystems/ceph/pacific/images/ceph/ceph',
+        'ses7': {
+            'ceph': 'registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph',
+        },
+        'ses7p': {
+            'ceph': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph'
+        },
+        'octopus': {
+            'ceph': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'
+        },
+        'pacific': {
+            'ceph': 'registry.opensuse.org/filesystems/ceph/pacific/images/ceph/ceph'
+        },
     }
 
     IMAGE_PATHS_PRODUCT = {
-        'ses7': 'registry.suse.com/ses/7/ceph/ceph',
+        'ses7': {
+            'ceph': 'registry.suse.com/ses/7/ceph/ceph',
+        },
+        'ses7p': {
+            'ceph': 'registry.suse.com/ses/7.1/ceph/ceph',
+        }
     }
 
     INTERNAL_MEDIA_REPOS = {

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -49,6 +49,10 @@ class Constant():
                             'prometheus/prometheus-alertmanager:0.21.0',
             'node-exporter': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
                              'prometheus/prometheus-node-exporter:1.1.2',
+            'haproxy': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
+                       'ceph/haproxy:2.0.14',
+            'keepalived': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/'
+                          'keepalived:2.0.19',
         },
         'octopus': {
             'ceph': 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -44,11 +44,11 @@ class Constant():
             'grafana': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
                        'ceph/grafana:7.5.12',
             'prometheus': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                          'prometheus/prometheus-server:2.32.1',
+                          'ceph/prometheus-server:2.32.1',
             'alertmanager': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                            'prometheus/prometheus-alertmanager:0.21.0',
+                            'ceph/prometheus-alertmanager:0.21.0',
             'node-exporter': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
-                             'prometheus/prometheus-node-exporter:1.1.2',
+                             'ceph/prometheus-node-exporter:1.1.2',
             'haproxy': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/'
                        'ceph/haproxy:2.0.14',
             'keepalived': 'registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/'

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -201,6 +201,10 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                 self.settings.node_exporter_image_path = image_paths.get('node-exporter')
             if self.settings.alertmanager_image_path == '':
                 self.settings.alertmanager_image_path = image_paths.get('alertmanager')
+            if self.settings.haproxy_image_path == '':
+                self.settings.haproxy_image_path = image_paths.get('haproxy')
+            if self.settings.keepalived_image_path == '':
+                self.settings.keepalived_image_path = image_paths.get('keepalived')
 
     def __set_up_make_check(self):
         self.settings.override('single_node', True)
@@ -641,6 +645,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'prometheus_image_path': self.settings.prometheus_image_path,
             'node_exporter_image_path': self.settings.node_exporter_image_path,
             'alertmanager_image_path': self.settings.alertmanager_image_path,
+            'haproxy_image_path': self.settings.haproxy_image_path,
+            'keepalived_image_path': self.settings.keepalived_image_path,
             'use_salt': self.settings.use_salt,
             'node_manager': NodeManager(list(self.nodes.values())),
             'caasp_deploy_ses': self.settings.caasp_deploy_ses,
@@ -998,6 +1004,10 @@ deployment might not be completely destroyed.
                     self.settings.grafana_image_path)
                 result += "- node_exporter_image_path: {}\n".format(
                     self.settings.node_exporter_image_path)
+                result += "- haproxy_image_path:       {}\n".format(
+                    self.settings.haproxy_image_path)
+                result += "- keepalived_image_path:    {}\n".format(
+                    self.settings.keepalived_image_path)
             for synced_folder in self.settings.synced_folder:
                 result += "- synced_folder:    {}\n".format(' -> '.join(synced_folder))
             if self.settings.custom_repos:

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -170,14 +170,28 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             self.settings.reg = None
 
     def __populate_image_path(self):
-        if self.settings.deployment_tool == 'cephadm' and not self.settings.image_path:
-            if not self.settings.devel_repo:
-                if self.settings.version in self.settings.image_paths_product:
-                    self.settings.image_path = \
-                        self.settings.image_paths_product[self.settings.version]
-                    return
-            self.settings.image_path = \
-                self.settings.image_paths_devel[self.settings.version]
+        """
+        Set the image paths based on the `devel_repo` setting to either devel or
+        product.
+        """
+        if self.settings.deployment_tool != 'cephadm' or self.settings.image_path != '':
+            return
+
+        version = self.settings.version
+        # product
+        if not self.settings.devel_repo:
+            if (
+                version in self.settings.image_paths_product
+                and 'ceph' in self.settings.image_paths_product[version]
+            ):
+                self.settings.image_path = self.settings.image_paths_product[version]['ceph']
+                return
+
+            Log.warning('--product was selected but no product image was found for ceph. '
+                        'Using devel image instead.')
+
+        # devel
+        self.settings.image_path = self.settings.image_paths_devel[version]['ceph']
 
     def __set_up_make_check(self):
         self.settings.override('single_node', True)

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -980,7 +980,16 @@ deployment might not be completely destroyed.
                 result += ("- git branch:       {}\n"
                            .format(self.settings.makecheck_ceph_branch))
             if self.settings.version in ['octopus', 'ses7', 'pacific', 'ses7p']:
-                result += "- ceph_image_path:       {}\n".format(self.settings.ceph_image_path)
+                result += "- ceph_image_path:          {}\n".format(
+                    self.settings.ceph_image_path)
+                result += "- prometheus_image_path:    {}\n".format(
+                    self.settings.prometheus_image_path)
+                result += "- alertmanager_image_path:  {}\n".format(
+                    self.settings.alertmanager_image_path)
+                result += "- grafana_image_path:       {}\n".format(
+                    self.settings.grafana_image_path)
+                result += "- node_exporter_image_path: {}\n".format(
+                    self.settings.node_exporter_image_path)
             for synced_folder in self.settings.synced_folder:
                 result += "- synced_folder:    {}\n".format(' -> '.join(synced_folder))
             if self.settings.custom_repos:

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -21,6 +21,7 @@ from .exceptions import \
                         CmdException, \
                         DeploymentAlreadyExists, \
                         DeploymentDoesNotExists, \
+                        DeploymentIncompatible, \
                         DepIDWrongLength, \
                         DepIDIllegalChars, \
                         DuplicateRolesNotSupported, \
@@ -121,7 +122,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.__populate_os()
         self.__populate_deployment_tool()
         self.__populate_container_registry()
-        self.__populate_image_path()
+        self.__populate_image_paths()
         if not self.settings.libvirt_networks and not existing:
             self.__generate_static_networks()
         if self.settings.version in ['makecheck']:
@@ -169,29 +170,29 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         else:
             self.settings.reg = None
 
-    def __populate_image_path(self):
+    def __populate_image_paths(self):
         """
-        Set the image paths based on the `devel_repo` setting to either devel or
-        product.
+        Set the image paths based on the `devel_repo` setting to either "devel"
+        or "product".
         """
-        if self.settings.deployment_tool != 'cephadm' or self.settings.image_path != '':
+        if self.settings.deployment_tool != 'cephadm':
             return
 
-        version = self.settings.version
-        # product
-        if not self.settings.devel_repo:
-            if (
-                version in self.settings.image_paths_product
-                and 'ceph' in self.settings.image_paths_product[version]
-            ):
-                self.settings.image_path = self.settings.image_paths_product[version]['ceph']
-                return
+        if self.settings.devel_repo:
+            image_paths = self.settings.image_paths_devel[self.settings.version]
+        else:
+            image_paths = self.settings.image_paths_product[self.settings.version]
 
-            Log.warning('--product was selected but no product image was found for ceph. '
-                        'Using devel image instead.')
-
-        # devel
-        self.settings.image_path = self.settings.image_paths_devel[version]['ceph']
+        if self.settings.ceph_image_path == '':
+            self.settings.ceph_image_path = image_paths['ceph']  # must be specified
+        if self.settings.grafana_image_path == '':
+            self.settings.grafana_image_path = image_paths.get('grafana')
+        if self.settings.prometheus_image_path == '':
+            self.settings.prometheus_image_path = image_paths.get('prometheus')
+        if self.settings.node_exporter_image_path == '':
+            self.settings.node_exporter_image_path = image_paths.get('node-exporter')
+        if self.settings.alertmanager_image_path == '':
+            self.settings.alertmanager_image_path = image_paths.get('alertmanager')
 
     def __set_up_make_check(self):
         self.settings.override('single_node', True)
@@ -627,7 +628,11 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'stop_before_ceph_orch_apply': self.settings.stop_before_ceph_orch_apply,
             'stop_before_cephadm_bootstrap': self.settings.stop_before_cephadm_bootstrap,
             'reg': self.settings.reg,
-            'image_path': self.settings.image_path,
+            'ceph_image_path': self.settings.ceph_image_path,
+            'grafana_image_path': self.settings.grafana_image_path,
+            'prometheus_image_path': self.settings.prometheus_image_path,
+            'node_exporter_image_path': self.settings.node_exporter_image_path,
+            'alertmanager_image_path': self.settings.alertmanager_image_path,
             'use_salt': self.settings.use_salt,
             'node_manager': NodeManager(list(self.nodes.values())),
             'caasp_deploy_ses': self.settings.caasp_deploy_ses,
@@ -975,7 +980,7 @@ deployment might not be completely destroyed.
                 result += ("- git branch:       {}\n"
                            .format(self.settings.makecheck_ceph_branch))
             if self.settings.version in ['octopus', 'ses7', 'pacific', 'ses7p']:
-                result += "- image_path:       {}\n".format(self.settings.image_path)
+                result += "- ceph_image_path:       {}\n".format(self.settings.ceph_image_path)
             for synced_folder in self.settings.synced_folder:
                 result += "- synced_folder:    {}\n".format(' -> '.join(synced_folder))
             if self.settings.custom_repos:
@@ -1749,28 +1754,32 @@ deployment might not be completely destroyed.
         return dep
 
     @classmethod
-    def load(cls, dep_id, load_status=True):
+    def load(cls, dep_id, load_status=True) -> 'Deployment':
         dep_dir = os.path.join(Constant.A_WORKING_DIR, dep_id)
         if not os.path.exists(dep_dir) or not os.path.isdir(dep_dir):
             Log.debug("->{}<- does not exist or is not a directory"
                       .format(dep_dir))
             raise DeploymentDoesNotExists(dep_id)
+
         metadata_file = os.path.join(dep_dir, Constant.METADATA_FILENAME)
         if not os.path.exists(metadata_file) or not os.path.isfile(metadata_file):
             Log.debug("metadata file ->{}<- does not exist or is not a file"
                       .format(metadata_file))
             raise DeploymentDoesNotExists(dep_id)
-
         with open(metadata_file, 'r', encoding='utf-8') as file:
             metadata = json.load(file)
+        try:
+            dep = cls(metadata['id'], Settings(strict=False, **metadata['settings']), existing=True)
+            if load_status:
+                dep.load_status()
+            return dep
 
-        dep = cls(metadata['id'], Settings(strict=False, **metadata['settings']), existing=True)
-        if load_status:
-            dep.load_status()
-        return dep
+        except (AttributeError, TypeError) as error:
+            Log.debug(error)
+            raise DeploymentIncompatible(dep_id) from error
 
     @classmethod
-    def list(cls, load_status=False):
+    def list(cls, load_status=False) -> List['Deployment']:
         curframe = inspect.currentframe()
         calframe = inspect.getouterframes(curframe, 2)
         Log.debug("Entering deployment.list (called from ->{}<-)".format(calframe[1][3]))
@@ -1791,4 +1800,8 @@ deployment might not be completely destroyed.
                 deps.append(Deployment.load(dep_id, load_status))
             except DeploymentDoesNotExists:
                 continue
+            except DeploymentIncompatible:
+                Log.warning(
+                    f'Deployment {dep_id} is incompatible with the current version of sesdev'
+                )
         return deps

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -974,7 +974,7 @@ deployment might not be completely destroyed.
                            .format(self.settings.makecheck_ceph_repo))
                 result += ("- git branch:       {}\n"
                            .format(self.settings.makecheck_ceph_branch))
-            if self.settings.version in ['octopus', 'ses7', 'pacific']:
+            if self.settings.version in ['octopus', 'ses7', 'pacific', 'ses7p']:
                 result += "- image_path:       {}\n".format(self.settings.image_path)
             for synced_folder in self.settings.synced_folder:
                 result += "- synced_folder:    {}\n".format(' -> '.join(synced_folder))

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -205,6 +205,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                 self.settings.haproxy_image_path = image_paths.get('haproxy')
             if self.settings.keepalived_image_path == '':
                 self.settings.keepalived_image_path = image_paths.get('keepalived')
+            if self.settings.snmp_gateway_image_path == '':
+                self.settings.snmp_gateway_image_path = image_paths.get('snmp-gateway')
 
     def __set_up_make_check(self):
         self.settings.override('single_node', True)
@@ -647,6 +649,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'alertmanager_image_path': self.settings.alertmanager_image_path,
             'haproxy_image_path': self.settings.haproxy_image_path,
             'keepalived_image_path': self.settings.keepalived_image_path,
+            'snmp_gateway_image_path': self.settings.snmp_gateway_image_path,
             'use_salt': self.settings.use_salt,
             'node_manager': NodeManager(list(self.nodes.values())),
             'caasp_deploy_ses': self.settings.caasp_deploy_ses,
@@ -1008,6 +1011,8 @@ deployment might not be completely destroyed.
                     self.settings.haproxy_image_path)
                 result += "- keepalived_image_path:    {}\n".format(
                     self.settings.keepalived_image_path)
+                result += "- snmp_gateway_image_path:  {}\n".format(
+                    self.settings.snmp_gateway_image_path)
             for synced_folder in self.settings.synced_folder:
                 result += "- synced_folder:    {}\n".format(' -> '.join(synced_folder))
             if self.settings.custom_repos:

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -183,16 +183,24 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         else:
             image_paths = self.settings.image_paths_product[self.settings.version]
 
-        if self.settings.ceph_image_path == '':
-            self.settings.ceph_image_path = image_paths['ceph']  # must be specified
-        if self.settings.grafana_image_path == '':
-            self.settings.grafana_image_path = image_paths.get('grafana')
-        if self.settings.prometheus_image_path == '':
-            self.settings.prometheus_image_path = image_paths.get('prometheus')
-        if self.settings.node_exporter_image_path == '':
-            self.settings.node_exporter_image_path = image_paths.get('node-exporter')
-        if self.settings.alertmanager_image_path == '':
-            self.settings.alertmanager_image_path = image_paths.get('alertmanager')
+        if isinstance(image_paths, str):
+            # preserves compatibility to start, stop and destroy older deployments
+            self.settings.ceph_image_path = image_paths
+            Log.info(
+                f'Loaded outdated deployment {self.dep_id}. '
+                f'No issues are to be expected because of that.'
+            )
+        else:
+            if self.settings.ceph_image_path == '':
+                self.settings.ceph_image_path = image_paths['ceph']  # must be specified
+            if self.settings.grafana_image_path == '':
+                self.settings.grafana_image_path = image_paths.get('grafana')
+            if self.settings.prometheus_image_path == '':
+                self.settings.prometheus_image_path = image_paths.get('prometheus')
+            if self.settings.node_exporter_image_path == '':
+                self.settings.node_exporter_image_path = image_paths.get('node-exporter')
+            if self.settings.alertmanager_image_path == '':
+                self.settings.alertmanager_image_path = image_paths.get('alertmanager')
 
     def __set_up_make_check(self):
         self.settings.override('single_node', True)

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -83,6 +83,13 @@ class DeploymentDoesNotExists(SesDevException):
         )
 
 
+class DeploymentIncompatible(SesDevException):
+    def __init__(self, dep_id):
+        super().__init__(
+            f"Deployment {dep_id} is incompatible"
+        )
+
+
 class DuplicateRolesNotSupported(SesDevException):
     def __init__(self, role):
         super().__init__(

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -122,17 +122,42 @@ SETTINGS = {
     },
     'image_path': {
         'type': str,
+        'help': 'Deprecated container image path for Ceph daemons.',
+        'default': '',
+    },
+    'ceph_image_path': {
+        'type': str,
         'help': 'Container image path for Ceph daemons',
+        'default': '',
+    },
+    'grafana_image_path': {
+        'type': str,
+        'help': 'Container image path for Grafana daemons',
+        'default': '',
+    },
+    'prometheus_image_path': {
+        'type': str,
+        'help': 'Container image path for Prometheus daemons',
+        'default': '',
+    },
+    'node_exporter_image_path': {
+        'type': str,
+        'help': 'Container image path for Node-Exporter daemons',
+        'default': '',
+    },
+    'alertmanager_image_path': {
+        'type': str,
+        'help': 'Container image path for Alertmanager daemons',
         'default': '',
     },
     'image_paths_devel': {
         'type': dict,
-        'help': 'paths to devel container images',
+        'help': 'Paths to devel container images',
         'default': Constant.IMAGE_PATHS_DEVEL,
     },
     'image_paths_product': {
         'type': dict,
-        'help': 'paths to product container images',
+        'help': 'Paths to product container images',
         'default': Constant.IMAGE_PATHS_PRODUCT,
     },
     'internal_media_repos': {

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -160,6 +160,11 @@ SETTINGS = {
         'help': 'Container image path for HAProxy daemons',
         'default': '',
     },
+    'snmp_gateway_image_path': {
+        'type': str,
+        'help': 'Container image path for SNMP-Gateway daemons',
+        'default': '',
+    },
     'image_paths_devel': {
         'type': dict,
         'help': 'Paths to devel container images',

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -150,6 +150,16 @@ SETTINGS = {
         'help': 'Container image path for Alertmanager daemons',
         'default': '',
     },
+    'keepalived_image_path': {
+        'type': str,
+        'help': 'Container image path for Keepalived daemons',
+        'default': '',
+    },
+    'haproxy_image_path': {
+        'type': str,
+        'help': 'Container image path for HAProxy daemons',
+        'default': '',
+    },
     'image_paths_devel': {
         'type': dict,
         'help': 'Paths to devel container images',

--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -226,6 +226,11 @@ ceph mgr module enable prometheus
 
 {% if rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring %}
 
+ceph config set mgr mgr/cephadm/container_image_prometheus {{prometheus_image_path}}
+ceph config set mgr mgr/cephadm/container_image_grafana {{grafana_image_path}}
+ceph config set mgr mgr/cephadm/container_image_alertmanager {{alertmanager_image_path}}
+ceph config set mgr mgr/cephadm/container_image_node_exporter {{node_exporter_image_path}}
+
 {% set service_spec_gw = "/root/service_spec_gw.yml" %}
 rm -f {{ service_spec_gw }}
 touch {{ service_spec_gw }}

--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -1,5 +1,21 @@
+{% if prometheus_image_path %}
+ceph config set mgr mgr/cephadm/container_image_prometheus {{prometheus_image_path}}
+{% endif %}
+{% if grafana_image_path %}
+ceph config set mgr mgr/cephadm/container_image_grafana {{grafana_image_path}}
+{% endif %}
+{% if alertmanager_image_path %}
+ceph config set mgr mgr/cephadm/container_image_alertmanager {{alertmanager_image_path}}
+{% endif %}
+{% if node_exporter_image_path %}
+ceph config set mgr mgr/cephadm/container_image_node_exporter {{node_exporter_image_path}}
+{% endif %}
+{% if keepalived_image_path %}
 ceph config set mgr mgr/cephadm/container_image_keepalived {{keepalived_image_path}}
+{% endif %}
+{% if haproxy_image_path %}
 ceph config set mgr mgr/cephadm/container_image_haproxy {{haproxy_image_path}}
+{% endif %}
 
 {% set service_spec_core = "/root/service_spec_core.yml" %}
 rm -f {{ service_spec_core }}
@@ -227,11 +243,6 @@ ceph mgr module enable prometheus
 {% endif %}{# grafana_nodes > 0 or alertmanager_nodes > 0 #}
 
 {% if rgw_nodes > 0 or igw_nodes > 0 or deploy_monitoring %}
-
-ceph config set mgr mgr/cephadm/container_image_prometheus {{prometheus_image_path}}
-ceph config set mgr mgr/cephadm/container_image_grafana {{grafana_image_path}}
-ceph config set mgr mgr/cephadm/container_image_alertmanager {{alertmanager_image_path}}
-ceph config set mgr mgr/cephadm/container_image_node_exporter {{node_exporter_image_path}}
 
 {% set service_spec_gw = "/root/service_spec_gw.yml" %}
 rm -f {{ service_spec_gw }}

--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -16,6 +16,9 @@ ceph config set mgr mgr/cephadm/container_image_keepalived {{keepalived_image_pa
 {% if haproxy_image_path %}
 ceph config set mgr mgr/cephadm/container_image_haproxy {{haproxy_image_path}}
 {% endif %}
+{% if snmp_gateway_image_path %}
+ceph config set mgr mgr/cephadm/container_image_snmp_gateway {{snmp_gateway_image_path}}
+{% endif %}
 
 {% set service_spec_core = "/root/service_spec_core.yml" %}
 rm -f {{ service_spec_core }}

--- a/seslib/templates/cephadm/deployment_day_2.sh.j2
+++ b/seslib/templates/cephadm/deployment_day_2.sh.j2
@@ -1,3 +1,5 @@
+ceph config set mgr mgr/cephadm/container_image_keepalived {{keepalived_image_path}}
+ceph config set mgr mgr/cephadm/container_image_haproxy {{haproxy_image_path}}
 
 {% set service_spec_core = "/root/service_spec_core.yml" %}
 rm -f {{ service_spec_core }}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -167,6 +167,7 @@ fi
 {% include "salt/provision.sh.j2" %}
 {% if node == master %}
 {% include "salt/ceph-salt/deployment_day_1.sh.j2" %}
+
 {% include "cephadm/deployment_day_2.sh.j2" %}
 {% include "salt/qa_test.j2" %}
 {% endif %}{# node == master #}

--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -76,8 +76,8 @@ ceph-salt config /time_server/subnet set {{ public_network }}
 ceph-salt config /containers/registries_conf/registries add prefix={{ reg.prefix }} location={{ reg.location }} insecure={{ reg.insecure }}
 {% endif %}
 
-{% if image_path %}
-ceph-salt config /cephadm_bootstrap/ceph_image_path set {{ image_path }}
+{% if ceph_image_path %}
+ceph-salt config /cephadm_bootstrap/ceph_image_path set {{ ceph_image_path }}
 {% endif %}
 
 {% if storage_nodes < 3 %}

--- a/seslib/tools.py
+++ b/seslib/tools.py
@@ -6,6 +6,10 @@ import string
 import subprocess
 import sys
 import time
+from urllib.parse import urlparse
+from typing import Tuple
+
+import requests
 
 from .exceptions import CmdException
 from .log import Log
@@ -79,3 +83,16 @@ def gen_random_string(length):
     letters = string.ascii_letters
     result_str = ''.join(random.choice(letters) for i in range(length))
     return result_str.lower()
+
+
+def image_manifest_exists(image_url: str) -> Tuple[bool, requests.Response]:
+    def container_path_to_manifest_url(container_path: str) -> str:
+        tag = "latest"
+        if re.search(r":(\w+)$", container_path):
+            container_path, tag = container_path.rsplit(":", 1)
+        url = urlparse(f"https://{container_path}")
+        return f"{url.scheme}://{url.netloc}/v2{url.path}/manifests/{tag}"
+
+    url = container_path_to_manifest_url(image_url)
+    resp = requests.head(url, verify=False)
+    return resp.status_code == 200, resp

--- a/tests/test_container_availability.py
+++ b/tests/test_container_availability.py
@@ -1,0 +1,22 @@
+from seslib.constant import Constant
+from seslib.tools import image_manifest_exists
+
+
+def test_opensuse_org_images():
+    for deployment_name, images in Constant.IMAGE_PATHS_DEVEL.items():
+        print(deployment_name)
+        for image_name, image_url in images.items():
+            # We do not have any tests for hard-coded container images yet. This
+            # is due to not reading them out in sesdev but also due to the
+            # inability to query registry.suse.com for the manifests of the
+            # container images, which is possible for registry.opensuse.org and
+            # registry.suse.de.
+            if image_url in ["registry.opensuse.org", "registry.suse.de"]:
+                exists, resp = image_manifest_exists(image_url)
+                msg = (
+                    f"Container image {image_name} of deployment {deployment_name} not available"
+                    f"Status Code: {resp.status_code}\tURL: {image_url}"
+                )
+                assert exists, msg
+
+                print(f'\tFound container image "{image_name}" in "{image_url}"')

--- a/tests/test_parse_config_yaml.py
+++ b/tests/test_parse_config_yaml.py
@@ -24,7 +24,8 @@ version_devel_repos:
       leap-15.2:
           - 'https://download.opensuse.org/repositories/filesystems:/ceph:/octopus/openSUSE_Leap_15.2'
 image_paths_devel:
-    octopus: 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'
+    octopus:
+        ceph: 'registry.opensuse.org/filesystems/ceph/octopus/images/ceph/ceph'
 container_registry:
     prefix: 'registry.suse.de'
     location: '1.2.3.4:5000'


### PR DESCRIPTION
By default, development container images from build.suse.de should be used, as also build.suse.de repositories are used (`--devel` is on by default). So, basically we'll be using development container images whenever we're using development repositories. The same applies to `--product`, container images from registry.suse.com will be used if `--product` is specified. 

This change also enables to customize container images for monitoring on deployment creation, as it is possible for the ceph image already.

Currently, development container images are unspecified for `ses7`, `octopus` and `pacific` deployments (just `ses7p` has received them so far).

The deployment report reveals which container images will be used. `None` means that the container images defined in our downstream fork will be taken over unaltered. Keep in mind that the image paths we've defined in the downstream fork point to registry.suse.com.

This change would also enable the use of `octopus` and `pacific` container images in `filesystems:ceph:octopus` and `filesystems:ceph:pacific` on OBS, although they are currently not configured to use those images automatically. One could however manually define them using 
- `--prometheus-image-path`
- `--grafana-image-path`
- `--node-exporter-image-path` and
- `--alertmanager-image-path`

when creating deployments.

```console
➜  sesdev git:(devel-containers) sesdev create ses7 --dry-run --single-node --prometheus-image-path=docker.io/ubuntu/prometheus
=== Creating deployment "ses7-mini" with the following configuration ===

Deployment-wide parameters (applicable to all VMs in deployment):

- deployment ID:    ses7-mini
- number of VMs:    1
- version:          ses7
- OS:               sles-15-sp2
- public network:   10.20.116.0/24
- ceph_image_path:          registry.suse.de/devel/storage/7.0/containers/ses/7/ceph/ceph
- prometheus_image_path:    docker.io/ubuntu/prometheus
- alertmanager_image_path:  None
- grafana_image_path:       None
- node_exporter_image_path: None
- qa_test:          False

Individual VM parameters:

[...]

Dry run. Stopping now, before creating any VMs.

Exiting...
```

If custom container images for the chosen deployment are found in sesdev, they are used and mentioned in the deployment report.

```console
➜  sesdev git:(devel-containers) sesdev create ses7p --dry-run --single-node                                                    
=== Creating deployment "ses7p-mini" with the following configuration ===

Deployment-wide parameters (applicable to all VMs in deployment):

- deployment ID:    ses7p-mini
- number of VMs:    1
- version:          ses7p
- OS:               sles-15-sp3
- public network:   10.20.21.0/24
- ceph_image_path:          registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph
- prometheus_image_path:    registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/prometheus/prometheus-server:2.27.1
- alertmanager_image_path:  registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/prometheus/prometheus-alertmanager:0.21.0
- grafana_image_path:       registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/grafana:7.5.12
- node_exporter_image_path: registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/prometheus/prometheus-node-exporter:1.1.2
- qa_test:          False

Individual VM parameters:

[...]

Dry run. Stopping now, before creating any VMs.

Exiting...
```

Command line arguments override the sesdev configuration.

```console
➜  sesdev git:(devel-containers) sesdev create ses7p --dry-run --single-node --prometheus-image-path=docker.io/ubuntu/prometheus
=== Creating deployment "ses7p-mini" with the following configuration ===

Deployment-wide parameters (applicable to all VMs in deployment):

- deployment ID:    ses7p-mini
- number of VMs:    1
- version:          ses7p
- OS:               sles-15-sp3
- public network:   10.20.20.0/24
- ceph_image_path:          registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/ceph
- prometheus_image_path:    docker.io/ubuntu/prometheus
- alertmanager_image_path:  registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/prometheus/prometheus-alertmanager:0.21.0
- grafana_image_path:       registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/ceph/grafana:7.5.12
- node_exporter_image_path: registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/prometheus/prometheus-node-exporter:1.1.2
- qa_test:          False

Individual VM parameters:

[...]

Dry run. Stopping now, before creating any VMs.

Exiting...
``