### PR TITLE
maintenance tests: differentiate codestreams

### DIFF
--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -128,28 +128,76 @@ class Constant():
     # generate the repo urls used during maintenance update testing
     MAINTENANCE_REPO_TEMPLATES = {
         'ses6': {
-            '{}-update':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
-            '{}-update-sp1':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP1_Update',
+            '{}-basesystem':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_SLE-Module-Basesystem_15-SP1_x86_64',
+            '{}-server-applications':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_SLE-Module-Server-Applications_15-SP1_x86_64/',
             '{}-storage':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_6_x86_64'
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_Storage_6_x86_64',
+        },
+        'ses7': {
+            '{}-basesystem':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_SLE-Module-Basesystem_15-SP2_x86_64',
+            '{}-server-applications':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_SLE-Module-Server-Applications_15-SP2_x86_64/',
+            '{}-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_Storage_7_x86_64',
+        },
+        'ses7p': {
+            '{}-basesystem':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_SLE-Module-Basesystem_15-SP3_x86_64',
+            '{}-server-applications':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_SLE-Module-Server-Applications_15-SP3_x86_64/',
+            '{}-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_Storage_7.1_x86_64',
+        }
+    }
+
+    # A dict of string templates for codestream urls. There are currently
+    # unused, but we may want to test maintenance updates against them at some
+    # point.
+    MAINTENANCE_CODESTREAM_TEMPLATES = {
+        'ses6': {
+            '{}-update':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15_Update',
+            '{}-update-sp1':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP1_Update',
+            '{}-update-product-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP1_Update_Products_SES6_Update'
         },
         'ses7': {
             '{}-update':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15_Update',
             '{}-update-sp2':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP2_Update',
-            '{}-storage':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_7_x86_64'
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP2_Update',
+            '{}-update-product-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP2_Update_Products_SES7_Update'
         },
         'ses7p': {
             '{}-update':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15_Update',
             '{}-update-sp3':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP3_Update',
-            '{}-storage':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_7.1_x86_64'
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP3_Update',
+            '{}-update-product-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP3_Update_Products_SES7.1_Update'
         }
     }
 


### PR DESCRIPTION
Differentiate codestreams from repos. During maintenance testing repos are to be used to ensure that the environment matches what we expect to find at customer sites. Hoevewer in the future, we may want to test against codestreams too, so a list of relevant codestreams is kept at the ready.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>