### PR TITLE
fix: typo in options for `--os` flag

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -139,10 +139,13 @@ def common_create_options(func):
         click.option('--roles', type=str, default=None,
                      help='List of roles for each node. Example for two nodes: '
                           '[master, client, prometheus],[storage, mon, mgr]'),
-        click.option('--os', type=click.Choice(['leap-15.1', 'leap-15.2', 'leap-15.3',
+        click.option('--os', type=click.Choice(['leap-15.1',
+                                                'leap-15.2',
+                                                'leap-15.3',
                                                 'tumbleweed',
-                                                'sles-15-sp1', 'sles-15-sp2',
-                                                'sles-15-sp3'
+                                                'sles-15-sp1',
+                                                'sles-15-sp2',
+                                                'sles-15-sp3',
                                                 'ubuntu-bionic']),
                      default=None, help='OS (open)SUSE distro'),
         click.option('--provision/--no-provision',


### PR DESCRIPTION
Fix typo in options for `--os` flag. A missing comma accidentally joined
the options `sles-15-sp3` and `ubuntu-bionic`.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>