### PR TITLE
Jenkinsfile.integration: use python3.11 for jcs

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -143,10 +143,10 @@ pipeline {
                 }
                 sh """
                     mkdir -p ${compute_workspace}
-                    virtualenv ${jcs_venv}
+                    python3.11 -m venv ${jcs_venv}
                     source ${jcs_venv}/bin/activate
-                    python3 -m pip install --upgrade pip
-                    pip3 --use-feature=2020-resolver install \
+                    python -m pip install --upgrade pip
+                    pip install \
                         git+${params.CUSTOM_JCS_REPO}#egg=jcs[openstack,obs,jenkins]
                     jcs \
                         --os-network-public ${cloud_params[params.OS_CLOUD]['cloud_network_public']} \


### PR DESCRIPTION
It appears in the newer openstackclient code the new feature available starting from Python 3.7:
```
  from __future__ import annotations
```
For more info see:
  https://peps.python.org/pep-0563/#enabling-the-future-behavior-in-python-3-7

Since the default Python in Leap 15.4 is still 3.6, so maybe just start using the latest available 3.11 for jcs.