### PR TITLE
tox: speed up linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,5 +22,4 @@ commands =
 [testenv:lint]
 allowlist_externals = pylint
 commands =
-  pylint sesdev
-  pylint seslib
+  pylint -j0 sesdev seslib


### PR DESCRIPTION
From previously ~15s to ~7s by utilizing more cores using the `-j0` command line argument of `pylint`.

Note: I'm using `tox -p` to start the two tox jobs in parallel, one of which is being sped up by this PR.