### PR TITLE
k3s/longhorn: use LVM to support additional storage disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,10 +587,9 @@ To deploy a specific version of Longorn, use the `--longhorn-version` option:
 $ sesdev create k3s --deploy-longhorn --longhorn-version=1.4.1
 ```
 
-Currently Longhorn deployments will only use _one_ disk.  If more are
-specified using the `--num-disks` option, only the first disk will be
-mounted for use by Longhorn.  All other additional disks will remain
-untouched.
+The `--num-disks` option can be used if you want more than one storage disk.
+All storage disks will be made part of a single linear LVM volume mounted for
+use by Longhorn.
 
 #### On a remote libvirt server via SSH
 

--- a/seslib/templates/k3s/provision.sh.j2
+++ b/seslib/templates/k3s/provision.sh.j2
@@ -8,7 +8,7 @@ zypper --non-interactive install curl openssl
 export PATH=$PATH:/usr/local/bin
 
 {% if k3s_deploy_longhorn %}
-zypper --non-interactive install nfs-client open-iscsi e2fsprogs
+zypper --non-interactive install nfs-client open-iscsi e2fsprogs lvm2
 systemctl enable iscsid
 systemctl start iscsid
 {% endif %} {# k3s_deploy_longhorn #}
@@ -193,12 +193,16 @@ curl -sfL https://get.k3s.io | K3S_URL=https://{{ master.fqdn }}:6443 sh -
 
 {% if k3s_deploy_longhorn %}
 if [ ! -b /dev/vdb ]; then
-    echo "ERROR: Longhorn deployments require one additional disk"
+    echo "ERROR: Longhorn deployments require at least one additional disk"
     false
 fi
-mkfs.ext4 /dev/vdb
+
+# This won't handle more than 25 disks.  Tim is pretty sure that's fine.
+vgcreate longhorn /dev/vd[b-z]
+lvcreate --name longhorn-data -l 100%VG longhorn
+mkfs.ext4 /dev/longhorn/longhorn-data
 mkdir /var/lib/longhorn
-echo "/dev/vdb /var/lib/longhorn ext4 defaults 0 2" >> /etc/fstab
+echo "/dev/longhorn/longhorn-data /var/lib/longhorn ext4 defaults 0 2" >> /etc/fstab
 mount /var/lib/longhorn
 {% endif %} {# k3s_deploy_longhorn #}
 


### PR DESCRIPTION
This is a really simple use of LVM to just create a linear logical volume over `/dev/vd[b-z]`, then mount that for use by Longhorn.  The default is still to deploy with only one additional disk, but at least now if more than one disk is requested, we'll actually do something with the extra disks.