### PR TITLE
seslib: dump contents of /etc/ceph if `ceph status` fails during deployment

### DIFF
--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -201,3 +201,6 @@ if ! ceph status ; then
     false
 fi
 set -x
+
+echo "EVERYTHING IS FINE BUT WE'RE GOING TO BAIL OUT NOW ANYWAY"
+false

--- a/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
+++ b/seslib/templates/salt/ceph-salt/deployment_day_1.sh.j2
@@ -185,5 +185,19 @@ if [ "$ACTUAL_NUMBER_OF_MGRS" -gt "1" ] ; then
 fi
 set -x
 
-ceph status
-echo "\"ceph status\" exit code: $?"
+set +x
+echo "ceph status"
+if ! ceph status ; then
+    echo "\"ceph status\" failed, dumping contents of /etc/ceph"
+    ls -l /etc/ceph
+    for f in /etc/ceph/* ; do
+        echo -e "\n$f:"
+        cat $f
+    done
+    for f in /var/log/ceph/cephadm* /var/log/ceph-salt.log ; do
+        echo -e "\n$f:"
+        cat $f
+    done
+    false
+fi
+set -x


### PR DESCRIPTION
We've seen a bunch of jenkins test failures during cluster creation where MONs and MGRs are deployed during bootstrap but somehow the subsequent call to `ceph status` fails due to a missing admin keyring:
```
    master: +++ ssh master.mini.test cephadm ls
    master: MONs in cluster (actual/expected): 1/1 (3080 seconds to timeout)
    master: MGRs in cluster (actual/expected): 1/1 (3080 seconds to timeout)
    master: +++ set +x
    master: ++ ceph status
    master: 2023-03-24T10:19:36.718+0000 7f3ef1ca5700 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
    master: 2023-03-24T10:19:36.718+0000 7f3ef1ca5700 -1 AuthRegistry(0x7f3eec05ed08) no keyring found at /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,, disabling cephx
    master: 2023-03-24T10:19:36.818+0000 7f3ef1ca5700 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
    master: 2023-03-24T10:19:36.818+0000 7f3ef1ca5700 -1 AuthRegistry(0x7f3ef1ca3f50) no keyring found at /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,, disabling cephx
    master: 2023-03-24T10:19:36.858+0000 7f3eeb7fe700 -1 monclient(hunting): handle_auth_bad_method server allowed_methods [2] but i only support [1]
    master: 2023-03-24T10:19:36.862+0000 7f3ef1ca5700 -1 monclient: authenticate NOTE: no keyring found; disabled cephx authentication
    master: [errno 13] RADOS permission denied (error connecting to the cluster)
```
The only thing I can think of is that somehow maybe there's a timing issue with `cephadm bootstrap` writing out the admin keyring, but I'm struggling to see how that could actually happen, and I haven't been able to reproduce the issue myself.  In case we hit it again, this commit adds code to dump out the contents of all the files in /etc/ceph/, to see if that helps us figure out WTF is going on.

Signed-off-by: Tim Serong <tserong@suse.com>