### PR TITLE
feature: show network addresses in status view

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -1371,7 +1371,8 @@ def status(**kwargs):
         dep = Deployment.load(deployment_id)
         node_found = False
         if format_opt not in ['json']:
-            p_table = PrettyTable(["Node", "Status"])
+            p_table = PrettyTable(["Node", "Status", "Public Address",
+                                   "Cluster Address"])
             p_table.align = "l"
         for (node_name, node_obj) in dep.nodes.items():
             if node_opt:
@@ -1380,15 +1381,21 @@ def status(**kwargs):
                     if format_opt in ['json']:
                         click.echo("\"{}\"".format(node_obj.status))
                         return
-                    p_table.add_row([node_name, node_obj.status])
+                    p_table.add_row([node_name, node_obj.status,
+                                     node_obj.public_address,
+                                     node_obj.cluster_address])
             else:
                 if format_opt in ['json']:
                     node_list.append({
                         "name": node_name,
                         "status": node_obj.status,
+                        "public_address": node_obj.public_address,
+                        "cluster_address": node_obj.cluster_address,
                     })
                 else:
-                    p_table.add_row([node_name, node_obj.status])
+                    p_table.add_row([node_name, node_obj.status,
+                                     node_obj.public_address,
+                                     node_obj.cluster_address])
         if node_opt:
             if node_found:
                 assert format_opt not in ['json'], \
@@ -1455,7 +1462,8 @@ def _show_status_of_all_deployments(**kwargs):
         return status_str
 
     if format_opt not in ['json']:
-        p_table = PrettyTable(["ID", "Version", "Status", "Nodes"])
+        p_table = PrettyTable(["ID", "Version", "Status", "Nodes",
+                               "Public Network", "Cluster Network"])
         p_table.align = "l"
 
     for dep in deps:
@@ -1467,15 +1475,22 @@ def _show_status_of_all_deployments(**kwargs):
         nodes = getattr(dep, 'nodes', None)
         node_names = '(unknown)' if nodes is None else ', '.join(nodes)
         Log.debug("_status: -> node_names: {}".format(node_names))
+        public_network = getattr(dep, 'public_network_segment', None)
+        Log.debug("_status: -> public_network: {}".format(public_network))
+        cluster_network = getattr(dep, 'cluster_network_segment', None)
+        Log.debug("_status: -> public_network: {}".format(public_network))
         if format_opt in ['json']:
             deployments_list.append({
                 "id": dep.dep_id,
                 "version": version,
                 "status": status_str,
                 "nodes": list(nodes),
+                "public_network:": public_network,
+                "cluster_network:": cluster_network,
             })
         else:
-            p_table.add_row([dep.dep_id, version, status_str, node_names])
+            p_table.add_row([dep.dep_id, version, status_str, node_names,
+                             public_network, cluster_network])
     if format_opt in ['json']:
         click.echo(json.dumps(deployments_list, sort_keys=True, indent=4))
     else:

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -96,6 +96,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.nodes_with_role = {}
         self.public_network_segment = "{}0/24".format(self.settings.public_network) \
             if self.settings.public_network else None
+        self.cluster_network_segment = "{}0/24".format(self.settings.cluster_network) \
+            if self.settings.cluster_network else None
         self.roles_of_nodes = {}
         for role in Constant.ROLES_KNOWN:
             self.node_counts[role] = 0


### PR DESCRIPTION
- Show subnets in CIDR notation in cluster overview
- Show network addresses in cluster status view

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

Example:
```
│ ~/repos/sesdev │> sesdev status
Found 3 deployments:

+------------+---------+---------+-----------------------------+----------------+-----------------+
| ID         | Version | Status  | Nodes                       | Public Network | Cluster Network |
+------------+---------+---------+-----------------------------+----------------+-----------------+
| alpha-ses6 | ses6    | stopped | master, node1, node2, node3 | 10.20.55.0/24  | 10.21.3.0/24    |
| beta-ses6  | ses6    | stopped | master, node1, node2, node3 | 10.20.142.0/24 | 10.21.104.0/24  |
| ses7p      | ses7p   | running | master, node1, node2, node3 | 10.20.92.0/24  | 10.21.176.0/24  |
+------------+---------+---------+-----------------------------+----------------+-----------------+

│ ~/repos/sesdev │> sesdev status ses7p

Current status of the 4 nodes of deployment "ses7p"

+--------+---------+----------------+-----------------+
| Node   | Status  | Public Address | Cluster Address |
+--------+---------+----------------+-----------------+
| master | running | 10.20.92.200   | None            |
| node1  | running | 10.20.92.201   | 10.21.176.201   |
| node2  | running | 10.20.92.202   | 10.21.176.202   |
| node3  | running | 10.20.92.203   | 10.21.176.203   |
+--------+---------+----------------+-----------------+

│ ~/repos/sesdev │> sesdev status ses7p node1

Current status of node "node1" in deployment "ses7p"

+-------+---------+----------------+-----------------+
| Node  | Status  | Public Address | Cluster Address |
+-------+---------+----------------+-----------------+
| node1 | running | 10.20.92.201   | 10.21.176.201   |
+-------+---------+----------------+-----------------+
```