### PR TITLE
seslib: Ignore Podman 2.2.1 in `octopus`

### DIFF
--- a/seslib/templates/zypper.j2
+++ b/seslib/templates/zypper.j2
@@ -39,6 +39,11 @@ zypper --non-interactive removerepo repo-source-non-oss || true
 zypper addrepo --refresh {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}
 
+# Ignore Podman 2.2.1 due to bug: https://github.com/SUSE/sesdev/issues/633
+{% if version == 'octopus' %}
+zypper addlock "podman == 2.2.1"
+{% endif %}
+
 # ses6 deepsea install from source requires:
 # - SES6 Internal Media repo
 # - SLE-15-SP1 Developer Tools Module repos


### PR DESCRIPTION
Ignore Podman 2.2.1 in `octopus` as it contains an unfixed bug that, in
conjunction with using `--network=host` leads to an `/etc/hosts` entry
being added which confuses Pythons `socket.getfqdn()` function and leads
to inaccessible links in `ceph mgr services`.

Fixes: https://github.com/SUSE/sesdev/issues/633

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>