### PR TITLE
feature: provision additional ssh public keys

### DIFF
--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -130,6 +130,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         self.__maybe_tweak_roles()
         self.__maybe_adjust_num_disks()
         self.__generate_nodes()
+        self.__get_extra_ssh_keys()
         self.node_list = ','.join(self.nodes.keys())
 
     def __populate_roles(self):
@@ -207,6 +208,25 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                 self.settings.keepalived_image_path = image_paths.get('keepalived')
             if self.settings.snmp_gateway_image_path == '':
                 self.settings.snmp_gateway_image_path = image_paths.get('snmp-gateway')
+
+    def __get_extra_ssh_keys(self):
+        Log.debug('__get_extra_ssh_keys')
+        self._extra_ssh_keys = []
+
+        try:
+            keylines = tools.run_sync(['ssh-add', '-L']).splitlines()
+        except CmdException as _e:
+            Log.info('Could not fetch keys from ssh agent: {}'.format(_e.stderr))
+            keylines = []
+
+        for line in keylines:
+            _, _, _keyid = line.split()
+            if _keyid in self.settings.ssh_extra_auth_keys:
+                Log.info('found extra key {}'.format(_keyid))
+                self._extra_ssh_keys.append({
+                    'keyid': _keyid,
+                    'keyline': line,
+                    })
 
     def __set_up_make_check(self):
         self.settings.override('single_node', True)
@@ -560,6 +580,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
 
         context = {
             'ssh_key_name': Constant.SSH_KEY_NAME,
+            'ssh_extra_key_ids': [key['keyid'] for key in self._extra_ssh_keys],
             'sesdev_path_to_qa': Constant.PATH_TO_QA,
             'dep_id': self.dep_id,
             'os': self.settings.os,
@@ -727,6 +748,13 @@ class Deployment():  # use Deployment.create() to create a Deployment object
         with open(pub_key, 'wb') as file:
             file.write(public_key + b" sesdev\n")
         os.chmod(pub_key, 0o600)
+
+        for key in self._extra_ssh_keys:
+            path = os.path.join(keys_dir, "id_{}.pub".format(key['keyid']))
+            with open(path, 'w', encoding='utf-8') as file:
+                file.write(key['keyline'])
+            os.chmod(path, 0o600)
+
         #
         # create bin dir for helper scripts
         bin_dir = os.path.join(self._dep_dir, 'bin')

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -414,6 +414,12 @@ SETTINGS = {
         'help': 'Prioritise secure mode over "crc" in the ms_*_mode options.',
         'default': False,
     },
+    'ssh_extra_auth_keys': {
+        'type': list,
+        'help': ('Additional public keys to provision into '
+                 '/root/.ssh/authorized_keys'),
+        'default': []
+    },
 }
 
 

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -18,6 +18,11 @@ Vagrant.configure("2") do |config|
                               destination:".ssh/{{ ssh_key_name }}"
     node.vm.provision "file", source: "keys/{{ ssh_key_name }}.pub",
                               destination:".ssh/{{ ssh_key_name }}.pub"
+{% for _id in ssh_extra_key_ids %}
+    node.vm.provision "file", source: "keys/id_{{ _id }}.pub",
+                              destination: ".ssh/id_{{ _id }}.pub"
+{% endfor %}
+
 {% if node == master %}
 
     node.vm.provision "file", source: "bin/", destination: "/home/vagrant/"

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -58,12 +58,21 @@ grep -E '^127\.[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+' /etc/hosts
 
 # distribute SSH keys
 cat /home/vagrant/.ssh/{{ ssh_key_name }}.pub >> /home/vagrant/.ssh/authorized_keys
+{% for _id in ssh_extra_key_ids %}
+cat "/home/vagrant/.ssh/id_{{ _id }}.pub" >> /home/vagrant/.ssh/authorized_keys
+{% endfor %}
 [ ! -e "/root/.ssh" ] && mkdir /root/.ssh
 chmod 600 /home/vagrant/.ssh/{{ ssh_key_name }}
 cp /home/vagrant/.ssh/{{ ssh_key_name }}* /root/.ssh/
+{% for _id in ssh_extra_key_ids %}
+cp "/home/vagrant/.ssh/id_{{ _id }}.pub" /root/.ssh/
+{% endfor %}
 ln -s /root/.ssh/{{ ssh_key_name }} /root/.ssh/id_rsa
 ln -s /root/.ssh/{{ ssh_key_name }}.pub /root/.ssh/id_rsa.pub
 cat /root/.ssh/{{ ssh_key_name }}.pub >> /root/.ssh/authorized_keys
+{% for _id in ssh_extra_key_ids %}
+cat "/root/.ssh/id_{{ _id }}.pub" >> /root/.ssh/authorized_keys
+{% endfor %}
 
 # disable host checking when SSHing within the cluster
 cat >> /root/.ssh/config << 'EOF'


### PR DESCRIPTION
- Add feature to provision additional ssh public keys to the VM's
  `/root/.ssh/authorized_keys` file.

This feature allows a user to specify a list of key ids. The public keys
belonging to those ids will be fetched from the ssh agent and
provisioned to the VM's `/root/.ssh/authorized_keys` file. This allows
for better interaction with tools like `mtui`, which don't utilize
`sesdev` as ssh wrapper but still need ssh access to the VMs.

fixes: #647
Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>