### PR TITLE
ci: parametrize jcs repo

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -115,6 +115,9 @@ pipeline {
                description: 'If set, a custom job name will be set')
         string(name: 'CUSTOM_JOB_DESC', defaultValue: '',
                description: 'If set, a custom job description will be set')
+        string(name: 'CUSTOM_JCS_REPO',
+               defaultValue: 'https://github.com/kshtsk/jcs.git@fix-jenkins-version-check',
+               description: 'Use customized version of jcs to deploy worker')
     }
 
     environment {
@@ -144,7 +147,7 @@ pipeline {
                     source ${jcs_venv}/bin/activate
                     python3 -m pip install --upgrade pip
                     pip3 --use-feature=2020-resolver install \
-                        git+https://github.com/kshtsk/jcs.git@fix-jenkins-version-check#egg=jcs[openstack,obs,jenkins]
+                        git+${params.CUSTOM_JCS_REPO}#egg=jcs[openstack,obs,jenkins]
                     jcs \
                         --os-network-public ${cloud_params[params.OS_CLOUD]['cloud_network_public']} \
                         create \


### PR DESCRIPTION
Add parameter for custom JCS repo to allow testing fixes to JCS before deploying to production

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>