### PR TITLE
feature: generate maintentance test reports

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -554,6 +554,17 @@ class Constant():
         'makecheck': 'tumbleweed',
     }
 
+    # Human readable names corresponding to official products where applicable
+    VERSION_OFFICIAL = {
+        'ses5': 'SES 5',
+        'nautilus': 'Ceph Nautilus',
+        'ses6': 'SES 6',
+        'octopus': 'Ceph Octopus',
+        'ses7': 'SES 7',
+        'pacific': 'Ceph Pacific',
+        'ses7p': 'SES 7.1'
+    }
+
     ZYPPER_PRIO_ELEVATED = 50
 
     @classmethod

--- a/seslib/zypper.py
+++ b/seslib/zypper.py
@@ -3,3 +3,12 @@ class ZypperRepo():
         self.name = kwargs.get('name', '')
         self.url = kwargs.get('url', '')
         self.priority = kwargs.get('priority', None)
+
+
+class ZypperPackage():
+    def __init__(self, **kwargs):
+        self.state = kwargs.get('state', '')
+        self.repo = kwargs.get('repo', '')
+        self.name = kwargs.get('name', '')
+        self.version = kwargs.get('version', '')
+        self.arch = kwargs.get('arch', '')


### PR DESCRIPTION
- Add command for generating maintenance test report data on a running
  cluster.

When testing maintenance updates for various packages, certain
informations need to be collected and entered into the final report.
Thus far, the information was largely collected by hand from various
commands run against the cluster.

This change adds a new sub command, which aggregates this information
and prints it ready for copy-and-paste to the console.
Included in this information is
 - The command and configuration used to create the test cluster
 - Basic information about the resulting cluster layout
 - A list of packages and installation statuses from each relevenat
   repo on each host
 - The Ceph cluster status

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>