### PR TITLE
qa: fix make_salt_master_an_admin_node_test and NFS tests

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -1094,8 +1094,12 @@ function nfs_maybe_list_objects_in_recovery_pool_test {
         if [ "$NFS_NODE_LIST" ] && [ "$MDS_NODE_LIST" ] ; then
             # NFS Recovery Pool expected to exist
             skipped=""
+            local nfs_pool=".nfs"
+            if [ "$DEPLOYMENT_VERSION" = "octopus" ] ; then
+                nfs_pool="nfs-ganesha"
+            fi
             set -x
-            rados --pool nfs-ganesha --namespace sesdev_nfs ls | tee "$tmpfile"
+            rados --pool "$nfs_pool" --namespace sesdev_nfs ls | tee "$tmpfile"
             set +x
             if [ -s "$tmpfile" ] ; then
                 result="OK"
@@ -1126,7 +1130,11 @@ function nfs_maybe_create_export {
         if [ "$NFS_NODE_LIST" ] && [ "$MDS_NODE_LIST" ] ; then
             skipped=""
             set -x
-            ceph nfs export create cephfs sesdev_fs sesdev_nfs "/sesdev_nfs"
+            if [ "$DEPLOYMENT_VERSION" = "octopus" ] ; then
+                ceph nfs export create cephfs sesdev_fs sesdev_nfs "/sesdev_nfs"
+            else
+                ceph nfs export create cephfs sesdev_nfs "/sesdev_nfs" sesdev_fs
+            fi
             ceph nfs export ls sesdev_nfs --detailed | tee "$tmpfile"
             length="$(<"$tmpfile" jq -r 'length')"
             set +x

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -218,7 +218,7 @@ function make_salt_master_an_admin_node_test {
     local arbitrary_mon_node
     echo
     echo "WWWW: make_salt_master_an_admin_node_test"
-    _zypper_install_on_master ceph-common
+    rpm -q --quiet ceph-common || _zypper_install_on_master ceph-common
     set -x
     mkdir -p "/etc/ceph"
     if [ -f "$ADMIN_KEYRING" ] || [ -f "$CEPH_CONF" ] ; then


### PR DESCRIPTION
This is related to https://github.com/SUSE/sesdev/issues/672. When running `sesdev create ses7p --qa-test`, the
make_salt_master_an_admin_node_test function will try to install ceph-common.  If we're suffering from subtle version drift between ceph-common and ceph-base from different repos, this will fail with something like:
```
  Problem: the installed ceph-base-16.2.9.536+g41a9f9a5573-150300.3.3.1.x86_64 requires 'ceph-common = 16.2.9.536+g41a9f9a5573-150300.3.3.1', but this requirement cannot be provided
   Solution 1: deinstallation of ceph-base-16.2.9.536+g41a9f9a5573-150300.3.3.1.x86_64
   Solution 2: do not install ceph-common-16.2.9.536+g41a9f9a5573-150300.6.3.1.x86_64
   Solution 3: break ceph-base-16.2.9.536+g41a9f9a5573-150300.3.3.1.x86_64 by ignoring some of its dependencies
```
This is because zypper is trying to upgrade us to a newer version of ceph-common from a different repo.  We can avoid this problem by not trying to install ceph-common if it's already present.

Signed-off-by: Tim Serong <tserong@suse.com>