### PR TITLE
report: add grafana status and version to report

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -5,6 +5,8 @@ from os import environ, path
 import re
 import sys
 import requests
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
 
 from prettytable import PrettyTable
 
@@ -1368,6 +1370,26 @@ def report(deployment_id):
                 service_name_is_already_printed = True
     click.echo("")
 
+    grafana_status = dep.get_grafana_status()
+    click.echo("* Grafana Status:")
+    click.echo(_indent(f"Status Ok: {grafana_status['ok']}"))
+    click.echo(_indent(f"Version: {grafana_status['version']}"))
+    click.echo("")
+
+    alertmanager_status = dep.get_alertmanager_status()
+    click.echo("* Alertmanager Status:")
+    click.echo(_indent(f"Status Ok: {alertmanager_status['ok']}"))
+    click.echo(_indent(f"Version: {alertmanager_status['version']}"))
+    click.echo("")
+
+    node_exporter_status = dep.get_node_exporter_status()
+    click.echo("* Node Exporter Status:")
+    for node, nodestatus in node_exporter_status.items():
+        click.echo(_indent(f"- {node}:"))
+        click.echo(_indent(f"Status Ok: {nodestatus['ok']}", 8))
+        click.echo(_indent(f"Version: {nodestatus['version']}", 8))
+        click.echo("")
+
     click.echo(f"* {ver} cluster status:")
     click.echo("")
     dep.ssh('master', ['ceph', 'status'], interactive=False)
@@ -1700,13 +1722,12 @@ def shell_completion(shell):
 
 @cli.command()
 @click.argument('review_request_id')
-@click.argument('version')
 @common_create_options
 @deepsea_options
 @ceph_salt_options
 @libvirt_options
 @ipv6_options
