### PR TITLE
feature: create test deployment from maintenance id

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -124,6 +124,35 @@ class Constant():
 
     LOGFILE = None
 
+    # A dict of string templates for repo urls. These templates are used to
+    # generate the repo urls used during maintenance update testing
+    MAINTENANCE_REPO_TEMPLATES = {
+        'ses6': {
+            '{}-update':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+            '{}-update-sp1':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP1_Update',
+            '{}-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_6_x86_64'
+        },
+        'ses7': {
+            '{}-update':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+            '{}-update-sp2':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP2_Update',
+            '{}-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_7_x86_64'
+        },
+        'ses7p': {
+            '{}-update':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+            '{}-update-sp3':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP3_Update',
+            '{}-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_7.1_x86_64'
+        }
+    }
+
     MAKECHECK_DEFAULT_RAM = 8
 
     MAKECHECK_DEFAULT_REPO_BRANCH = {


### PR DESCRIPTION
- Create a test deployment with auto-generated settings from a
  maintenance id

Maintenance update package tests rely on a consisted test environment to
produce reliable results. This change codifies the settings used to
generate such an environment, so that operator errors are minimized.
This convenience command takes a maintenance id of the form
'S:M:xxxxx:yyyyyy' and generates a cluster with the right additional
repos and settings for reliable testing.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>