### PR TITLE
ses6: set dashboard admin password via grain

### DIFF
--- a/seslib/templates/salt/deepsea/nautilus_pre_stage_3.sh.j2
+++ b/seslib/templates/salt/deepsea/nautilus_pre_stage_3.sh.j2
@@ -1,0 +1,2 @@
+# set password of dashboard user 'admin' to 'admin'
+salt-call grains.set dashboard_creds:admin admin

--- a/seslib/templates/salt/deepsea/nautilus_pre_stage_4.sh.j2
+++ b/seslib/templates/salt/deepsea/nautilus_pre_stage_4.sh.j2
@@ -1,2 +1,0 @@
-# set password of dashboard user 'admin' to 'admin'
-echo -n admin | ceph dashboard ac-user-set-password admin -i -

--- a/seslib/templates/salt/deepsea/ses6_pre_stage_3.sh.j2
+++ b/seslib/templates/salt/deepsea/ses6_pre_stage_3.sh.j2
@@ -1,0 +1,1 @@
+{% include "salt/deepsea/nautilus_pre_stage_3.sh.j2" %}

--- a/seslib/templates/salt/deepsea/ses6_pre_stage_4.sh.j2
+++ b/seslib/templates/salt/deepsea/ses6_pre_stage_4.sh.j2
@@ -1,1 +1,0 @@
-{% include "salt/deepsea/nautilus_pre_stage_4.sh.j2" %}


### PR DESCRIPTION
By default, DeepSea will set a random password for the dashboard admin user, by calling salt's random.get_str function:

https://github.com/SUSE/DeepSea/blob/64cf6c350da1214cc0bbcc11e372b25cbd29d35a/srv/salt/ceph/dashboard/default.sls#L2

It's possible for the string returned to include characters that break the parsing of the above jinja template and/or screw up the line that echoes the password into `ceph dashboard ac-user-create`.  We can work around this potential problem by setting the admin password to "admin" in advance of stage 3, using the dashboard_creds grain.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1200794
Signed-off-by: Tim Serong <tserong@suse.com>