### PR TITLE
maintenance report: add list of repos

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -1318,6 +1318,7 @@ def report(deployment_id):
     cmd += f" {deployment_id}"
     dep.start(_print_log)
 
+    repos = dep.list_repos()
     packages = dep.list_packages(repos=[r['url'] for r in dep.settings.custom_repos])
 
     click.echo("<QAM-SES>")
@@ -1331,6 +1332,15 @@ def report(deployment_id):
     for line in dep.configuration_report(show_individual_vms=True).splitlines():
         click.echo(_indent(line))
     click.echo("")
+
+    click.echo("* List of repos configured:")
+    for node, repos in repos.items():
+        click.echo("")
+        click.echo(f" -- {node}:")
+        for repo in repos:
+            click.echo(_indent(f"{repo.name:20} {repo.priority:3} {repo.url}"))
+    click.echo("")
+
     click.echo("* Packages installed from Maintenance repos:")
     for node, pkgs in packages.items():
         click.echo("")


### PR DESCRIPTION
Add list of configured repos to the maintenance report. This is useful
to trace back which repo url a specific package listed in the same
maintenance report came from. It will also be useful in the future to
ensure a package update test actually installed the expected packages
and not packages from a different repo.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>