### PR TITLE
maintenance report: include ceph versions

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -1361,6 +1361,21 @@ def report(deployment_id):
         for pkg in pkgs:
             click.echo(_indent(f"{pkg.name}  {pkg.version}  (from {pkg.repo})"))
     click.echo("")
+
+    click.echo("* Ceph versions:")
+    click.echo("")
+    versions = dep.list_versions()
+    click.echo(_indent("service type | count | version"))
+    for service_name in versions.keys():
+        service_name_is_already_printed = False
+        for service_version, service_count in versions[service_name].items():
+            if service_name_is_already_printed:
+                click.echo(_indent(f"             | {service_count:5} | {service_version}"))
+            else:
+                click.echo(_indent(f"{service_name:12} | {service_count:5} | {service_version}"))
+                service_name_is_already_printed = True
+    click.echo("")
+
     click.echo(f"* {ver} cluster status:")
     click.echo("")
     dep.ssh('master', ['ceph', 'status'], interactive=False)

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -1866,6 +1866,19 @@ deployment might not be completely destroyed.
 
         return packages
 
+    def list_versions(self):
+        """
+        Returns Ceph version information as returned by `ceph versions` in a
+        python dict
+        """
+        cmd = "ceph versions"
+        node = list(self.nodes.keys())[0]
+        ssh_cmd = self._ssh_cmd(node)
+        ssh_cmd.append(cmd)
+        raw_json = tools.run_sync(ssh_cmd)
+        versions = json.loads(raw_json)
+        return versions
+
     # This is the "real" constructor
     @classmethod
     def create(cls, dep_id, log_handler, settings):


### PR DESCRIPTION
Include ceph version information in the maintenance report. This is
useful to ensure that at the end of the test workflow the versions
running in the cluster (both package- and container-versions) are as
expected.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>