### PR TITLE
deploy: exclude dedicated master from disks

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -384,7 +384,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                                                              200 + node_id)
                     for _ in range(self.settings.num_disks):
                         node.storage_disks.append(Disk(self.settings.disk_size))
-                elif self.settings.explicit_num_disks and not node.has_exclusive_role('master'):
+                elif self.settings.explicit_num_disks \
+                        and not node.has_exactly_roles(['master', 'admin']):
                     for _ in range(self.settings.num_disks):
                         node.storage_disks.append(Disk(self.settings.disk_size))
 

--- a/seslib/node.py
+++ b/seslib/node.py
@@ -43,9 +43,15 @@ class Node():
     def has_exclusive_role(self, role):
         Log.debug("Node {}: has_exclusive_role: self.roles: {}"
                   .format(self.fqdn, self.roles))
-        if role not in Constant.ROLES_KNOWN:
-            raise RoleNotKnown(role)
-        return self.roles == [role]
+        self.has_exactly_roles([role])
+
+    def has_exactly_roles(self, exact_roles: list):
+        Log.debug("Node {}: has_exactly_roles: self.roles: {}"
+                  .format(self.fqdn, self.roles))
+        for role in exact_roles:
+            if role not in Constant.ROLES_KNOWN:
+                raise RoleNotKnown(role)
+        return self.roles == exact_roles
 
     def has_address(self, address):
         return address in \


### PR DESCRIPTION
If a node has only the roles `master` and `admin`, it should not be
provisioned with disks when the command line option `--num-disks` is
given.
There was a check in place, but it was broken because the node with the
`master` role must also have the `admin` role and the check did not
account for that.

fixes: #450