### PR TITLE
Add support for deploying k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The Jenkins CI tests that `sesdev` can be used to deploy a single-node Ceph
          * [CaaSP k8s cluster](#caasp-k8s-cluster)
          * [CaaSP with Rook/Ceph/SES](#caasp-with-rookcephses)
          * [CaaSP on just one node](#caasp-on-just-one-node)
+      * [k3s (with or without Rook/Ceph/SES)](#k3s-with-or-without-rookcephses)
+         * [k3s cluster](#k3s-cluster)
+         * [k3s with Rook/Ceph/SES](#k3s-with-rookcephses)
       * [On a remote libvirt server via SSH](#on-a-remote-libvirt-server-via-ssh)
       * [Using salt instead of DeepSea/ceph-salt CLI](#using-salt-instead-of-deepseaceph-salt-cli)
       * [With a FQDN environment](#with-a-fqdn-environment)
@@ -537,6 +540,34 @@ $ sesdev create caasp4 --single-node --deploy-ses
 Note: since passing `--single-node` without an explicit deployment name causes
 the name to be set to `DEPLOYMENT_VERSION-mini`, the resulting cluster from the
 example above would be called `caasp4-mini`.
+
+#### k3s (with or without Rook/Ceph/SES)
+
+##### k3s cluster
+
+To create a k3s cluster that has 4 `worker` nodes and
+a `master` node:
+
+```
+$ sesdev create k3s
+```
+
+This uses `curl -sfL https://get.k3s.io | -` to install k3s,
+and `curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash` to install helm.
+
+By default it just creates and configures a k3s cluster, and workers don't
+have any disks unless the `--deploy-ses` (see below) or `--num-disks` options
+are given.
+
+##### k3s with Rook/Ceph/SES
+
+To have sesdev deploy Rook on the k3s cluster, give the `--deploy-ses` option.
+The default disk size is 8G, number of worker nodes 4, number of disks per
+worker node 3:
+
+```
+$ sesdev create k3s --deploy-ses
+```
 
 #### On a remote libvirt server via SSH
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -776,11 +776,17 @@ def _create_command(deployment_id, settings_dict):
                 click.echo()
             elif dep.settings.version == 'k3s':
                 if dep.settings.caasp_deploy_ses:
-                    click.echo("Rook will be off doing its magic dance now.")
-                    click.echo("After logging into the cluster, try these:")
-                    click.echo("")
+                    click.echo("Rook will be off doing its magic dance now, which may take")
+                    click.echo("some time.  After logging into the cluster, try these:")
+                    click.echo()
                     click.echo("  # kubectl -n rook-ceph logs -l app=rook-ceph-operator")
                     click.echo("  # kubectl -n rook-ceph get pods")
+                    click.echo()
+                    click.echo("A toolbox pod will also be deployed.  When it's ready, try:")
+                    click.echo()
+                    click.echo("  # kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash")
+                    click.echo()
+                    click.echo("Inside the toolbox you can use the ceph CLI (`ceph status` etc.)")
                     click.echo()
             else:
                 click.echo("Or, access the Ceph Dashboard with:")

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -436,6 +436,7 @@ def _gen_settings_dict(
         username=None,
         msgr2_secure_mode=None,
         msgr2_prefer_secure=None,
+        k3s_version=None,
 ):
 
     settings_dict = {}
@@ -456,6 +457,8 @@ def _gen_settings_dict(
             roles_string = Constant.ROLES_SINGLE_NODE['nautilus']
         elif version == 'caasp4':
             roles_string = Constant.ROLES_SINGLE_NODE['caasp4']
+        elif version == 'k3s':
+            roles_string = Constant.ROLES_SINGLE_NODE['k3s']
         else:
             raise VersionNotKnown(version)
         settings_dict['roles'] = _parse_roles(roles_string)
@@ -696,6 +699,9 @@ def _gen_settings_dict(
             raise OptionNotSupportedInVersion('--rgw-ssl', version)
         settings_dict['rgw_ssl'] = rgw_ssl
 
+    if k3s_version is not None:
+        settings_dict['k3s_version'] = k3s_version
+
     return settings_dict
 
 
@@ -768,6 +774,10 @@ def _create_command(deployment_id, settings_dict):
                 click.echo()
                 click.echo("  $ sesdev tunnel {} suma".format(deployment_id))
                 click.echo()
+            elif dep.settings.version == 'k3s':
+                # Nothing extra to print
+                # TODO: really?
+                pass
             else:
                 click.echo("Or, access the Ceph Dashboard with:")
                 click.echo()
@@ -910,6 +920,22 @@ def caasp4(deployment_id, **kwargs):
     _prep_kwargs(kwargs)
     settings_dict = _gen_settings_dict('caasp4', **kwargs)
     deployment_id = _maybe_gen_dep_id('caasp4', deployment_id, settings_dict)
+    _create_command(deployment_id, settings_dict)
+
+
+@create.command()
+@click.argument('deployment_id', required=False)
+@common_create_options
+@libvirt_options
+@click.option("--k3s-version", default=None,
+              help='k3s version to install (defaults to latest stable)')
+def k3s(deployment_id, **kwargs):
+    """
+    Creates a k3s cluster using Tumbleweed
+    """
+    _prep_kwargs(kwargs)
+    settings_dict = _gen_settings_dict('k3s', **kwargs)
+    deployment_id = _maybe_gen_dep_id('k3s', deployment_id, settings_dict)
     _create_command(deployment_id, settings_dict)
 
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -659,8 +659,11 @@ def _gen_settings_dict(
     if stop_before_run_make_check is not None:
         settings_dict['makecheck_stop_before_run_make_check'] = stop_before_run_make_check
 
-    if deploy_ses:
+    if deploy_ses and version == 'caasp4':
         settings_dict['caasp_deploy_ses'] = True
+
+    if deploy_ses and version == 'k3s':
+        settings_dict['k3s_deploy_ses'] = True
 
     for folder in synced_folder:
         try:
@@ -775,7 +778,7 @@ def _create_command(deployment_id, settings_dict):
                 click.echo("  $ sesdev tunnel {} suma".format(deployment_id))
                 click.echo()
             elif dep.settings.version == 'k3s':
-                if dep.settings.caasp_deploy_ses:
+                if dep.settings.k3s_deploy_ses:
                     click.echo("Rook will be off doing its magic dance now, which may take")
                     click.echo("some time.  After logging into the cluster, try these:")
                     click.echo()

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -775,9 +775,13 @@ def _create_command(deployment_id, settings_dict):
                 click.echo("  $ sesdev tunnel {} suma".format(deployment_id))
                 click.echo()
             elif dep.settings.version == 'k3s':
-                # Nothing extra to print
-                # TODO: really?
-                pass
+                if dep.settings.caasp_deploy_ses:
+                    click.echo("Rook will be off doing its magic dance now.")
+                    click.echo("After logging into the cluster, try these:")
+                    click.echo("")
+                    click.echo("  # kubectl -n rook-ceph logs -l app=rook-ceph-operator")
+                    click.echo("  # kubectl -n rook-ceph get pods")
+                    click.echo()
             else:
                 click.echo("Or, access the Ceph Dashboard with:")
                 click.echo()
@@ -927,6 +931,8 @@ def caasp4(deployment_id, **kwargs):
 @click.argument('deployment_id', required=False)
 @common_create_options
 @libvirt_options
+@click.option("--deploy-ses", is_flag=True, default=False,
+              help="Deploy SES using rook in k3s")
 @click.option("--k3s-version", default=None,
               help='k3s version to install (defaults to latest stable)')
 def k3s(deployment_id, **kwargs):

--- a/seslib/constant.py
+++ b/seslib/constant.py
@@ -362,6 +362,7 @@ class Constant():
 
     ROLES_DEFAULT = {
         "caasp4": [["master"], ["worker"], ["worker"], ["loadbalancer"]],
+        "k3s": [["master"], ["worker"], ["worker"], ["worker"], ["worker"]],
         "makecheck": [["makecheck"]],
         "nautilus": [["master", "client", "prometheus", "grafana"],
                      ["storage", "mon", "mgr", "rgw", "igw"],
@@ -381,6 +382,7 @@ class Constant():
 
     ROLES_DEFAULT_BY_VERSION = {
         'caasp4': ROLES_DEFAULT["caasp4"],
+        'k3s': ROLES_DEFAULT["k3s"],
         'makecheck': ROLES_DEFAULT["makecheck"],
         'nautilus': ROLES_DEFAULT["nautilus"],
         'octopus': ROLES_DEFAULT["octopus"],
@@ -415,6 +417,7 @@ class Constant():
 
     ROLES_SINGLE_NODE = {
         "caasp4": "[ master ]",
+        "k3s": "[ master ]",
         "nautilus": "[ master, storage, mon, mgr, prometheus, grafana, mds, igw, rgw, "
                     "nfs ]",
         "octopus": "[ master, admin, bootstrap, storage, mon, mgr, mds, igw, rgw, "
@@ -500,6 +503,10 @@ class Constant():
                 'http://download.nue.suse.com/ibs/SUSE/Updates/SUSE-CAASP/4.5/x86_64/update/'
             ],
         },
+        'k3s': {
+            'sles-15-sp3': [],
+            'tumbleweed': [],
+        },
         'makecheck': {
             'sles-15-sp1': [
                 'http://download.nue.suse.com/ibs/Devel:/Storage:/6.0/images/repo/'
@@ -535,6 +542,7 @@ class Constant():
         'octopus': 'cephadm',
         'pacific': 'cephadm',
         'caasp4': None,
+        'k3s': None,
         'makecheck': None,
     }
 
@@ -546,6 +554,7 @@ class Constant():
         'octopus': 'leap-15.2',
         'pacific': 'leap-15.3',
         'caasp4': 'sles-15-sp2',
+        'k3s': 'tumbleweed',
         'makecheck': 'tumbleweed',
     }
 

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -265,7 +265,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
     def __maybe_adjust_num_disks(self):
         single_node = self.settings.single_node or len(self.settings.roles) == 1
         storage_nodes = self.node_counts["storage"]
-        if self.settings.version in ['caasp4'] and self.settings.caasp_deploy_ses:
+        if self.settings.version in ['caasp4', 'k3s'] and self.settings.caasp_deploy_ses:
             if single_node:
                 storage_nodes = 1
             else:

--- a/seslib/deployment.py
+++ b/seslib/deployment.py
@@ -265,7 +265,8 @@ class Deployment():  # use Deployment.create() to create a Deployment object
     def __maybe_adjust_num_disks(self):
         single_node = self.settings.single_node or len(self.settings.roles) == 1
         storage_nodes = self.node_counts["storage"]
-        if self.settings.version in ['caasp4', 'k3s'] and self.settings.caasp_deploy_ses:
+        if ((self.settings.version == 'caasp4' and self.settings.caasp_deploy_ses) or
+            (self.settings.version == 'k3s' and self.settings.k3s_deploy_ses)):
             if single_node:
                 storage_nodes = 1
             else:
@@ -420,7 +421,9 @@ class Deployment():  # use Deployment.create() to create a Deployment object
                     node.cpus = max(node.cpus, 2)
                     if self.settings.ram < 2:
                         node.ram = 2 * 2**10
-                if self.settings.caasp_deploy_ses or self.settings.explicit_num_disks:
+                if (self.settings.caasp_deploy_ses or
+                   self.settings.k3s_deploy_ses or
+                   self.settings.explicit_num_disks):
                     if 'worker' in node_roles or single_node:
                         for _ in range(self.settings.num_disks):
                             node.storage_disks.append(Disk(self.settings.disk_size))
@@ -673,6 +676,7 @@ class Deployment():  # use Deployment.create() to create a Deployment object
             'use_salt': self.settings.use_salt,
             'node_manager': NodeManager(list(self.nodes.values())),
             'caasp_deploy_ses': self.settings.caasp_deploy_ses,
+            'k3s_deploy_ses': self.settings.k3s_deploy_ses,
             'synced_folders': self.settings.synced_folder,
             'makecheck_ceph_repo': self.settings.makecheck_ceph_repo,
             'makecheck_ceph_branch': self.settings.makecheck_ceph_branch,

--- a/seslib/exceptions.py
+++ b/seslib/exceptions.py
@@ -120,8 +120,8 @@ class ExplicitAdminRoleNotAllowed(SesDevException):
 class MultipleRolesPerMachineNotAllowedInCaaSP(SesDevException):
     def __init__(self):
         super().__init__(
-            "Multiple roles per machine detected. This is not allowed in CaaSP "
-            "clusters. For a single-node cluster, use the --single-node option "
+            "Multiple roles per machine detected. This is not allowed in CaaSP or "
+            "k3s clusters. For a single-node cluster, use the --single-node option "
             "or --roles=\"[master]\" (in this special case, the master node "
             "will function also as a worker node)"
         )

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -15,12 +15,14 @@ SETTINGS = {
         'help': 'Enable/disable AppArmor',
         'default': True,
     },
-    # This should rightly now be named something more generic, e.g:
-    # "kube_deploy_ses", but that will confuse sesdev when it looks
-    # at settings of existing deployments, so it can stay as is.
     'caasp_deploy_ses': {
         'type': bool,
-        'help': 'Deploy SES using rook in CaasP or k3s',
+        'help': 'Deploy SES using rook in CaasP',
+        'default': False,
+    },
+    'k3s_deploy_ses': {
+        'type': bool,
+        'help': 'Deploy SES using rook in k3s',
         'default': False,
     },
     'ceph_salt_git_repo': {

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -125,6 +125,11 @@ SETTINGS = {
         'help': 'Deprecated container image path for Ceph daemons.',
         'default': '',
     },
+    'k3s_version': {
+        'type': str,
+        'help': 'k3s version to install (defaults to latest stable)',
+        'default': '',
+    },
     'ceph_image_path': {
         'type': str,
         'help': 'Container image path for Ceph daemons',

--- a/seslib/settings.py
+++ b/seslib/settings.py
@@ -15,9 +15,12 @@ SETTINGS = {
         'help': 'Enable/disable AppArmor',
         'default': True,
     },
+    # This should rightly now be named something more generic, e.g:
+    # "kube_deploy_ses", but that will confuse sesdev when it looks
+    # at settings of existing deployments, so it can stay as is.
     'caasp_deploy_ses': {
         'type': bool,
-        'help': 'Deploy SES using rook in CaasP',
+        'help': 'Deploy SES using rook in CaasP or k3s',
         'default': False,
     },
     'ceph_salt_git_repo': {

--- a/seslib/templates/k3s/provision.sh.j2
+++ b/seslib/templates/k3s/provision.sh.j2
@@ -1,0 +1,115 @@
+set -ex
+
+zypper --non-interactive install curl
+
+# need this to pick up kubectl, helm etc. which are installed to /usr/local/bin
+export PATH=$PATH:/usr/local/bin
+
+{% if k3s_version %}
+export INSTALL_K3S_VERSION={{ k3s_version }}
+{% endif %}
+
+{% if node == master %}
+
+# Lifted from seslib/templates/caasp/master.sh.j2
+function wait_for_master_ready {
+    set +ex
+    echo "Waiting for master to be ready"
+    timeout_seconds="900"
+    remaining_seconds="$timeout_seconds"
+    interval_seconds="10"
+    while true ; do
+        set -x
+        ACTUAL_NUMBER_OF_MASTERS="$(kubectl get nodes 2>/dev/null | egrep -c "master\s+Ready")"
+        set +x
+        echo "masters in cluster (actual/expected): $ACTUAL_NUMBER_OF_MASTERS/1 (${remaining_seconds} seconds to timeout)"
+        remaining_seconds="$(( remaining_seconds - interval_seconds ))"
+        [ "$ACTUAL_NUMBER_OF_MASTERS" = "1" ] && break
+        if [ "$remaining_seconds" -le "0" ] ; then
+            echo "It seems unlikely that a master will ever appear. Bailing out!"
+            set -e
+            false
+        fi
+        sleep "$interval_seconds"
+    done
+    set -ex
+}
+
+# Also lifted from seslib/templates/caasp/master.sh.j2, except for the
+# ACTUAL_NUMBER_O_F_WORKERS= line, which checked for "worker[0-9]+\s+Ready",
+# but that won't do because the nodes are named "node[0-9]", not "worker[0-9]"
+function wait_for_workers_ready {
+    set +ex
+    echo "Waiting for {{ worker_nodes }} workers to be ready"
+    timeout_seconds="900"
+    remaining_seconds="$timeout_seconds"
+    interval_seconds="10"
+    while true ; do
+        set -x
+        ACTUAL_NUMBER_OF_WORKERS="$(kubectl get nodes 2>/dev/null | egrep -c "node[0-9]+\s+Ready")"
+        set +x
+        echo "workers in cluster (actual/expected): $ACTUAL_NUMBER_OF_WORKERS/{{ worker_nodes }} (${remaining_seconds} seconds to timeout)"
+        remaining_seconds="$(( remaining_seconds - interval_seconds ))"
+        [ "$ACTUAL_NUMBER_OF_WORKERS" = "{{ worker_nodes }}" ] && break
+        if [ "$remaining_seconds" -le "0" ] ; then
+            echo "It seems unlikely that {{ worker_nodes }} workers will ever appear. Bailing out!"
+            set -e
+            false
+        fi
+        sleep "$interval_seconds"
+    done
+    set -ex
+}
+
+curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" sh -
+
+# Unfortunately we can't use `kubectl wait --for=condition=Ready node/{{ master.name }} --timeout 15m`
+# because this runs before the master node even exists, and so we get
+# 'Error from server (NotFound): nodes "master" not found'
+wait_for_master_ready
+
+wait_for_workers_ready
+
+# Helm seems generally useful, let's install it
+curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+helm version
+
+# This sets KUBECONFIG for everyone to the global k3s config.
+# Without this, helm will try to talk to http://localhost:8080/version
+# by default, which of course won't work.
+echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /etc/profile.local
+
+{% else %} {# node == master #}
+
+function get_k3s_token {
+    set +ex
+    echo "Waiting for K3S token from master"
+    timeout_seconds="900"
+    remaining_seconds="$timeout_seconds"
+    interval_seconds="30"
+    while true ; do
+        remaining_seconds="$(( remaining_seconds - interval_seconds ))"
+        if scp master:/var/lib/rancher/k3s/server/node-token /tmp/k3s_token 2>/dev/null ; then
+            # Got the node token, probably (when exactly does that token get created
+            # on the master? could we conceivably have a weird race where we get an
+            # empty token file here?)
+            break
+        fi
+        if [ "$remaining_seconds" -le "0" ] ; then
+            echo "It seems unlikely that a master will ever appear. Bailing out!"
+            set -e
+            false
+        fi
+        echo "waiting for k3s token (${remaining_seconds} seconds to timeout)"
+        sleep "$interval_seconds"
+    done
+    set -ex
+}
+
+get_k3s_token
+export K3S_TOKEN=$(cat /tmp/k3s_token)
+rm /tmp/k3s_token
+
+curl -sfL https://get.k3s.io | K3S_URL=https://{{ master.fqdn }}:6443 sh -
+
+{% endif %}

--- a/seslib/templates/k3s/provision.sh.j2
+++ b/seslib/templates/k3s/provision.sh.j2
@@ -110,6 +110,9 @@ kubectl create -f rook-ceph/examples/cluster.yaml
 # The above will take some time (maybe 20 minutes in my testing),
 # so let's not wait for it :-)
 
+echo "Creating toolbox container..."
+kubectl create -f rook-ceph/examples/toolbox.yaml
+
 {% endif %} {# caasp_deploy_ses #}
 
 {% else %} {# node == master #}

--- a/seslib/templates/k3s/provision.sh.j2
+++ b/seslib/templates/k3s/provision.sh.j2
@@ -1,6 +1,8 @@
 set -ex
 
-zypper --non-interactive install curl
+# curl is needed to download the k3s and helm installers
+# the helm installer needs openssl to do checksum verification
+zypper --non-interactive install curl openssl
 
 # need this to pick up kubectl, helm etc. which are installed to /usr/local/bin
 export PATH=$PATH:/usr/local/bin

--- a/seslib/templates/k3s/provision.sh.j2
+++ b/seslib/templates/k3s/provision.sh.j2
@@ -79,6 +79,37 @@ helm version
 # by default, which of course won't work.
 echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /etc/profile.local
 
+{% if caasp_deploy_ses %}
+
+mkdir -p ~/cluster
+cd ~/cluster
+helm pull oci://registry.suse.com/ses/7.1/charts/rook-ceph
+# Currently rook-ceph-1.10.1.tgz
+# TODO: can we ask helm for the name of the file?  Or just assume it's
+# the only file currently in the directory?
+tar -xzf rook-ceph-*.tgz
+
+kubectl create namespace rook-ceph
+
+# The earlier addition of KUBECONFIG to /etc/profile.local won't help
+# us in this current session, so need to set it explicitly here.
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+helm install -n rook-ceph rook-ceph ./rook-ceph/
+
+echo "Waiting for the rook operator"
+kubectl wait --timeout=5m --namespace rook-ceph --for=condition=Ready pod  -l "app=rook-ceph-operator"
+
+echo "Let rook take all nodes that aren't the master"
+kubectl label node -l 'node-role.kubernetes.io/master!=true' node-role.rook-ceph/cluster=any
+
+echo "Creating ceph cluster..."
+kubectl create -f rook-ceph/examples/cluster.yaml
+
+# The above will take some time (maybe 20 minutes in my testing),
+# so let's not wait for it :-)
+
+{% endif %} {# caasp_deploy_ses #}
+
 {% else %} {# node == master #}
 
 function get_k3s_token {

--- a/seslib/templates/k3s/provision.sh.j2
+++ b/seslib/templates/k3s/provision.sh.j2
@@ -81,7 +81,7 @@ helm version
 # by default, which of course won't work.
 echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /etc/profile.local
 
-{% if caasp_deploy_ses %}
+{% if k3s_deploy_ses %}
 
 mkdir -p ~/cluster
 cd ~/cluster
@@ -113,7 +113,7 @@ kubectl create -f rook-ceph/examples/cluster.yaml
 echo "Creating toolbox container..."
 kubectl create -f rook-ceph/examples/toolbox.yaml
 
-{% endif %} {# caasp_deploy_ses #}
+{% endif %} {# k3s_deploy_ses #}
 
 {% else %} {# node == master #}
 

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -183,6 +183,10 @@ fi
 {% elif version == 'caasp4' %}
 {% include "caasp/provision.sh.j2" %}
 
+# k3s
+{% elif version == 'k3s' %}
+{% include "k3s/provision.sh.j2" %}
+
 # make check
 {% elif version == 'makecheck' %}
 {% include "makecheck/provision.sh.j2" %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ seslib =
     templates/salt/deepsea/*.j2
     templates/salt/suma/*.j2
     templates/cephadm/*.j2
+    templates/k3s/*.j2
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_parse_config_yaml.py
+++ b/tests/test_parse_config_yaml.py
@@ -50,4 +50,4 @@ def test_parse_config_yaml(isfile, exists):
         ['mon', 'mgr', 'storage'],
         ['mon', 'mgr', 'storage'],
     ]
-    assert len(settings['other_roles'].keys()) == 8
+    assert len(settings['other_roles'].keys()) == 9


### PR DESCRIPTION
This does a couple of things:

1) Lets us use `sesdev` to deploy k3s, just for the sake of having an easy way to create little VM clusters running k3s (think: arbitrary k3s dev/test playground)
2) Adds the ability to deploy rook on top of k3s, for the sake of testing rook/ceph for ongoing SES maintenance.