### PR TITLE
constants: add haproxy, keepalived and snmp images

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -85,6 +85,12 @@ class Constant():
                             'ceph/prometheus-alertmanager:latest',
             'node-exporter': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
                              'ceph/prometheus-node-exporter:latest',
+            'haproxy': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
+                       'ceph/haproxy:latest',
+            'keepalived': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
+                          'ceph/keepalived:latest',
+            'snmp-gateway': 'registry.opensuse.org/filesystems/ceph/pacific/images/'
+                            'ceph/prometheus-snmp_notifier:latest',
         },
     }
 


### PR DESCRIPTION
Add HAProxy, Keppalived and SNMP Gateway image paths from OBS to
constants for pacific deployments.

Fixes: #640
Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>