### PR TITLE
feature: mixed disk drive layouts

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -152,9 +152,9 @@ def common_create_options(func):
                      help='Number of virtual CPUs for the VMs'),
         click.option('--ram', default=None, type=int,
                      help='Amount of RAM for each VM in gigabytes'),
-        click.option('--disk-size', default=None, type=int,
+        click.option('--disk-size', default=None, type=int, multiple=True,
                      help='Size in gigabytes of storage disks (used by OSDs)'),
-        click.option('--num-disks', default=None, type=int,
+        click.option('--num-disks', default=None, type=int, multiple=True,
                      help='Number of storage disks in OSD nodes'),
         click.option('--single-node/--no-single-node', default=False,
                      help='Deploy a single node cluster. Overrides --roles'),
@@ -478,13 +478,13 @@ def _gen_settings_dict(
         settings_dict['explicit_ram'] = False
 
     if num_disks is not None:
-        settings_dict['num_disks'] = num_disks
+        settings_dict['num_disks'] = list(num_disks)
         settings_dict['explicit_num_disks'] = True
     else:
         settings_dict['explicit_num_disks'] = False
 
     if disk_size is not None:
-        settings_dict['disk_size'] = disk_size
+        settings_dict['disk_size'] = list(disk_size)
 
     if bluestore is not None:
         if bluestore:

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -556,6 +556,8 @@ class Constant():
 
     ZYPPER_PRIO_ELEVATED = 50
 
+    DEFAULT_DISK_SIZE = 12  # in GiB
+
     @classmethod
     def init_path_to_qa(cls, full_path_to_sesdev_executable):
         if full_path_to_sesdev_executable.startswith('/usr'):

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -76,9 +76,9 @@ SETTINGS = {
         'default': Constant.DEVELOPER_TOOLS_REPOS,
     },
     'disk_size': {
-        'type': int,
+        'type': list,
         'help': 'Storage disk size in gigabytes',
-        'default': 8,
+        'default': [Constant.DEFAULT_DISK_SIZE],
     },
     'domain': {
         'type': str,
@@ -255,9 +255,9 @@ SETTINGS = {
         'default': False,
     },
     'num_disks': {
-        'type': int,
+        'type': list,
         'help': 'Number of additional disks in storage nodes',
-        'default': 2,
+        'default': [2],
     },
     'os': {
         'type': str,


### PR DESCRIPTION
Provision mixed disk drive layouts when specifying `--num-disks` and
`--disk-size` multiple times.

fixes: #652
Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>