### PR TITLE
add missing `requests` module to the python venv

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     PrettyTable
     pycryptodomex >= 3.4.6
     PyYAML >= 3.13
+    Requests
 
 packages =
     seslib


### PR DESCRIPTION
After bootstrap of a newly installed clone:

```
$ sesdev create ses7
Traceback (most recent call last):
  File "/root/src/github.com/mgfritch/sesdev/venv/bin/sesdev", line 33, in <module>
    sys.exit(load_entry_point('sesdev', 'console_scripts', 'sesdev')())
  File "/root/src/github.com/mgfritch/sesdev/venv/bin/sesdev", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib64/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/src/github.com/mgfritch/sesdev/sesdev/__init__.py", line 13, in <module>
    from sesdev.box import box_list_handler, box_remove_handler
  File "/root/src/github.com/mgfritch/sesdev/sesdev/box.py", line 3, in <module>
    from seslib.box import Box
  File "/root/src/github.com/mgfritch/sesdev/seslib/box.py", line 6, in <module>
    from . import tools
  File "/root/src/github.com/mgfritch/sesdev/seslib/tools.py", line 12, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```


Signed-off-by: Michael Fritch <mfritch@suse.com>