-def maintenance_test(review_request_id, version, **kwargs):
+def maintenance_test(review_request_id, **kwargs):
     """
     Create a test cluster for installation/smoke testing of package maintenance
     updates. Takes a review request id of the form 'SUSE:Maintenance:xxxxx:yyyyyy'
@@ -1776,36 +1797,71 @@ does not exist.")
             click.echo(f"Review Request ID {rrid} does not conform to pattern S:M:xxxxx:yyyyyy")
             sys.exit(1)
 
-    maintenance_incident_id, review_request_number = _parse_review_request_id(review_request_id)
-    deployment_id = f"{maintenance_incident_id}-{review_request_number}-{version}"
+    def _platform_to_ses_version(testplatform):
+        if 'addon=ses(major=6,minor=0)' in testplatform:
+            return 'ses6'
+        if 'addon=ses(major=7,minor=0)' in testplatform:
+            return 'ses7'
+        if 'addon=ses(major=7,minor=1)' in testplatform:
+            return 'ses7p'
+        return None
 
-    repo_urls = {}
+    def _get_maintenance_test_info(incident_id, request_id):
+        url = f"https://qam.suse.de/testreports/SUSE:Maintenance:\
+{incident_id}:{request_id}/metadata.json"
 
-    for alias, url in Constant.MAINTENANCE_REPO_TEMPLATES[version].items():
-        if _check_url(url.format(maintenance_incident_id)):
-            repo_urls[alias.format(maintenance_incident_id)] = url.format(maintenance_incident_id)
+        try:
+            urllib3.disable_warnings(category=InsecureRequestWarning)
+            info = requests.get(url, verify=False)
+            testplatforms = info.json()['testplatform']
+            platforms_to_test = [_platform_to_ses_version(platform)
+                                 for platform in testplatforms
+                                 if _platform_to_ses_version(platform) is not None]
+            print("Testplan:")
+            for plat in platforms_to_test:
+                print(f"  - {plat}")
+            return platforms_to_test
+        except requests.exceptions.RequestException:
+            print("error getting maintenace test info")
+            return []
 
-    if len(repo_urls) == 0:
-        click.echo('Could not find any maintenance repos.')
-        click.echo('Please make sure you are connected to the E&I VPN.')
-        click.echo('\nThe following URLs were probed:')
+    def _do_test(incident_id, request_id, version):
+        deployment_id = f"{incident_id}-{request_id}-{version}"
+
+        repo_urls = {}
+
         for alias, url in Constant.MAINTENANCE_REPO_TEMPLATES[version].items():
-            click.echo('  - ' + alias.format(maintenance_incident_id) + ': ' +
-                       url.format(maintenance_incident_id))
-        click.echo('Aborting...')
-        sys.exit(1)
+            if _check_url(url.format(incident_id)):
+                repo_urls[alias.format(incident_id)] = url.format(incident_id)
 
-    _prep_kwargs(kwargs)
-    settings_dict = _gen_settings_dict(version, **kwargs)
-    settings_dict['devel_repo'] = False
-    settings_dict['repo_priority'] = True
+        if len(repo_urls) == 0:
+            click.echo('Could not find any maintenance repos.')
+            click.echo('Please make sure you are connected to the E&I VPN.')
+            click.echo('\nThe following URLs were probed:')
+            for alias, url in Constant.MAINTENANCE_REPO_TEMPLATES[version].items():
+                click.echo('  - ' + alias.format(incident_id) + ': ' +
+                           url.format(incident_id))
+            click.echo('Aborting...')
+            sys.exit(1)
 
-    for repo_name, repo_url in repo_urls.items():
-        settings_dict['custom_repos'].append(
-            {
-                'name': repo_name,
-                'url': _maybe_munge_repo_url(repo_url),
-                'priority': Constant.ZYPPER_PRIO_ELEVATED
-            })
+        _prep_kwargs(kwargs)
+        settings_dict = _gen_settings_dict(version, **kwargs)
+        settings_dict['devel_repo'] = False
+        settings_dict['repo_priority'] = True
 
-    _create_command(deployment_id, settings_dict)
+        for repo_name, repo_url in repo_urls.items():
+            settings_dict['custom_repos'].append(
+                {
+                    'name': repo_name,
+                    'url': _maybe_munge_repo_url(repo_url),
+                    'priority': Constant.ZYPPER_PRIO_ELEVATED
+                })
+
+        settings_dict['non_interactive'] = True
+        _create_command(deployment_id, settings_dict)
+
+    maintenance_incident_id, review_request_number = _parse_review_request_id(review_request_id)
+    testplan = _get_maintenance_test_info(maintenance_incident_id, review_request_number)
+
+    for testversion in testplan:
+        _do_test(maintenance_incident_id, review_request_number, testversion)

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -129,27 +129,45 @@ class Constant():
     MAINTENANCE_REPO_TEMPLATES = {
         'ses6': {
             '{}-update':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15_Update',
             '{}-update-sp1':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP1_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP1_Update',
+            '{}-update-product-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP1_Update_Products_SES6_Update',
             '{}-storage':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_6_x86_64'
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_Storage_6_x86_64'
         },
         'ses7': {
             '{}-update':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15_Update',
             '{}-update-sp2':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP2_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP2_Update',
+            '{}-update-product-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP2_Update_Products_SES7_Update',
             '{}-storage':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_7_x86_64'
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_Storage_7_x86_64'
         },
         'ses7p': {
             '{}-update':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15_Update',
             '{}-update-sp3':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_SLE-15-SP3_Update',
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP3_Update',
+            '{}-update-product-storage':
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_SLE-15-SP3_Update_Products_SES7.1_Update',
             '{}-storage':
-                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/SUSE_Updates_Storage_7.1_x86_64'
+                'http://download.suse.de/ibs/SUSE:/Maintenance:/{}/'
+                'SUSE_Updates_Storage_7.1_x86_64'
         }
     }
 
@@ -363,10 +381,10 @@ class Constant():
     ROLES_DEFAULT = {
         "caasp4": [["master"], ["worker"], ["worker"], ["loadbalancer"]],
         "makecheck": [["makecheck"]],
-        "nautilus": [["master", "client", "prometheus", "grafana"],
-                     ["storage", "mon", "mgr", "rgw", "igw"],
-                     ["storage", "mon", "mgr", "mds", "igw", "nfs"],
-                     ["storage", "mon", "mgr", "mds", "rgw", "nfs"]],
+        "nautilus": [["master", "client", "prometheus", "alertmanager", "grafana", "node-exporter"],
+                     ["storage", "mon", "mgr", "rgw", "igw", "node-exporter"],
+                     ["storage", "mon", "mgr", "mds", "igw", "nfs", "node-exporter"],
+                     ["storage", "mon", "mgr", "mds", "rgw", "nfs", "node-exporter"]],
         "octopus": [["admin", "master", "client", "prometheus", "grafana", "alertmanager",
                      "node-exporter"],
                     ["bootstrap", "storage", "mon", "mgr", "rgw", "igw", "node-exporter"],


### PR DESCRIPTION
- Add grafana, node-exporter and alertmanager status and version info to cluster report. This is useful for maintenance testing because it serves as basic smoketest for the verdored grafana, node-exporter and alertmanager in SES.

- Update maintenance test repo urls to include a new possible repo

- Make sesdev figure out on its own which versions of SES to test a maintenance incident on.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>