### PR TITLE
Increase `ceph orch ps` wait for timeout

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -436,7 +436,7 @@ function _wait_for {
         local orch_ps
         local orch_ls
         local minutes_to_wait
-        minutes_to_wait="5"
+        minutes_to_wait="10"
         local minute
         local i
         local success
@@ -767,7 +767,7 @@ function number_of_services_expected_vs_orch_ps_test {
     echo "WWWW: number_of_services_expected_vs_orch_ps_test"
     if [ "$VERSION_ID" = "15.2" ] || [ "$VERSION_ID" = "15.3" ] || [ "$ID" = "opensuse-tumbleweed" ] ; then
         local minutes_to_wait
-        minutes_to_wait="5"
+        minutes_to_wait="10"
         local minute
         local i
         local success


### PR DESCRIPTION
The serve loop can occasionally take more than 5 min to refresh the HostCache

This avoids sporadic failures during `sesdev create ses7p --qa-test` where the service has been deployed but we need to wait a few min longer for a refresh of the HostCache before the deployed daemon will appear:

```
    master: Minutes left to wait: 0
    master:  iscsi daemons did not appear even after waiting 5 minutes.
Giving up.
    master:
    master:
    master: Overall result: NOT_OK (error )
```