### PR TITLE
ci: specify private network for jenkins agent

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,3 +1,4 @@
+---
 name: "tox"
 
 on:
@@ -7,59 +8,32 @@ on:
 jobs:
 
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
         include:
-        - tox-env: py36
-          py-ver: 3.6
-        - tox-env: py38
-          py-ver: 3.8
+          - py-ver: 3.6
+          - py-ver: 3.8
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.py-ver }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.py-ver }}
+      - name: Set up Python ${{ matrix.py-ver }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.py-ver }}
 
-    - name: Install dependencies
-      run: |
-        sudo apt install libvirt-dev -y
-        python --version
-        python -m pip install --upgrade pip
-        pip install tox
-        pip install ".[dev]"
+      - name: Install dependencies
+        run: |
+          sudo apt install libvirt-dev -y
+          python -m pip install --upgrade pip
+          pip install "tox>=3.24,<4"
+          pip install ".[dev]"
+          pip install .
+          pip list
 
-    - name: Test with tox
-      env:
-        TOXENV: ${{ matrix.tox-env }}
-      run: tox
-
-    # - name: Upload Coverage to Codecov
-    #   uses: codecov/codecov-action@v1
-
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install dependencies
-      run: |
-        sudo apt install libvirt-dev -y
-        python -m pip install --upgrade pip
-        pip install tox
-        pip install ".[dev]"
-
-    - name: Run lint with tox
-      env:
-        TOXENV: lint
-      run: tox
+      - name: Test with tox
+        run: |
+          tox --version
+          tox

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -147,6 +147,7 @@ pipeline {
                         git+https://github.com/kshtsk/jcs.git@fix-jenkins-version-check#egg=jcs[openstack,obs,jenkins]
                     jcs \
                         --os-network-public ${cloud_params[params.OS_CLOUD]['cloud_network_public']} \
+                        --os-network-fixed fixed \
                         create \
                         --cloud openstack \
                         --instance-type ${cloud_params[params.OS_CLOUD]['cloud_instance_type']} \


### PR DESCRIPTION
Explicitly specify the private network for the jenkins agent created in OVH cloud to run the sesdev integration. This should avoid the exception 409 "Multiple possible networks found" when creating the agent VM:

The private network is explicitly set to be the same as the public network.

```
+ jcs --os-network-public Ext-Net create --cloud openstack --instance-type s1-8 --jenkins-credential storage-automation-for-root-user minimal-opensuse-15.4-x86_64 sesdev-integration_master-19
Connected to jenkins server 2.378
Traceback (most recent call last):
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/bin/jcs", line 8, in <module>
    sys.exit(main())
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/jcs/__init__.py", line 289, in main
    args.func(args)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/jcs/__init__.py", line 189, in _do_create
    args.os_network_fixed, args.os_network_public, args.os_security_groups)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/jcs/openst.py", line 45, in os_instance_create
    wait=True, auto_ip=True)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/cloud/_utils.py", line 235, in func_wrapper
    return func(*args, **kwargs)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/cloud/_compute.py", line 922, in create_server
    server = self.compute.create_server(**kwargs)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/compute/v2/_proxy.py", line 652, in create_server
    return self._create(_server.Server, **attrs)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/proxy.py", line 581, in _create
    return res.create(self, base_path=base_path)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/resource.py", line 1487, in create
    self._translate_response(response, has_body=has_body)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/resource.py", line 1254, in _translate_response
    exceptions.raise_from_response(response, error_message=error_message)
  File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/exceptions.py", line 235, in raise_from_response
    http_status=http_status, request_id=request_id
openstack.exceptions.ConflictException: ConflictException: 409: Client Error for url: https://compute.de1.cloud.ovh.net/v2.1/68bb3d2bb759469c94d53c072b024f22/servers, Multiple possible networks found, use a Network ID to be more specific.
script returned exit code 1
```

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>