### PR TITLE
Jenkinsfile.integration: use `sesdev create --salt`

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -68,7 +68,7 @@ def cloud_params = [
 ]
 
 def sesdev_create_cmd(ceph_salt_git_repo, ceph_salt_git_branch, extra_repo_urls) {
-    cmd = "sesdev create pacific --non-interactive"
+    cmd = "sesdev create pacific --salt --non-interactive"
     if (!ceph_salt_git_repo.isEmpty()) {
         if (ceph_salt_git_branch.isEmpty()) {
             error('ceph-salt git repo set, but no ceph-salt git branch given')

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -251,6 +251,8 @@ pipeline {
                     sesdev scp -r mini master:/var/log/ceph artifacts/ || true
                     sesdev scp -r mini master:/var/log/salt artifacts/ || true
                     sesdev scp mini master:/var/log/ceph-salt.log artifacts/ || true
+                    sesdev ssh mini master -- ps auxww --forest > artifacts/ps || true
+                    sesdev ssh mini master journalctl > artifacts/journalctl || true
 
                 """
                 archiveArtifacts artifacts: 'artifacts/**/*', allowEmptyArchive: true


### PR DESCRIPTION
After looking through ceph-salt logs from previous failed Jenkins runs, and also at Volker's issue which seems to be the same thing (see https://github.com/SUSE/sesdev/issues/700), my current suspicion is that the ceph-salt executor is correctly starting `salt -G 'ceph-salt:member' state.apply ceph-salt` but is then failing to pick up some (or all) of the event notifications, which results in it returning too soon, while `cephadm bootstrap` is still running.

Assuming I'm on the right track here, let's ask `sesdev` to run that salt command directly, to remove the ceph-salt executor from the picture entirely.